### PR TITLE
feat: ホーム画面のダミー要素を整理して仮ログイン UI を正規化する

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,11 +3,12 @@
     <div class="card-body items-center text-center">
       <h1 class="card-title text-3xl">weight_dialy</h1>
       <p class="text-base-content/70">日常の小さな勝ちを、自動で拾って褒める。</p>
-      <div class="badge badge-primary badge-outline">Day 1: daisyUI 動作確認</div>
       <div class="card-actions mt-4">
-        <button class="btn btn-primary">Primary</button>
-        <button class="btn btn-secondary">Secondary</button>
-        <button class="btn btn-accent">Accent</button>
+        <% if logged_in? %>
+          <p class="text-base-content">ようこそ、<%= current_user.name %>さん。</p>
+        <% else %>
+          <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post, class: "btn btn-primary", data: { turbo: false } %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,13 +3,14 @@
     <div class="card-body items-center text-center">
       <h1 class="card-title text-3xl">weight_dialy</h1>
       <p class="text-base-content/70">日常の小さな勝ちを、自動で拾って褒める。</p>
-      <div class="card-actions mt-4">
-        <% if logged_in? %>
-          <p class="text-base-content">ようこそ、<%= current_user.name %>さん。</p>
-        <% else %>
+      <% if logged_in? %>
+        <p class="text-base-content mt-4">ようこそ、<%= current_user.name %>さん。</p>
+      <% else %>
+        <div class="card-actions mt-4">
+          <%# OmniAuth ミドルウェアが /auth/:provider を処理するため named route なし %>
           <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post, class: "btn btn-primary", data: { turbo: false } %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title><%= content_for(:title) || "weight_dialy" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="App">
+    <meta name="application-name" content="weight_dialy">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -32,8 +32,6 @@
         <% if logged_in? %>
           <span class="mr-3 inline-block max-w-[8rem] truncate align-middle"><%= current_user.name %></span>
           <%= button_to "ログアウト", logout_path, method: :delete, class: "btn btn-ghost" %>
-        <% else %>
-          <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post, class: "btn btn-primary", data: { turbo: false } %>
         <% end %>
       </div>
     </header>

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe "Home", type: :request do
+  describe "GET /" do
+    context "未ログイン時" do
+      before { get root_path }
+
+      it "200 OK を返す" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "Google でログインボタンを表示する" do
+        expect(response.body).to include("Google でログイン")
+      end
+
+      it "ようこそメッセージを表示しない" do
+        expect(response.body).not_to include("ようこそ")
+      end
+
+      it "過去のダミーバッジ文字列を含まない" do
+        expect(response.body).not_to include("Day 1: daisyUI 動作確認")
+      end
+
+      it "旧ダミーボタン Primary を含まない" do
+        expect(response.body).not_to include(">Primary<")
+      end
+
+      it "旧ダミーボタン Secondary を含まない" do
+        expect(response.body).not_to include(">Secondary<")
+      end
+
+      it "旧ダミーボタン Accent を含まない" do
+        expect(response.body).not_to include(">Accent<")
+      end
+    end
+
+    context "ログイン時" do
+      let(:user) { create(:user) }
+
+      before do
+        mock_google_oauth2(uid: user.uid, email: user.email, name: user.name)
+        get auth_callback_path(provider: "google_oauth2")
+        get root_path
+      end
+
+      it "200 OK を返す" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "ようこそメッセージにユーザー名を含む" do
+        expect(response.body).to include("ようこそ、#{user.name}さん。")
+      end
+
+      it "ホーム本体の Google でログインボタンを表示しない" do
+        expect(response.body).not_to include("Google でログイン")
+      end
+
+      it "ヘッダにユーザー名を表示する" do
+        expect(response.body).to include(user.name)
+      end
+
+      it "ヘッダにログアウトボタンを表示する" do
+        expect(response.body).to include("ログアウト")
+      end
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe "Home", type: :request do
         expect(response.body).not_to include("Day 1: daisyUI 動作確認")
       end
 
+      # 過去のダミーボタン (Primary / Secondary / Accent) の回帰防止:
+      # button_to が生成する <button>...</button> のボタンテキストとして
+      # 該当文字列が現れないことを `>Primary<` のような囲い文字で検証する
       it "旧ダミーボタン Primary を含まない" do
         expect(response.body).not_to include(">Primary<")
       end
@@ -51,7 +54,7 @@ RSpec.describe "Home", type: :request do
         expect(response.body).to include("ようこそ、#{user.name}さん。")
       end
 
-      it "ホーム本体の Google でログインボタンを表示しない" do
+      it "Google でログインボタンをどこにも表示しない" do
         expect(response.body).not_to include("Google でログイン")
       end
 


### PR DESCRIPTION
## Summary

- ホーム画面の **Day 1 仮 UI** を本物の入口に整理 (バッジ + 3 ダミーボタン削除 → 「Google でログイン」 1 ボタン)
- PR #12 で導入した**ヘッダの仮ログイン UI をホームカード本体に正規化** (1 画面 1 CTA)
- `<meta name="application-name">` を `"App"` → `"weight_dialy"` に修正 (PR #12 design-reviewer 再レビュー新規発見への対応)
- RSpec 38 examples / 0 failures (新規 home_spec 12 examples 追加)

## なぜこの構成か (教材ポイント)

### 案 A: シンプルなカード構成 (現行の延長)

スコープを「**ダミー除去 + 仮 UI 正規化**」に絞り、Hero キャッチコピー追加 (β 領域) や Demo モード CTA 追加 (Day 3 デモモード Issue) は **意図的にスコープ外** とした。コピー強化は別軸の議論になり本 Issue で確定すると将来のコピー検討の機会が失われるため、**「掃除」と「コピー強化」を分離**。

### `logged_in?` 分岐で表示切り替え

- **未ログイン時**: ホームカードに「Google でログイン」ボタンを Primary で 1 つ
- **ログイン時**: 「ようこそ、(name) さん。」(**M1: シンプル路線**、コピー強化は将来の別 Issue で議論する余地を残す)

### ヘッダの正規化

- 未ログイン時の Login ボタン削除 (ホームカードに統合 = **1 画面 1 CTA**)
- ログイン時の「ユーザー名 + ログアウト」表示は維持

### 回帰防止 spec

`>Primary<`, `>Secondary<`, `>Accent<` の文字列含有を **明示的に否定**。将来うっかり似たクラス名を使うコードが入っても、ボタンテキストとしてのダミーが復活しないことを spec が守る。

## コミット構成

1. `feat`: ホーム画面のダミー要素を整理して仮ログイン UI を正規化する
2. `test`: ホームの request spec を追加 (test-writer による)

## Test plan

- [x] `bundle exec rspec`: 38 examples, 0 failures (既存 26 + 新規 home_spec 12)
- [x] 実機 未ログイン: Day 1 バッジ + 3 ダミーボタンが消えている、ホームカードに「Google でログイン」ボタン 1 つ、ヘッダはアプリ名のみ
- [x] 実機 ログイン後: ホームカードが「ようこそ、(name) さん。」表示、ヘッダにユーザー名 + ログアウト
- [x] 実機 ログアウト: 未ログイン状態に戻る
- [x] 実機 タブタイトル: `weight_dialy`

## 関連

Closes #13

- 親メモ: `memory/project_day2_kickoff.md` (Day 2 残り 🥇 最優先)
- 関連 PR:
  - #3 (daisyUI 5 統合 — Day 1 バッジ + 3 ダミーボタンを導入)
  - #12 (Google OAuth — ヘッダ仮 UI を導入、本 PR で正規化)
- 後続 Issue 候補:
  - **コピー強化** (Hero / メッセージのトーン): β 領域として将来の別 Issue
  - **Demo モード CTA 追加**: Day 3 のデモモード実装 Issue
  - **フラッシュ自動非表示 Stimulus**: 別 Issue 起票予定 (PR #12 design-reviewer S-2 由来)
- Backlog #8 追記済み: `/about` ページ拡張 (使い方ページとして強化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)