### PR TITLE
daisyUI 5 を Tailwind 4 に統合 + ホーム画面の最小骨格を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@
 # Claude Code (local-only settings, do not share)
 /.claude/settings.local.json
 /.claude/.credentials.json
+
+# Node (npm install output)
+/node_modules
+npm-debug.log*

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@plugin "daisyui";

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,14 @@
+<div class="min-h-screen flex items-center justify-center bg-base-200">
+  <div class="card w-96 bg-base-100 shadow-xl">
+    <div class="card-body items-center text-center">
+      <h1 class="card-title text-3xl">weight_dialy</h1>
+      <p class="text-base-content/70">日常の小さな勝ちを、自動で拾って褒める。</p>
+      <div class="badge badge-primary badge-outline">Day 1: daisyUI 動作確認</div>
+      <div class="card-actions mt-4">
+        <button class="btn btn-primary">Primary</button>
+        <button class="btn btn-secondary">Secondary</button>
+        <button class="btn btn-accent">Accent</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "home#index"
 end

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,10 @@
+# mise tool versions for weight_dialy
+#
+# Ruby は .ruby-version で管理 (Rails 慣習)。
+# Node は daisyUI / Tailwind 4 のプラグイン解決のために必要。
+#
+# 使い方: mise が入った環境で `mise install` を打つと両方入る。
+#         Dev Container の場合は postCreate で自動セットアップされる予定 (TODO)。
+
+[tools]
+node = "22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "weight_dialy",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "daisyui": "^5.5.19"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "5.5.19",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
+      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "daisyui": "^5.5.19"
+  }
+}


### PR DESCRIPTION
## Summary
- daisyUI 5.5.19 を Tailwind 4 にプラグインとして統合
- Node 22 を mise.toml で管理 (Rails 公式 devcontainer は Node を同梱していないため)
- ホーム画面 `/` を仮のショーケース UI で実装 (daisyUI ビルド検証も兼ねる)

## なぜこの構成か (教材性メモ)
- **Tailwind 4 + daisyUI 5**: v4 から `@plugin "name";` ディレクティブが使えるようになり、設定ファイル不要で CSS 1 行で導入できる。daisyUI 側もこれに合わせて v5 で統合方法をシンプル化
- **mise.toml で Node 管理**: Rails 公式 devcontainer に Node が無いため、追加の言語ランタイムをプロジェクト固有で管理する手段として `mise.toml` を採用 (`.ruby-version` と二重化せず)
- **`@import "tailwindcss"; @plugin "daisyui";`** だけで完結 — 旧 Tailwind 3 系の `tailwind.config.js` の plugins 配列は不要

## 動作確認
- [x] `bin/rails tailwindcss:build` 実行で `🌼 daisyUI 5.5.19` バナーが出る
- [x] 出力 CSS (28KB) に daisyUI クラスが含まれる
- [x] `/` (ルート) で daisyUI コンポーネント (card, btn-primary 等) が描画される
- [x] **要動作確認 (レビュアー)**: ブラウザで http://localhost:3000 を開き、青/紫/オレンジのボタン + 影付きカードが表示されることを目視

## 既知の TODO (本 PR では対応しない)
- mise install を Dev Container postCreate で自動化する (現状は手動実行)

## レビュー観点 (subagent 向け)
- code-reviewer: routes.rb の root 指定、HomeController の作りが Rails Way に沿っているか
- strategic-reviewer: mise.toml で Node 管理、devcontainer feature 追加を見送った判断は妥当か
- design-reviewer: ホーム画面の文言・色使い・配置 (まだ仮なので要素そのものより全体方針として)

🤖 Generated with [Claude Code](https://claude.com/claude-code)