### PR TITLE
refactor: OAuth credentials を credentials 優先 + ENV fallback にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@
 # 承認済みリダイレクト URI に http://localhost:3000/auth/google_oauth2/callback を登録
 GOOGLE_CLIENT_ID=your-client-id-here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret-here
+
+# === 本番デプロイ時のみ必要 ===
+# config/master.key の中身を本番サーバーの環境変数として渡す
+# (credentials.yml.enc を復号するための鍵)
+# ローカル開発では config/master.key ファイルが直接読まれるので設定不要
+# RAILS_MASTER_KEY=

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,7 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2,
-           ENV["GOOGLE_CLIENT_ID"],
-           ENV["GOOGLE_CLIENT_SECRET"],
+           Rails.application.credentials.dig(:google, :client_id) || ENV["GOOGLE_CLIENT_ID"],
+           Rails.application.credentials.dig(:google, :client_secret) || ENV["GOOGLE_CLIENT_SECRET"],
            {
              scope: "email,profile",
              prompt: "select_account",

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,7 @@
+# Google OAuth の Client ID/Secret は本番では config/credentials.yml.enc を一次情報とし、
+# 未設定なら ENV にフォールバックする。開発環境では credentials を空のままにして .env から読む。
+# 本番で両方未設定の場合はファイル末尾のバリデーションで起動時に検出する。
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2,
            Rails.application.credentials.dig(:google, :client_id) || ENV["GOOGLE_CLIENT_ID"],
@@ -11,3 +15,14 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 OmniAuth.config.allowed_request_methods = [ :post ]
+
+if Rails.env.production?
+  client_id = Rails.application.credentials.dig(:google, :client_id) || ENV["GOOGLE_CLIENT_ID"]
+  client_secret = Rails.application.credentials.dig(:google, :client_secret) || ENV["GOOGLE_CLIENT_SECRET"]
+
+  if client_id.blank? || client_secret.blank?
+    raise "Google OAuth credentials が未設定です " \
+          "(config/credentials.yml.enc の :google.client_id / :client_secret か、" \
+          "環境変数 GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET のいずれかで設定してください)"
+  end
+end


### PR DESCRIPTION
## Summary
- `config/initializers/omniauth.rb` の Google Client ID / Secret 読み込みを **credentials 優先 + ENV フォールバック** 式に変更
- 本番では `config/credentials.yml.enc` から、開発では引き続き `.env` から読まれる構造に整理
- **スコープ拡張**: 本番で credentials/ENV 両方未設定なら起動時に `raise` する fail-fast バリデーションを同時導入 (re-review で追加。「静かに ENV 運用のまま発表会突入する事故」を物理防止するため、フォールバック式と同一 PR で入れる方が安全という判断)
- Day 5 のデプロイ作業前に秘密管理を統一しておく前段 (memory: Day 3 🥇 タスク)

## 変更内容
```diff
+ # Google OAuth の Client ID/Secret は本番では config/credentials.yml.enc を一次情報とし、
+ # 未設定なら ENV にフォールバックする。開発環境では credentials を空のままにして .env から読む。
+ # 本番で両方未設定の場合はファイル末尾のバリデーションで起動時に検出する。
+
- ENV["GOOGLE_CLIENT_ID"],
- ENV["GOOGLE_CLIENT_SECRET"],
+ Rails.application.credentials.dig(:google, :client_id) || ENV["GOOGLE_CLIENT_ID"],
+ Rails.application.credentials.dig(:google, :client_secret) || ENV["GOOGLE_CLIENT_SECRET"],

# (末尾に追加)
+ if Rails.env.production?
+   client_id = Rails.application.credentials.dig(:google, :client_id) || ENV["GOOGLE_CLIENT_ID"]
+   client_secret = Rails.application.credentials.dig(:google, :client_secret) || ENV["GOOGLE_CLIENT_SECRET"]
+   if client_id.blank? || client_secret.blank?
+     raise "Google OAuth credentials が未設定です ..."
+   end
+ end
```

## なぜ credentials 優先 + ENV フォールバックか
| 環境 | 値の出どころ | 理由 |
|---|---|---|
| 開発 | `.env` (ENV) | credentials 未設定なので ENV にフォールバック。手元で値を書き換えるのが楽 |
| 本番 | `config/credentials.yml.enc` | サーバには `master.key` を `RAILS_MASTER_KEY` 環境変数で配布。秘密値はリポジトリに暗号化して入る |

逆 (ENV 優先) も成立するが、本番でうっかり環境変数を入れ忘れると credentials が無視される事故があり得るため、**「本番は credentials が一次情報」** の運用が読み手にとって明確。後輩が Rails 標準の秘密管理パターンを学ぶ題材としても素直。

## なぜ fail-fast を同 PR に同梱したか
レビュー反映時に追加。フォールバック式は便利な反面、「本番で両方未設定でもアプリが起動して、OAuth を踏んだ瞬間に初めて壊れる」=「静かに本番事故」を許容してしまう。fail-fast を別 PR に切ると「片方だけマージされた中間状態」が生じ、その間の本番デプロイが危険。**「変更点 A の安全性が変更点 B に依存しているなら、A と B は同一 PR で入れる」** 原則に従って同梱した。

## 動作確認
- `bundle exec rspec`: 38 examples / 0 failures
- `bundle exec rubocop`: 0 offenses
- 開発環境での Google OAuth ログイン: 既存挙動と変わらず ENV から読まれる (credentials 側に google キー未設定のため)
- CI: lint / scan_ruby / scan_js 全 pass

## レビュー反映ログ
[code-reviewer]
- ⚠️ 本番で両方未設定時に nil が静かに通る → 本番限定 fail-fast バリデーション追加
- 💡 .env.example に RAILS_MASTER_KEY 案内不足 → コメント追記

[strategic-reviewer]
- 🟢 論点 3 (教材性永続化) → omniauth.rb 先頭に運用方針コメント 3 行追加

## スコープ外 (後続作業)
- 本番 credentials の中身設定: `bin/rails credentials:edit -e production` で設定 (Day 5 デプロイ時に対応)
- `master.key` のデプロイ先への配布計画 (Kamal なら `secret`、Render/Fly.io なら環境変数として `RAILS_MASTER_KEY`)
- memory `project_day3_kickoff.md` に Day 5 チェックリスト追記 (本 PR マージ直後に対応)
- Day 5 用 Issue 起票 (Day 4 終了時に対応)
- `doc/development.md` の秘密管理方針セクション (Day 4 ポリッシュ枠)

## セキュリティ確認
- `config/master.key` は `.gitignore` の `/config/*.key` で除外済み (git 追跡なしを `git ls-files config/master.key` で確認)

## Test plan
- [x] RSpec 全 38 examples グリーン
- [x] rubocop 0 offenses
- [x] CI green (lint / scan_ruby / scan_js)
- [x] 再レビュー (code-reviewer ✅ Approve / strategic-reviewer 🟢 Go)
- [ ] ローカルで Google OAuth ログインを実機テスト (ユーザー操作)

🤖 Generated with [Claude Code](https://claude.com/claude-code)