### PR TITLE
feat: フラッシュメッセージの自動非表示 + 閉じるボタンを Stimulus で実装する

### DIFF
--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
-// flash メッセージを 3 秒後に自動で消す + 閉じるボタンで即時クローズする
-// Turbo navigation で element が外れたときに timeout が残らないよう disconnect で clear
+// Turbo navigation で element が外れたときに timeout が残らないよう disconnect で clear。
+// close() でも clearTimeout を呼んで明示的にタイマーを停止してから remove する。
 export default class extends Controller {
   connect() {
     this.timeout = setTimeout(() => this.close(), 3000)
@@ -12,6 +12,7 @@ export default class extends Controller {
   }
 
   close() {
+    clearTimeout(this.timeout)
     this.element.remove()
   }
 }

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// flash メッセージを 3 秒後に自動で消す + 閉じるボタンで即時クローズする
+// Turbo navigation で element が外れたときに timeout が残らないよう disconnect で clear
+export default class extends Controller {
+  connect() {
+    this.timeout = setTimeout(() => this.close(), 3000)
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+
+  close() {
+    this.element.remove()
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,10 +37,16 @@
     </header>
 
     <% if flash[:notice] %>
-      <div class="alert alert-success container mx-auto mt-4"><%= flash[:notice] %></div>
+      <div class="alert alert-success container mx-auto mt-4" data-controller="flash">
+        <span><%= flash[:notice] %></span>
+        <button type="button" class="btn btn-ghost btn-sm" data-action="click->flash#close" aria-label="閉じる">×</button>
+      </div>
     <% end %>
     <% if flash[:alert] %>
-      <div class="alert alert-error container mx-auto mt-4"><%= flash[:alert] %></div>
+      <div class="alert alert-error container mx-auto mt-4" data-controller="flash">
+        <span><%= flash[:alert] %></span>
+        <button type="button" class="btn btn-ghost btn-sm" data-action="click->flash#close" aria-label="閉じる">×</button>
+      </div>
     <% end %>
 
     <main class="container mx-auto mt-4 px-5 flex">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,15 +37,15 @@
     </header>
 
     <% if flash[:notice] %>
-      <div class="alert alert-success container mx-auto mt-4" data-controller="flash">
+      <div class="alert alert-success container mx-auto mt-4" role="alert" data-controller="flash">
         <span><%= flash[:notice] %></span>
-        <button type="button" class="btn btn-ghost btn-sm" data-action="click->flash#close" aria-label="閉じる">×</button>
+        <button type="button" class="btn btn-ghost btn-circle" data-action="click->flash#close" aria-label="閉じる">×</button>
       </div>
     <% end %>
     <% if flash[:alert] %>
-      <div class="alert alert-error container mx-auto mt-4" data-controller="flash">
+      <div class="alert alert-error container mx-auto mt-4" role="alert" data-controller="flash">
         <span><%= flash[:alert] %></span>
-        <button type="button" class="btn btn-ghost btn-sm" data-action="click->flash#close" aria-label="閉じる">×</button>
+        <button type="button" class="btn btn-ghost btn-circle" data-action="click->flash#close" aria-label="閉じる">×</button>
       </div>
     <% end %>
 


### PR DESCRIPTION
## Summary

- **Stimulus 初導入** で flash メッセージを 3 秒後に自動非表示 + 閉じるボタン (×) を追加
- `app/javascript/controllers/flash_controller.js` 新規 (6 行ロジック + コメント)
- 既存の `eagerLoadControllersFrom` 機構に乗るため **config の追加なし** (ファイル配置だけで動く)
- RSpec 38 examples / 0 failures (HTML 構造変更による回帰なし)

## なぜこの構成か (教材ポイント)

### Stimulus controller の最小サンプル

weight_dialy で初の Stimulus controller。後輩が読んだとき「Stimulus はこう書く」が分かる最小限のサンプルとして残す狙い:

```js
import { Controller } from "@hotwired/stimulus"

export default class extends Controller {
  connect()    { this.timeout = setTimeout(() => this.close(), 3000) }
  disconnect() { clearTimeout(this.timeout) }
  close()      { this.element.remove() }
}
```

3 メソッドで完結。ライフサイクル (`connect` / `disconnect`) と独自 action (`close`) の両方を見せる教材性。

### `disconnect()` で `clearTimeout` する意図

Turbo Drive のページ遷移で element が DOM から外れた時に setTimeout が残るとメモリリークになる。教材として「**Stimulus controller の disconnect は副作用を片付ける場所**」を明示する。

### 自動登録の仕組み

`config/importmap.rb` で `pin_all_from "app/javascript/controllers", under: "controllers"` + `app/javascript/controllers/index.js` で `eagerLoadControllersFrom("controllers", application)` 済みのため、**ファイル名 `flash_controller.js` を置くだけで `data-controller="flash"` が動く**。これは Rails 標準のセットアップ。後輩が「Stimulus controller を追加するときは index.js を書き換える必要があるのか?」を疑問に思うところを、PR 本文で解消しておく。

### スコープの線引き

- **フェードアウトアニメーション**: 別 Issue (CSS transition、シンプル路線優先)
- **複数 flash の積み重ね表示**: 将来必要になれば対応
- **JS の system spec**: capybara/cuprite 未導入のため対象外 (Backlog #8 で system spec 導入時に追加予定)

## Test plan

- [x] `bundle exec rspec`: 38 examples, 0 failures (HTML 構造変更による回帰なし)
- [x] 実機: ログイン → 緑 flash 表示 → 3 秒で自動消滅
- [x] 実機: × ボタンクリック → 即座に消える
- [x] 実機: ログアウト → 緑 flash → 同様に動作
- [x] 実機: Turbo navigation で連続操作しても干渉なし

## 関連

Closes #15

- 親メモ: `memory/project_day2_kickoff.md` (Day 2 残り 🥉)
- 関連 PR: #12 (Google OAuth — flash 導入元)、#14 (ホームダミー除去)
- 後続 Issue 候補:
  - フェードアウトアニメーション (CSS transition、別 Issue)
  - JS の system spec (Backlog #8 で system spec 導入時)

🤖 Generated with [Claude Code](https://claude.com/claude-code)