### PR TITLE
feat: 直接 push を阻止する二段構えガード

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook
+# Bash ツールで `git push ... main` を検知してブロックする。
+# 二段構えガードの 1 段目 (Claude Code 経由)。
+# 2 段目は .githooks/pre-push で人間の直接操作も阻止する。
+
+set -euo pipefail
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+if [[ -z "$command" ]]; then
+  exit 0
+fi
+
+if [[ ! "$command" =~ git[[:space:]]+push ]]; then
+  exit 0
+fi
+
+# main を destination とする push を検知:
+#   - `git push origin main`
+#   - `git push origin HEAD:main`
+#   - `git push origin <sha>:main`
+#   - `git push origin :main` (削除も阻止)
+#   - `git push -u origin main`
+#   - `git push --force origin main`
+if printf '%s' "$command" | grep -Eq '(^|[[:space:]])main([[:space:]]|$)|:main([[:space:]]|$)'; then
+  cat >&2 <<'EOF'
+🚫 main ブランチへの直接 push はブロックされました。
+
+理由: weight_dialy では「main 直コミット禁止 / PR 経由マージ」の運用ルールを採用しています。
+詳細: CLAUDE.md の「絶対ルール」を参照。
+
+正しい手順:
+  1. git checkout -b feature/<内容>
+  2. 作業 → コミット → git push -u origin feature/<内容>
+  3. gh pr create --base main
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -3,6 +3,10 @@
 # Bash ツールで `git push ... main` を検知してブロックする。
 # 二段構えガードの 1 段目 (Claude Code 経由)。
 # 2 段目は .githooks/pre-push で人間の直接操作も阻止する。
+#
+# UX 設計判断 (PR #5 review): エラーメッセージの「正しい手順」は軽い 1 行追記で済ませており、
+# 完全な場合分け (main にいる場合 / 作業ブランチにいる場合) は採用していない。
+# 後輩スクール生から「混乱した」フィードバックが来たら、完全分岐に拡張する。
 
 set -euo pipefail
 
@@ -24,23 +28,27 @@ if [[ -z "$push_segments" ]]; then
 fi
 
 # main を destination とする push を検知:
-#   - `git push origin main`
-#   - `git push origin HEAD:main`
-#   - `git push origin <sha>:main`
-#   - `git push origin :main` (削除も阻止)
-#   - `git push -u origin main`
-#   - `git push --force origin main`
-if printf '%s' "$push_segments" | grep -Eq '(^|[[:space:]])main([[:space:]]|$)|:main([[:space:]]|$)'; then
+#   - `git push origin main` / `-u origin main` / `--force origin main`
+#   - `git push origin HEAD:main` / `<sha>:main`
+#   - `git push origin :main` (削除)
+#   - `git push origin refs/heads/main` (full ref 形式)
+#   - `git push --all` / `--mirror` (main を含めて全 ref を送る)
+#
+# 設計メモ: この hook は「早期検出」の役割で、本命の安全網は .githooks/pre-push 側。
+# git は ref を解決してから pre-push を呼ぶため、どんな表記でも確実にブロックされる。
+# Claude hook は早めに気付かせるためのものなので、よくある記法をカバーすれば十分。
+if printf '%s' "$push_segments" | grep -Eq '(^|[[:space:]])main([[:space:]]|$)|:main([[:space:]]|$)|(^|[[:space:]])--(all|mirror)([[:space:]]|$)'; then
   cat >&2 <<'EOF'
 🚫 main ブランチへの直接 push はブロックされました。
 
 理由: weight_dialy では「main 直コミット禁止 / PR 経由マージ」の運用ルールを採用しています。
-詳細: CLAUDE.md の「絶対ルール」を参照。
+詳細: CLAUDE.md (プロジェクトルート) の「絶対ルール」を参照。
 
 正しい手順:
-  1. git checkout -b feature/<内容>
-  2. 作業 → コミット → git push -u origin feature/<内容>
-  3. gh pr create --base main
+  1. git checkout -b feature/<内容>     ← すでに作業ブランチにいる場合は 3 から
+  2. 作業 → コミット
+  3. git push -u origin feature/<内容>
+  4. gh pr create --base main
 EOF
   exit 2
 fi

--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -7,13 +7,19 @@
 set -euo pipefail
 
 input=$(cat)
-command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+# JSON が不正な場合は通す (誤検知を避ける)。実運用の Claude Code 入力は常に正しい JSON。
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
 if [[ -z "$command" ]]; then
   exit 0
 fi
 
-if [[ ! "$command" =~ git[[:space:]]+push ]]; then
+# `git push` を含むサブコマンドだけを抽出 (`;`, `&&`, `||`, `|` で区切る)
+# commit メッセージ等に "main" を含むケースを誤検知しないよう、push の引数列だけを対象にする。
+push_segments=$(printf '%s' "$command" | awk -v RS='[;&|]+' '/(^|[[:space:]])git[[:space:]]+push([[:space:]]|$)/')
+
+if [[ -z "$push_segments" ]]; then
   exit 0
 fi
 
@@ -24,7 +30,7 @@ fi
 #   - `git push origin :main` (削除も阻止)
 #   - `git push -u origin main`
 #   - `git push --force origin main`
-if printf '%s' "$command" | grep -Eq '(^|[[:space:]])main([[:space:]]|$)|:main([[:space:]]|$)'; then
+if printf '%s' "$push_segments" | grep -Eq '(^|[[:space:]])main([[:space:]]|$)|:main([[:space:]]|$)'; then
   cat >&2 <<'EOF'
 🚫 main ブランチへの直接 push はブロックされました。
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-push.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,6 +5,10 @@
 #
 # 有効化: clone 直後に `git config core.hooksPath .githooks` を実行する。
 # bin/setup から自動設定されるため、通常は手動設定不要。
+#
+# UX 設計判断 (PR #5 review): エラーメッセージの「正しい手順」は軽い 1 行追記で済ませており、
+# 完全な場合分け (main にいる場合 / 作業ブランチにいる場合) は採用していない。
+# 後輩スクール生から「混乱した」フィードバックが来たら、完全分岐に拡張する。
 
 set -euo pipefail
 
@@ -13,16 +17,17 @@ protected_branch="main"
 # 標準入力で `<local_ref> <local_sha> <remote_ref> <remote_sha>` 形式で push 内容が渡される
 while read -r local_ref local_sha remote_ref remote_sha; do
   if [[ "$remote_ref" == "refs/heads/$protected_branch" ]]; then
-    cat >&2 <<EOF
-🚫 main ブランチへの直接 push はブロックされました。
+    cat >&2 <<'EOF'
+🚫 [pre-push] main ブランチへの直接 push はブロックされました。
 
 理由: weight_dialy では「main 直コミット禁止 / PR 経由マージ」の運用ルールを採用しています。
-詳細: CLAUDE.md の「絶対ルール」を参照。
+詳細: CLAUDE.md (プロジェクトルート) の「絶対ルール」を参照。
 
 正しい手順:
-  1. git checkout -b feature/<内容>
-  2. 作業 → コミット → git push -u origin feature/<内容>
-  3. gh pr create --base main
+  1. git checkout -b feature/<内容>     ← すでに作業ブランチにいる場合は 3 から
+  2. 作業 → コミット
+  3. git push -u origin feature/<内容>
+  4. gh pr create --base main
 EOF
     exit 1
   fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Git pre-push hook
+# main ブランチへの直接 push を阻止する (人間の直接操作向け)。
+# 二段構えガードの 2 段目。1 段目は .claude/hooks/block-main-push.sh (Claude Code 経由)。
+#
+# 有効化: clone 直後に `git config core.hooksPath .githooks` を実行する。
+# bin/setup から自動設定されるため、通常は手動設定不要。
+
+set -euo pipefail
+
+protected_branch="main"
+
+# 標準入力で `<local_ref> <local_sha> <remote_ref> <remote_sha>` 形式で push 内容が渡される
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$remote_ref" == "refs/heads/$protected_branch" ]]; then
+    cat >&2 <<EOF
+🚫 main ブランチへの直接 push はブロックされました。
+
+理由: weight_dialy では「main 直コミット禁止 / PR 経由マージ」の運用ルールを採用しています。
+詳細: CLAUDE.md の「絶対ルール」を参照。
+
+正しい手順:
+  1. git checkout -b feature/<内容>
+  2. 作業 → コミット → git push -u origin feature/<内容>
+  3. gh pr create --base main
+EOF
+    exit 1
+  fi
+done
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,11 @@
 4. ブランチで作業 → コミット → プッシュ → PR (`gh pr create --base main`)
 5. マージ後、ブランチ削除
 
+#### 二段構えのガード (実装済み)
+- **Claude Code 側**: `.claude/hooks/block-main-push.sh` が PreToolUse hook で `git push ... main` をブロック
+- **Git 側**: `.githooks/pre-push` が人間が直接打った場合も阻止
+- **clone 直後の必須セットアップ**: `git config core.hooksPath .githooks` (bin/setup から自動設定)
+
 ---
 
 ## 📚 プロジェクト概要

--- a/bin/setup
+++ b/bin/setup
@@ -12,7 +12,10 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts "== Installing dependencies =="
+  puts "== Configuring git hooks =="
+  system! "git config core.hooksPath .githooks"
+
+  puts "\n== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
   # puts "\n== Copying sample files =="


### PR DESCRIPTION
## Summary
- Closes #4
- Claude Code の PreToolUse hook と git pre-push の二段構えで、`origin main` への直接 push を阻止する仕組みを導入
- 1 段目 (`.claude/hooks/block-main-push.sh`): Claude Code 経由の Bash 実行前にチェック
- 2 段目 (`.githooks/pre-push`): 人間がターミナルから直接打った場合に阻止
- `bin/setup` から `core.hooksPath = .githooks` を自動設定するため、clone 直後の手動操作なしで有効化される

## なぜこの構成か (教材性メモ)
- Claude hook 単独だと、人間が直接ターミナルで打った時に漏れる
- git pre-push 単独だと、Claude が打つ前段階で気付けず無駄な実行が走る
- 二段構えにすることで、どちらの経路でも防げる + 早い段階で意図を伝えられる
- フリーライフ workflow の `gh-pr-base-check.sh` パターンを参考に、weight_dialy では push 阻止に応用した

## 実装の工夫
- Claude hook は `git push` を含むサブコマンドだけを抽出してから ref を検査するため、commit メッセージや heredoc 内に `main` の文字列が含まれても誤検知しない (実装中に実際に踏んで修正)
- `git push origin main` / `HEAD:main` / `:main` (削除) / `--force origin main` のすべてをカバー
- JSON 不正時は通す (誤検知よりも実用性を優先 — 実運用の Claude Code 入力は常に正しい JSON)

## Test plan
- [x] Claude hook: feature/foo への push は通る
- [x] Claude hook: ls 等の関係ないコマンドは通る
- [x] Claude hook: `git push origin main` をブロック
- [x] Claude hook: `git push origin HEAD:main` をブロック
- [x] Claude hook: `git push origin :main` (削除) をブロック
- [x] Claude hook: `git push --force origin main` をブロック
- [x] Claude hook: commit メッセージ内に `main` を含んでも通る
- [x] git pre-push: `refs/heads/main` 宛てをブロック (exit 1)
- [x] git pre-push: feature ref は通る (exit 0)
- [x] feature ブランチへの実際の push が通る (この PR の push 自体)
- [x] レビュー後に main 直 push をローカルで試して両 hook の連携を再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)