### PR TITLE
feat: Google OAuth でログイン機能を導入する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Google OAuth credentials
+# 発行方法: https://console.cloud.google.com → 「API とサービス」→「認証情報」→「OAuth クライアント ID」
+# 承認済みリダイレクト URI に http://localhost:3000/auth/google_oauth2/callback を登録
+GOOGLE_CLIENT_ID=your-client-id-here.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret-here

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,12 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# Google OAuth 認証 [https://github.com/zquestz/omniauth-google-oauth2]
+gem "omniauth-google-oauth2"
+
+# OmniAuth GET callback への CSRF 対策 [https://github.com/cookpad/omniauth-rails_csrf_protection]
+gem "omniauth-rails_csrf_protection"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
@@ -60,6 +66,9 @@ group :development, :test do
 
   # Factory Bot for test fixtures [https://github.com/thoughtbot/factory_bot_rails]
   gem "factory_bot_rails"
+
+  # Load environment variables from .env [https://github.com/bkeepers/dotenv]
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -66,12 +66,12 @@ group :development, :test do
 
   # Factory Bot for test fixtures [https://github.com/thoughtbot/factory_bot_rails]
   gem "factory_bot_rails"
-
-  # Load environment variables from .env [https://github.com/bkeepers/dotenv]
-  gem "dotenv-rails"
 end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Load environment variables from .env (dev only — prod uses Rails credentials) [https://github.com/bkeepers/dotenv]
+  gem "dotenv-rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (6.0.4)
@@ -108,6 +111,12 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
@@ -119,6 +128,8 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashie (5.1.0)
+      logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -138,6 +149,8 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.19.4)
+    jwt (3.1.2)
+      base64
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -169,6 +182,10 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.4)
       date
       net-protocol
@@ -196,6 +213,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
+    oauth2 (2.0.18)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.2)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
@@ -222,6 +263,10 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -318,6 +363,9 @@ GEM
       ffi (~> 1.12)
       logger
     securerandom (0.4.1)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -368,6 +416,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    version_gem (1.1.9)
     web-console (4.3.0)
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
@@ -393,11 +442,14 @@ DEPENDENCIES
   brakeman
   bundler-audit
   debug
+  dotenv-rails
   factory_bot_rails
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   kamal
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,16 @@ class ApplicationController < ActionController::Base
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+
+  helper_method :current_user, :logged_in?
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def logged_in?
+    current_user.present?
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,8 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+    return @current_user if instance_variable_defined?(:@current_user)
+    @current_user = session[:user_id] ? User.find_by(id: session[:user_id]) : nil
   end
 
   def logged_in?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,19 @@
+class SessionsController < ApplicationController
+  def create
+    user = User.from_omniauth(request.env["omniauth.auth"])
+    session[:user_id] = user.id
+    redirect_to root_path, notice: "ログインしました"
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("OAuth login failed: #{e.message}")
+    redirect_to root_path, alert: "ログインに失敗しました"
+  end
+
+  def destroy
+    session.delete(:user_id)
+    redirect_to root_path, notice: "ログアウトしました"
+  end
+
+  def failure
+    redirect_to root_path, alert: "ログインに失敗しました"
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,13 @@
 class SessionsController < ApplicationController
   def create
-    user = User.from_omniauth(request.env["omniauth.auth"])
+    auth = request.env["omniauth.auth"]
+    if auth.nil?
+      Rails.logger.error("OAuth login failed: omniauth.auth is nil")
+      return redirect_to root_path, alert: "ログインに失敗しました"
+    end
+
+    user = User.from_omniauth(auth)
+    reset_session
     session[:user_id] = user.id
     redirect_to root_path, notice: "ログインしました"
   rescue ActiveRecord::RecordInvalid => e
@@ -9,7 +16,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    session.delete(:user_id)
+    reset_session
     redirect_to root_path, notice: "ログアウトしました"
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,17 @@
+class User < ApplicationRecord
+  validates :provider, presence: true
+  validates :uid, presence: true, uniqueness: { scope: :provider }
+  validates :email, presence: true
+  validates :name, presence: true
+
+  def self.from_omniauth(auth)
+    user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
+    user.assign_attributes(
+      email: auth.info.email,
+      name: auth.info.name,
+      image_url: auth.info.image
+    )
+    user.save!
+    user
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,27 @@
   </head>
 
   <body>
+    <header class="navbar bg-base-100 shadow-sm">
+      <div class="flex-1">
+        <%= link_to "weight_dialy", root_path, class: "btn btn-ghost text-xl" %>
+      </div>
+      <div class="flex-none">
+        <% if logged_in? %>
+          <span class="mr-3"><%= current_user.name %></span>
+          <%= button_to "ログアウト", logout_path, method: :delete, class: "btn btn-ghost" %>
+        <% else %>
+          <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post, class: "btn btn-primary", data: { turbo: false } %>
+        <% end %>
+      </div>
+    </header>
+
+    <% if flash[:notice] %>
+      <div class="alert alert-success container mx-auto mt-4"><%= flash[:notice] %></div>
+    <% end %>
+    <% if flash[:alert] %>
+      <div class="alert alert-error container mx-auto mt-4"><%= flash[:alert] %></div>
+    <% end %>
+
     <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "App" %></title>
+    <title><%= content_for(:title) || "weight_dialy" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="App">
@@ -30,7 +30,7 @@
       </div>
       <div class="flex-none">
         <% if logged_in? %>
-          <span class="mr-3"><%= current_user.name %></span>
+          <span class="mr-3 inline-block max-w-[8rem] truncate align-middle"><%= current_user.name %></span>
           <%= button_to "ログアウト", logout_path, method: :delete, class: "btn btn-ghost" %>
         <% else %>
           <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post, class: "btn btn-primary", data: { turbo: false } %>
@@ -45,7 +45,7 @@
       <div class="alert alert-error container mx-auto mt-4"><%= flash[:alert] %></div>
     <% end %>
 
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="container mx-auto mt-4 px-5 flex">
       <%= yield %>
     </main>
   </body>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -11,4 +11,3 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 OmniAuth.config.allowed_request_methods = [:post]
-OmniAuth.config.silence_get_warning = true

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,14 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2,
+           ENV["GOOGLE_CLIENT_ID"],
+           ENV["GOOGLE_CLIENT_SECRET"],
+           {
+             scope: "email,profile",
+             prompt: "select_account",
+             image_aspect_ratio: "square",
+             image_size: 200
+           }
+end
+
+OmniAuth.config.allowed_request_methods = [:post]
+OmniAuth.config.silence_get_warning = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
 
   get "/about", to: "about#show", as: :about
 
+  get "/auth/:provider/callback", to: "sessions#create", as: :auth_callback
+  get "/auth/failure", to: "sessions#failure", as: :auth_failure
+  delete "/logout", to: "sessions#destroy", as: :logout
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/db/migrate/20260501051150_create_users.rb
+++ b/db/migrate/20260501051150_create_users.rb
@@ -1,0 +1,15 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :provider, null: false
+      t.string :uid,      null: false
+      t.string :email,    null: false
+      t.string :name,     null: false
+      t.string :image_url
+
+      t.timestamps
+    end
+
+    add_index :users, [:provider, :uid], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_051150) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.string "image_url"
+    t.string "name", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:uid) { |n| "uid_#{n}" }
+    provider { "google_oauth2" }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    sequence(:name) { |n| "Test User #{n}" }
+    # 固定 URL で十分。画像取得テストは model spec の from_omniauth で行う
+    image_url { "https://example.com/photo.jpg" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe "validations" do
+    it "is valid with all required attributes" do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+
+    it "is invalid without provider" do
+      user = build(:user, provider: nil)
+      expect(user).not_to be_valid
+    end
+
+    it "is invalid without uid" do
+      user = build(:user, uid: nil)
+      expect(user).not_to be_valid
+    end
+
+    it "is invalid without email" do
+      user = build(:user, email: nil)
+      expect(user).not_to be_valid
+    end
+
+    it "is invalid without name" do
+      user = build(:user, name: nil)
+      expect(user).not_to be_valid
+    end
+
+    it "rejects duplicate uid within the same provider" do
+      create(:user, provider: "google_oauth2", uid: "same_uid")
+      duplicate = build(:user, provider: "google_oauth2", uid: "same_uid")
+      expect(duplicate).not_to be_valid
+    end
+
+    it "allows the same uid when provider differs" do
+      create(:user, provider: "google_oauth2", uid: "same_uid")
+      other_provider = build(:user, provider: "github", uid: "same_uid")
+      expect(other_provider).to be_valid
+    end
+  end
+
+  describe ".from_omniauth" do
+    let(:auth) do
+      OmniAuth::AuthHash.new(
+        provider: "google_oauth2",
+        uid: "google_123",
+        info: OmniAuth::AuthHash::InfoHash.new(
+          email: "new@example.com",
+          name: "New User",
+          image: "https://example.com/avatar.jpg"
+        )
+      )
+    end
+
+    context "when the user does not exist yet" do
+      it "creates a new user record" do
+        expect { User.from_omniauth(auth) }.to change(User, :count).by(1)
+      end
+
+      it "saves image_url from auth.info.image" do
+        user = User.from_omniauth(auth)
+        expect(user.image_url).to eq("https://example.com/avatar.jpg")
+      end
+    end
+
+    context "when the user already exists (same provider + uid)" do
+      before { create(:user, provider: "google_oauth2", uid: "google_123", email: "old@example.com", name: "Old Name") }
+
+      it "does not create a new record" do
+        expect { User.from_omniauth(auth) }.not_to change(User, :count)
+      end
+
+      it "updates email" do
+        user = User.from_omniauth(auth)
+        expect(user.email).to eq("new@example.com")
+      end
+
+      it "updates name" do
+        user = User.from_omniauth(auth)
+        expect(user.name).to eq("New User")
+      end
+
+      it "updates image_url" do
+        user = User.from_omniauth(auth)
+        expect(user.image_url).to eq("https://example.com/avatar.jpg")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /auth/google_oauth2/callback" do
+    context "when OAuth succeeds with a new user" do
+      before { mock_google_oauth2(uid: "new_uid_1", email: "newuser@example.com", name: "New User") }
+
+      it "creates a user record" do
+        expect { get auth_callback_path(provider: "google_oauth2") }.to change(User, :count).by(1)
+      end
+
+      it "stores the user id in the session" do
+        get auth_callback_path(provider: "google_oauth2")
+        expect(session[:user_id]).to eq(User.last.id)
+      end
+
+      it "redirects to root_path" do
+        get auth_callback_path(provider: "google_oauth2")
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "sets a notice flash" do
+        get auth_callback_path(provider: "google_oauth2")
+        expect(flash[:notice]).to eq("ログインしました")
+      end
+    end
+
+    context "when the user already exists" do
+      before do
+        create(:user, provider: "google_oauth2", uid: "existing_uid")
+        mock_google_oauth2(uid: "existing_uid", email: "existing@example.com", name: "Existing User")
+      end
+
+      it "does not create a new user record" do
+        expect { get auth_callback_path(provider: "google_oauth2") }.not_to change(User, :count)
+      end
+    end
+  end
+
+  describe "DELETE /logout" do
+    # session を直接 set するために logged-in 状態を作る
+    let(:user) { create(:user) }
+
+    before do
+      # request spec では get でセッションを作ってから logout するのが自然だが、
+      # セッション注入ヘルパーがないため、ログイン callback 経由で session を張る
+      mock_google_oauth2(uid: user.uid, email: user.email, name: user.name)
+      get auth_callback_path(provider: "google_oauth2")
+    end
+
+    it "clears the user session" do
+      delete logout_path
+      expect(session[:user_id]).to be_nil
+    end
+
+    it "redirects to root_path" do
+      delete logout_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "sets a notice flash" do
+      delete logout_path
+      expect(flash[:notice]).to eq("ログアウトしました")
+    end
+  end
+
+  describe "GET /auth/failure" do
+    it "redirects to root_path" do
+      get auth_failure_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "sets an alert flash" do
+      get auth_failure_path
+      expect(flash[:alert]).to eq("ログインに失敗しました")
+    end
+  end
+end

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -1,0 +1,44 @@
+# OmniAuth テストモードの有効化と認証ハッシュ生成ヘルパー
+#
+# OmniAuth はデフォルトで GET /auth/:provider/callback への直アクセスを
+# 禁止しているため、テストモードに切り替えてモックデータを差し込む。
+# 使い方:
+#   before { mock_google_oauth2(uid: "123", email: "test@example.com") }
+#   get auth_callback_path(provider: "google_oauth2")
+#
+# テストが終わったら after で reset_omniauth_mocks を呼ぶか、
+# 後述の after ブロックに委ねる (rails_helper.rb 側でリセット済み)。
+
+OmniAuth.config.test_mode = true
+
+module OmniauthHelpers
+  # Google OAuth2 モック認証ハッシュをアプリの env にセットする。
+  # request spec では Rails.application.env_config に直接差し込む方式が確実。
+  def mock_google_oauth2(uid: "default_uid", email: "user@example.com", name: "Test User", image: "https://example.com/photo.jpg")
+    auth_hash = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: uid,
+      info: OmniAuth::AuthHash::InfoHash.new(
+        email: email,
+        name: name,
+        image: image
+      )
+    )
+    OmniAuth.config.mock_auth[:google_oauth2] = auth_hash
+    # request spec は Rack env を直接触れないため env_config 経由でセットする
+    Rails.application.env_config["omniauth.auth"] = auth_hash
+  end
+
+  def reset_omniauth_mocks
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+end
+
+RSpec.configure do |config|
+  config.include OmniauthHelpers, type: :request
+
+  config.after(:each, type: :request) do
+    reset_omniauth_mocks
+  end
+end

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -1,4 +1,4 @@
-# OmniAuth テストモードの有効化と認証ハッシュ生成ヘルパー
+# OmniAuth テストモード関連のヘルパー
 #
 # OmniAuth はデフォルトで GET /auth/:provider/callback への直アクセスを
 # 禁止しているため、テストモードに切り替えてモックデータを差し込む。
@@ -6,10 +6,8 @@
 #   before { mock_google_oauth2(uid: "123", email: "test@example.com") }
 #   get auth_callback_path(provider: "google_oauth2")
 #
-# テストが終わったら after で reset_omniauth_mocks を呼ぶか、
-# 後述の after ブロックに委ねる (rails_helper.rb 側でリセット済み)。
-
-OmniAuth.config.test_mode = true
+# test_mode のグローバル副作用を避けるため、有効化は RSpec.configure 内で行う
+# (トップレベルで設定すると model spec など全 spec に副作用が及ぶため)。
 
 module OmniauthHelpers
   # Google OAuth2 モック認証ハッシュをアプリの env にセットする。
@@ -36,6 +34,10 @@ module OmniauthHelpers
 end
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    OmniAuth.config.test_mode = true
+  end
+
   config.include OmniauthHelpers, type: :request
 
   config.after(:each, type: :request) do


### PR DESCRIPTION
## Summary

- `omniauth-google-oauth2` + `omniauth-rails_csrf_protection` + `dotenv-rails` 導入で Google OAuth ログインを実装
- User モデルは **provider + uid 設計** で将来 Apple ID 増設可能
- ホームヘッダに仮ログイン UI (正規 UI はホームダミー除去 Issue で別扱い)
- RSpec 26 examples, 0 failures (model 13 / sessions request 10 / about 3)

## なぜこの構成か (教材ポイント)

### 案 A: omniauth-google-oauth2 + 手書き SessionsController (Devise なし)

**選定理由**:
- weight_dialy は **ソーシャル一本化方針** → Devise のメール+パスワード+確認メール機能の大半が unused になり overengineering
- 「Devise = 簡単」のイメージはフルセット使用時。**ソーシャルのみなら自前 omniauth の方がコード量が短い**
- omniauth の動きが透けて見える → 後輩教材性◎

**将来拡張への布石**:
- **Apple ID 増設** (Apple Developer Program $99 加入時): `omniauth-apple` gem 追加 + `provider == 'apple'` のレコードが増えるだけで対応可
- **メールパスワード認証併設**: `has_secure_password` を並列追加 (Rails 標準、半日仕事、既存 omniauth フローには手を加えない)

### `User.from_omniauth` は `find_or_initialize_by` + `assign_attributes` + `save!`

`find_or_create_by` のブロックは **create 時しか属性更新されない** ため、ログイン毎の email/name/image_url の更新を取り込む目的で `find_or_initialize_by` パターンを採用。Issue 本文の「`find_or_create_by(provider, uid)` で作成・更新」表記からは外れるが、**ログイン毎の最新化** という挙動の方を重視。

### スコープの線引き

- **正規ログインボタン本体**: ホームダミー除去 Issue で別扱い
- **本 PR のヘッダ仮ログインボタン**: 動作確認用 (turbo: false で外部遷移)。ホームダミー除去 Issue マージ後に正規 UI に統合する想定
- **認可制御 (`before_action :require_login`)**: 今回未実装。本格的な認可は歩数記録機能 Issue で動機が立ってから

## コミット構成

1. `feat`: Google OAuth ログイン機能を実装 (gem / .env / initializer / User / migration / SessionsController / routes / helpers / layouts)
2. `test`: User + Sessions の RSpec を追加 (test-writer による)

## Test plan

- [x] `bundle exec rspec` が緑 (26 examples, 0 failures)
- [x] 実機: ホーム → 「Google でログイン」ボタン → Google 認証画面 → アカウント選択 → ホームに戻る → ヘッダにユーザー名表示 → ログアウト → ヘッダが元に戻る
- [x] flash メッセージ ("ログインしました" / "ログアウトしました" / "ログインに失敗しました") の表示確認
- [x] `.env` 経由で credentials 管理が動く (本番は Day 5 のデプロイ時に Rails credentials.yml.enc に移行予定)

## 関連

Closes #11

- 親メモ: `memory/project_weight_dialy.md` (Google OAuth 確定方針)
- 関連 PR: #10 (RSpec 導入 — 本 PR の spec 基盤)
- 後続 Issue 候補:
  - **ホームダミー除去** (design-reviewer Blocker、本 PR の仮ログイン UI を正規化する役割も兼ねる)
  - **Apple Shortcuts Webhook 受信** (Day 3 後半着手予定)
- Backlog #8: 「Apple Developer Program 加入時に Sign in with Apple 増設」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 補足: `destroy` も `reset_session` に揃えた理由 (再レビュー反映時に追加)

`session.delete(:user_id)` でも user_id は消えるが、より完全に session を破棄する `reset_session` を採用。`create` 側で Session Fixation 対策として `reset_session` を使っているため、一貫性 + 教材性 (後輩が「セッション破棄は `reset_session` が標準作法」と読める形) を狙った判断。
