### PR TITLE
fix: bg-base-200 を <body> に移動してホーム/about の灰色エリア横伸びを直す

### DIFF
--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, "weight_dialy について" %>
 
+<%# min-h は 100vh から navbar (4rem) + <main> の mt-4 (1rem) を引いた高さ。
+    layout 側の <main class="... mt-4"> を変更したら本値も合わせて見直す。 %>
 <div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
   <div class="card w-full max-w-sm mx-auto bg-base-100 shadow-xl">
     <div class="card-body items-center text-center">

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "weight_dialy について" %>
 
-<div class="min-h-screen flex items-center justify-center bg-base-200">
+<div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
   <div class="card w-full max-w-sm mx-auto bg-base-100 shadow-xl">
     <div class="card-body items-center text-center">
       <h1 class="card-title text-3xl">weight_dialy について</h1>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,5 @@
+<%# min-h は 100vh から navbar (4rem) + <main> の mt-4 (1rem) を引いた高さ。
+    layout 側の <main class="... mt-4"> を変更したら本値も合わせて見直す。 %>
 <div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
   <div class="card w-full max-w-sm mx-auto bg-base-100 shadow-xl">
     <div class="card-body items-center text-center">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen flex items-center justify-center bg-base-200">
+<div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
   <div class="card w-full max-w-sm mx-auto bg-base-100 shadow-xl">
     <div class="card-body items-center text-center">
       <h1 class="card-title text-3xl">weight_dialy</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="bg-base-200">
     <header class="navbar bg-base-100 shadow-sm">
       <div class="flex-1">
         <%= link_to "weight_dialy", root_path, class: "btn btn-ghost text-xl" %>


### PR DESCRIPTION
## Summary

PR #23 (`<main>` から `flex` を削除してモバイル対応) の副作用として顕在化した「カード周囲に広い灰色の縁取り」現象を、`bg-base-200` を `<body>` に移動することで根治。

## なぜこの構成か (教材性メモ)

PR #23 前は `<main class="... flex">` 配下で `<div class="min-h-screen ... bg-base-200">` が flex item として shrink し、灰色エリアがカード幅 (384px) 程度に収まっていた。`<main>` の `flex` 削除でブロック要素に戻り、灰色エリアが画面横幅まで広がってしまった。

修正方針 3 案:

| 案 | 内容 | 評価 |
|---|---|---|
| **採用** | `bg-base-200` を `<body>` に移動、inner div から削除、`min-h-screen` → `min-h-[calc(100vh-5rem)]` | daisyUI hero パターンの正解形。ヘッダ白 + 全画面灰色 + カード白の 3 層が綺麗 |
| 不採用 | inner div に `max-w-sm` を追加して灰色エリア制限 | 縦長の灰色帯になり奇妙 |
| 不採用 | `<main>` を flex に戻す | PR #23 で削除した `<main>` の `flex` は垂直中央寄せの入れ子問題を起こすため戻せない |

## Test plan

- [x] RSpec: 38 examples, 0 failures
- [x] rubocop: 37 files, no offenses
- [x] grep `bg-base-200 app/views`: `<body>` の 1 箇所のみ (inner div から完全消去)
- [x] DevTools 目視: ホーム / /about 両方でヘッダ + 灰色背景 + カードの 3 層構造を確認
- [x] 375px (iPhone SE) でカードが viewport 内に収まり、横スクロールなし

## 補足

動作確認時に **ダークテーマで表示される** ケースがあるが、これは daisyUI 5.x の `prefers-color-scheme` 自動切替によるもので、本 PR の構造的修正とは独立の論点。ライト/ダーク戦略は Backlog #8 に積んで、UI 完成度が上がってから再検討予定。

## 関連

- Closes #26
- 副作用の発生源: PR #23 (`<main>` から `flex` 削除)
- 関連メモ: `memory/feedback_one_change_two_bugs.md` (本件は「1 改変 → 2 件発覚」の 2 件目を消化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
