### PR TITLE
chore: api-researcher 用に WebSearch / WebFetch 権限を追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "WebFetch"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,13 @@
   "permissions": {
     "allow": [
       "WebSearch",
-      "WebFetch"
+      "WebFetch(domain:developer.apple.com)",
+      "WebFetch(domain:support.apple.com)",
+      "WebFetch(domain:developers.strava.com)",
+      "WebFetch(domain:guides.rubyonrails.org)",
+      "WebFetch(domain:api.rubyonrails.org)",
+      "WebFetch(domain:docs.github.com)",
+      "WebFetch(domain:api.github.com)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

api-researcher サブエージェントが外部 API 仕様 (Apple Shortcuts / Strava / HMAC 等) を Web で調査できるよう、`.claude/settings.json` に `WebSearch` と `WebFetch` の許可を追加。

Day 2 の検証で「権限なしで api-researcher が失敗」していた状態を解消する。本 PR マージ後、Day 3 の本命タスク **🥈 Apple Shortcuts Webhook 受信** 着手前の事前調査が回せるようになる。

## なぜ settings.json (共有) に置くか

| 案 | 評価 |
|---|---|
| **採用: `settings.json` (committed)** | 後輩が clone した時にすぐ api-researcher が動く。教材性◎。weight_dialy 標準セットアップとして明示 |
| 不採用: `settings.local.json` (gitignored) | 個人設定のままだと clone 後に毎回手動付与が必要。学習教材として後輩に「apply 手順」を増やすコストが高い |

api-researcher の用途は API 仕様読み込みに限定されており、機密情報の流出経路にはならないため共有許可で問題ない。

## Test plan

- [x] `.claude/settings.json` に `permissions.allow: ["WebSearch", "WebFetch"]` を追加
- [x] 既存の `hooks` 設定 (block-main-push) は維持
- [ ] マージ後、本セッションで api-researcher を起動して Apple Shortcuts Webhook 仕様調査が走ることを確認

## 関連

- 親メモ: `memory/project_day3_kickoff.md` の「🥈 Apple Shortcuts → Webhook 受信」前提タスク
- Day 2 で「WebSearch/WebFetch 権限なしで失敗」していた件の解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)
