### PR TITLE
fix: rubocop の配列リテラル空白違反を解消する

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -10,4 +10,4 @@ Rails.application.config.middleware.use OmniAuth::Builder do
            }
 end
 
-OmniAuth.config.allowed_request_methods = [:post]
+OmniAuth.config.allowed_request_methods = [ :post ]

--- a/db/migrate/20260501051150_create_users.rb
+++ b/db/migrate/20260501051150_create_users.rb
@@ -10,6 +10,6 @@ class CreateUsers < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :users, [:provider, :uid], unique: true
+    add_index :users, [ :provider, :uid ], unique: true
   end
 end


### PR DESCRIPTION
## Summary
- `config/initializers/omniauth.rb:13` と `db/migrate/20260501051150_create_users.rb:13` の配列リテラルに rubocop-rails-omakase の `Layout/SpaceInsideArrayLiteralBrackets` 違反 (内側スペース欠落) があり、PR #14 以降 main の CI がずっと赤い状態だった
- `[:post]` → `[ :post ]` / `[:provider, :uid] → `[ :provider, :uid ]` の機械的修正のみ

## 経緯
PR #18 (引き継ぎテンプレ整備) を作成した際、ドキュメントしか変えていないにも関わらず CI lint が落ちたため調査。直近 3 PR (#14, #16, #17) も全て CI failure で main へマージされていた既存問題であることが判明。本 PR で main を一旦衛生化する。

## Day 2 への学び
- レビュー運用に「マージ前に CI グリーン必須」を組み込むべき (別途 CLAUDE.md 追記検討)
- 3 者並列レビューは内容観点では機能していたが、機械的 lint チェックが運用フローから抜け落ちていた

## Test plan
- [x] ローカル `bundle exec rubocop` で 37 files / 0 offenses
- [ ] CI が green になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)