### PR TITLE
feat: Claude Design v3 由来の sketchy 風テーマを大枠導入する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,12 @@
 - Hotwire ファースト (Turbo Frame / Stream / Stimulus)。SPA 化しない
 - N+1 防止: `.includes` / `.preload` を意識
 
+### 🎨 スタイル使い分けルール
+
+- **コンポーネント**: `app/assets/stylesheets/sketchy.css` の `sketch-*` クラスを正とする
+- **Tailwind utility**: `flex` / `grid` / `mt-4` / `container` 等のレイアウト用ユーティリティは引き続き使用 OK
+- **daisyUI コンポーネント** (`btn` / `card` / `navbar` / `alert` 等): **新規利用禁止**。既存箇所も触ったタイミングで `sketch-*` に置換
+
 ---
 
 ## ⚠️ やってはいけないこと

--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -1,0 +1,121 @@
+/*
+ * sketchy.css — Claude Design v3 由来の手書き風テーマ。
+ *
+ * 大枠のみ提供 (テーマ変数 / body / navbar / box / btn / toast / 文字サイズ)。
+ * 個別画面 (ダッシュボードチャート等) のクラスは、機能実装時にこのファイルへ追記する。
+ *
+ * フォント (Patrick Hand / Caveat / Kalam) は layout の <head> で <link> 読込済み前提。
+ * → 将来 CSP を有効化する場合は font-src に fonts.gstatic.com、style-src に fonts.googleapis.com を許可リスト追加が必要。
+ */
+
+:root {
+  --ink: #1a1a1a;
+  --ink-2: #3a3a3a;
+  --paper: #fbf8f1;
+  --paper-2: #f3eee0;
+  --muted: #6e6b60;
+  --accent: #ff7a45;
+  --accent-2: #ffd23f;
+  --accent-3: #4ea8de;
+  --accent-4: #7ac74f;
+}
+
+/* body 全体を紙質背景に。layout から bg-base-200 は外す前提。 */
+body {
+  background: var(--paper);
+  background-image:
+    radial-gradient(circle at 20% 10%, rgba(0,0,0,0.025) 0 1px, transparent 1px),
+    radial-gradient(circle at 80% 60%, rgba(0,0,0,0.02) 0 1px, transparent 1px);
+  background-size: 8px 8px, 12px 12px;
+  color: var(--ink);
+  font-family: 'Patrick Hand', 'Kalam', system-ui, sans-serif;
+}
+
+/* ---------- navbar ---------- */
+.sketch-navbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 20px; gap: 12px;
+  border-bottom: 2px solid var(--ink);
+  background: var(--paper);
+}
+.sketch-navbar-title {
+  font-family: 'Caveat', cursive; font-weight: 700; font-size: 32px;
+  line-height: 1; color: var(--ink); text-decoration: none;
+}
+/* "daily." の下に黄色マーカーを引く swoosh 装飾。
+   SVG 背景画像で上下端にゆらぎを入れた蛍光ペン跡を描く (linear-gradient は直線で機械的に見えるため不採用)。
+   preserveAspectRatio=none で文字幅に応じて横に伸縮、background-size で文字の下半分にだけ帯を表示。 */
+.sketch-swoosh {
+  display: inline-block;
+  padding: 0 6px;
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  background-size: 100% 42%;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 30' preserveAspectRatio='none'><path d='M0,8 C18,0 38,12 56,3 C74,0 88,11 100,4 L100,25 C82,29 62,22 44,26 C26,30 12,23 0,27 Z' fill='%23ffd23f' fill-opacity='0.95'/></svg>");
+}
+.sketch-navbar-right { display: flex; align-items: center; gap: 12px; }
+.sketch-navbar-name {
+  font-family: 'Kalam', cursive; font-size: 14px; color: var(--ink-2);
+  max-width: 8rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* ---------- button ---------- */
+/* button_to が <form> でラップするため :active のずれを安定させる工夫が必要 */
+.sketch-btn {
+  display: inline-block; border: 2px solid var(--ink); background: var(--paper);
+  font-family: 'Caveat', cursive; font-size: 18px; padding: 4px 14px; border-radius: 6px;
+  color: var(--ink); text-decoration: none; cursor: pointer;
+  box-shadow: 2px 2px 0 var(--ink);
+  transition: transform .08s ease, box-shadow .08s ease;
+}
+.sketch-btn:hover { transform: translate(-1px, -1px); box-shadow: 3px 3px 0 var(--ink); }
+.sketch-btn:active { transform: translate(2px, 2px); box-shadow: 0 0 0 var(--ink); }
+/* primary は #ff7a45 + 黒文字 (6.73:1) で WCAG AA 合格。白文字 (2.59:1) は不可。 */
+.sketch-btn-primary { background: var(--accent); color: var(--ink); }
+.sketch-btn-primary:hover { background: var(--accent); color: var(--ink); }
+
+/* ---------- box / card ---------- */
+.sketch-box {
+  border: 2px solid var(--ink); border-radius: 6px; background: var(--paper); padding: 16px;
+  box-shadow: 4px 4px 0 var(--ink);
+}
+.sketch-box.dashed { border-style: dashed; }
+.sketch-box.filled { background: var(--paper-2); }
+.sketch-box.accent { background: var(--accent); color: #fff; }
+.sketch-box.accent .sketch-label,
+.sketch-box.accent .sketch-small { color: rgba(255,255,255,.85); }
+
+/* ---------- typography ---------- */
+.sketch-h  { font-family: 'Caveat', cursive; font-weight: 700; font-size: 24px; margin: 0 0 6px; line-height: 1.1; }
+.sketch-hh { font-family: 'Caveat', cursive; font-size: 30px; margin: 0; line-height: 1.1; }
+.sketch-label { font-family: 'Kalam', cursive; font-size: 13px; color: var(--muted); }
+.sketch-small { font-family: 'Kalam', cursive; font-size: 12px; color: var(--ink-2); }
+.sketch-body-text { font-family: 'Kalam', cursive; font-size: 15px; line-height: 1.55; color: var(--ink-2); }
+
+/* highlight (黄/緑のマーカー風) */
+.sketch-hl-yellow { background: var(--accent-2); padding: 0 4px; }
+.sketch-hl-green  { background: var(--accent-4); padding: 0 4px; }
+
+/* ---------- flash toast ---------- */
+/* daisyUI alert を sketchy トーストに差し替え。
+   PR #25 で詰めた flash_controller.js の fade-out 挙動 (opacity transition) はそのまま動かすため、
+   transition: opacity を残し、初期 opacity-0 / 表示時 opacity-1 のクラスは layout 側で付ける。 */
+.sketch-toast {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
+  border: 2px solid var(--ink); border-radius: 6px; padding: 12px 14px;
+  box-shadow: 4px 4px 0 var(--ink);
+  font-family: 'Kalam', cursive; font-size: 14px; line-height: 1.45; color: var(--ink);
+  transition: opacity .3s;
+}
+.sketch-toast.notice { background: #e7f5d9; }
+.sketch-toast.alert  { background: #ffd9d9; }
+.sketch-toast-message { flex: 1; }
+.sketch-toast-close {
+  background: transparent; border: none; cursor: pointer; padding: 0;
+  width: 32px; height: 32px; flex-shrink: 0;
+  font-family: 'Caveat', cursive; font-size: 24px; line-height: 1; color: var(--ink);
+}
+.sketch-toast-close:hover { color: var(--accent); }
+
+/* ---------- page wrappers (汎用) ---------- */
+.sketch-page-narrow { max-width: 26rem; margin: 0 auto; padding: 24px 4px; }

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -1,17 +1,17 @@
 <% content_for :title, "weight_dialy について" %>
 
-<%# min-h は 100vh から navbar (4rem) + <main> の mt-4 (1rem) を引いた高さ。
-    layout 側の <main class="... mt-4"> を変更したら本値も合わせて見直す。 %>
+<%# min-h は 100vh から navbar (約 60px) + <main> の mt-4 (1rem) を引いた高さ。
+    layout 側の <main class="... mt-4"> や navbar padding を変更したら本値も合わせて見直す。 %>
 <div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
-  <div class="card w-full max-w-sm mx-auto bg-base-100 shadow-xl">
-    <div class="card-body items-center text-center">
-      <h1 class="card-title text-3xl">weight_dialy について</h1>
-      <p class="text-base-content/70">
-        通勤通学のついで歩きや、エスカレーターの代わりに階段。
+  <div class="sketch-page-narrow w-full">
+    <div class="sketch-box" style="text-align: center;">
+      <h1 class="sketch-hh" style="margin-bottom: 12px;">weight <span class="sketch-swoosh">daily.</span> について</h1>
+      <p class="sketch-body-text">
+        通勤通学のついで歩きや、エスカレーターの代わりに階段。<br>
         日常の小さな前向きな選択を自動で拾って褒める Web アプリです。
       </p>
-      <div class="card-actions mt-4">
-        <%= link_to "ホームへ戻る", root_path, class: "btn btn-primary" %>
+      <div style="margin-top: 16px;">
+        <%= link_to "ホームへ戻る", root_path, class: "sketch-btn sketch-btn-primary" %>
       </div>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,16 +1,18 @@
-<%# min-h は 100vh から navbar (4rem) + <main> の mt-4 (1rem) を引いた高さ。
-    layout 側の <main class="... mt-4"> を変更したら本値も合わせて見直す。 %>
+<%# min-h は 100vh から navbar (約 60px) + <main> の mt-4 (1rem) を引いた高さ。
+    layout 側の <main class="... mt-4"> や navbar padding を変更したら本値も合わせて見直す。 %>
 <div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
-  <div class="card w-full max-w-sm mx-auto bg-base-100 shadow-xl">
-    <div class="card-body items-center text-center">
-      <h1 class="card-title text-3xl">weight_dialy</h1>
-      <p class="text-base-content/70">日常の小さな勝ちを、自動で拾って褒める。</p>
+  <div class="sketch-page-narrow w-full">
+    <div class="sketch-box" style="text-align: center;">
+      <h1 class="sketch-hh" style="margin-bottom: 8px;">weight <span class="sketch-swoosh">daily.</span></h1>
+      <p class="sketch-body-text">日常の小さな勝ちを、自動で拾って褒める。</p>
       <% if logged_in? %>
-        <p class="text-base-content mt-4">ようこそ、<%= current_user.name %>さん。</p>
+        <p class="sketch-body-text" style="margin-top: 16px;">
+          ようこそ、<b><%= current_user.name %></b> さん。
+        </p>
       <% else %>
-        <div class="card-actions mt-4">
+        <div style="margin-top: 16px;">
           <%# OmniAuth ミドルウェアが /auth/:provider を処理するため named route なし %>
-          <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post, class: "btn btn-primary", data: { turbo: false } %>
+          <%= button_to "Google でログイン", "/auth/google_oauth2", method: :post, class: "sketch-btn sketch-btn-primary", data: { turbo: false } %>
         </div>
       <% end %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,42 +18,50 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
+    <%# Includes all stylesheet files in app/assets/stylesheets (sketchy.css も含む) %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+
+    <%# sketchy テーマで使う手書き風フォント。display=swap で FOUC を最小化 %>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@500;700&family=Kalam:wght@400;700&family=Patrick+Hand&display=swap" rel="stylesheet">
+
+    <%# JS 無効環境フォールバック: flash の opacity-0 を強制解除して永続不可視を防ぐ。
+        HTML5 仕様上 <noscript><style> は <head> 内に置くのが正 (body 内は実装依存)。 %>
+    <noscript><style>[data-controller="flash"] { opacity: 1 !important; }</style></noscript>
+
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-base-200">
-    <header class="navbar bg-base-100 shadow-sm">
-      <div class="flex-1">
-        <%= link_to "weight_dialy", root_path, class: "btn btn-ghost text-xl" %>
-      </div>
-      <div class="flex-none">
+  <body>
+    <header class="sketch-navbar">
+      <%= link_to root_path, class: "sketch-navbar-title" do %>
+        weight <span class="sketch-swoosh">daily.</span>
+      <% end %>
+      <div class="sketch-navbar-right">
         <% if logged_in? %>
-          <span class="mr-3 inline-block max-w-[8rem] truncate align-middle"><%= current_user.name %></span>
-          <%= button_to "ログアウト", logout_path, method: :delete, class: "btn btn-ghost" %>
+          <span class="sketch-navbar-name"><%= current_user.name %></span>
+          <%= button_to "ログアウト", logout_path, method: :delete, class: "sketch-btn" %>
         <% end %>
       </div>
     </header>
 
     <%# flash はトースト風に画面上部 fixed で重ねる (document flow から外れるため、表示/非表示で下のコンテンツがズレない)。
-        top-24 (96px) は navbar 高さ 64px + 余白 16px + 将来 navbar を sticky 化した時の追加バッファ確保。
-        left-1/2 + -translate-x-1/2 で水平中央寄せ、w-[calc(100%-2rem)] で左右 16px の余白を保証。
-        FOUC 対策: 初期に opacity-0 を仕込んで HTML レンダ直後から透明にし、Stimulus connect() で外して fade-in する。
-        JS 無効環境フォールバック: <noscript> で opacity を 1 に強制復帰させるため flash が永遠に消える事故を防ぐ。 %>
+        top-24 (96px) は navbar 高さ + 余白 + 将来 navbar を sticky 化した時の追加バッファ。
+        FOUC 対策: 初期 opacity-0 + Stimulus connect() で fade-in。JS 無効フォールバックは <head> の <noscript><style> 参照。
+        見た目は sketchy トーストに差し替え (sketch-toast)、フェード挙動 (flash_controller.js) は変更しない。 %>
     <% if flash[:notice] || flash[:alert] %>
-      <noscript><style>[data-controller="flash"] { opacity: 1 !important; }</style></noscript>
       <div class="fixed top-24 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-md space-y-2">
         <% if flash[:notice] %>
-          <div class="alert alert-success shadow-lg opacity-0 transition-opacity duration-300" role="alert" data-controller="flash">
-            <span><%= flash[:notice] %></span>
-            <button type="button" class="btn btn-ghost btn-circle size-12" data-action="click->flash#close" aria-label="閉じる">✕</button>
+          <div class="sketch-toast notice opacity-0" role="alert" data-controller="flash">
+            <span class="sketch-toast-message"><%= flash[:notice] %></span>
+            <button type="button" class="sketch-toast-close" data-action="click->flash#close" aria-label="閉じる">✕</button>
           </div>
         <% end %>
         <% if flash[:alert] %>
-          <div class="alert alert-error shadow-lg opacity-0 transition-opacity duration-300" role="alert" data-controller="flash">
-            <span><%= flash[:alert] %></span>
-            <button type="button" class="btn btn-ghost btn-circle size-12" data-action="click->flash#close" aria-label="閉じる">✕</button>
+          <div class="sketch-toast alert opacity-0" role="alert" data-controller="flash">
+            <span class="sketch-toast-message"><%= flash[:alert] %></span>
+            <button type="button" class="sketch-toast-close" data-action="click->flash#close" aria-label="閉じる">✕</button>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Summary

Anthropic の Claude Design で起こした手描き風 (lo-fi sketchy) デザインを、大枠 (navbar / box / btn / toast / typography) のみ全画面に導入。**未実装機能の UI は今回作らず、機能実装時にあわせて該当画面の UI を肉付けしていく方針**。

- 新規: \`app/assets/stylesheets/sketchy.css\` (テーマ CSS、Propshaft が自動配信)
- layout: navbar を sketch-navbar に、flash トーストを sketch-toast に置換 (\`flash_controller.js\` は無修正でフェード挙動維持)
- home / about: daisyUI card + btn-primary → sketch-box + sketch-btn-primary
- CLAUDE.md: スタイル使い分けルール追記 (sketch-\* 正、Tailwind utility OK、daisyUI 新規禁止)

## Why this scope

当初は v3 ワイヤーフレームのダッシュボード (30日チャート / AI 提案 / ストリーク / 自動取得カード) を home に流し込むモックも作ったが、**実データが入る Webhook 取り込み完了後に再構築する方が手戻りが少ない**ため本 PR から revert。本 PR では「テーマの大枠」だけを先に整備して、後続の機能実装時に各画面の sketchy 化を進める。

## Design decisions

- **swoosh ("daily." の下のマーカー)**: SVG data URI で上下端ゆらぎ付きの蛍光ペン跡を描画 (\`linear-gradient\` は直線的、\`::after + z-index:-1\` は親 bg があると隠れるため不採用)
- **WCAG AA 担保**: \`sketch-btn-primary\` は黒文字 (6.73:1)、\`--muted\` は #6e6b60 (5.03:1) に調整
- **noscript フォールバック**: HTML5 仕様準拠で \`<head>\` 内に配置
- **daisyUI と共存**: 撤去はしない。新規箇所は sketch-\* を使う運用に切り替え

## Out of scope (将来 PR で対応)

- レスポンシブの作り込み (最後にまとめて行う方針)
- タップ領域 44px 化 (モバイル対応の一環として最後に)
- partial 抽象化 (3回出てから原則、現状 home + about の2箇所のみ)
- ダッシュボード本体 (Webhook 取り込み後に再構築)

## Test plan

- [ ] \`/\` (未ログイン): sketchy なログインカード + Google ログインボタン (オレンジ + 黒文字)
- [ ] \`/\` (ログイン後): 歓迎カード + navbar 右にユーザー名 + sketchy ログアウトボタン
- [ ] \`/about\`: sketchy な about カード + 「ホームへ戻る」ボタン
- [ ] navbar: 「weight daily.」(Caveat フォント、daily の下に手描き風黄色マーカー)
- [ ] flash トースト: ログイン/ログアウト時のフェードイン → 3秒後フェードアウト → ✕ クリックで即消し が壊れていない
- [ ] JS 無効環境で flash が永続不可視にならない (\`<head>\` の \`<noscript><style>\` で復帰)

🤖 Generated with [Claude Code](https://claude.com/claude-code)