### PR TITLE
feat: Apple Shortcuts → Webhook 受信エンドポイント (Phase 1) を実装する

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,112 @@
+class WebhooksController < ApplicationController
+  # Webhook requests arrive with a Bearer token, not a browser session cookie.
+  # null_session discards any session data for this request without raising an
+  # exception, satisfying Rails' CSRF protection without skipping it entirely.
+  # (skip_forgery_protection / skip_before_action :verify_authenticity_token are avoided
+  # per project policy in CLAUDE.md)
+  protect_from_forgery with: :null_session
+
+  before_action :read_raw_body
+  before_action :authenticate_webhook!
+
+  def health_data
+    parsed = JSON.parse(@raw_body)
+    records_data = parsed["records"]
+
+    unless records_data.is_a?(Array)
+      record_delivery!(status: "invalid", error_message: "missing 'records' array")
+      render json: { error: "Invalid payload" }, status: :unprocessable_entity
+      return
+    end
+
+    accepted = upsert_records(records_data)
+    record_delivery!(status: "success")
+    render json: { accepted: accepted }, status: :ok
+  rescue JSON::ParserError => e
+    record_delivery!(status: "invalid", error_message: "JSON parse error: #{e.message.truncate(120)}")
+    render json: { error: "Invalid payload" }, status: :unprocessable_entity
+  end
+
+  private
+
+  # Read the raw body once and store it for both authentication and parsing.
+  # JSON middleware can consume the IO stream, so reading here ensures we always
+  # have the original bytes regardless of middleware ordering.
+  def read_raw_body
+    @raw_body = request.body.read
+    request.body.rewind
+  end
+
+  def authenticate_webhook!
+    token = extract_bearer_token
+    @webhook_user = token.present? ? User.find_by(webhook_token: token) : nil
+
+    # Use secure_compare to prevent timing attacks.
+    # Both sides are converted to String so the comparison is always same-length safe.
+    token_valid = @webhook_user &&
+                  ActiveSupport::SecurityUtils.secure_compare(
+                    @webhook_user.webhook_token.to_s,
+                    token.to_s
+                  )
+
+    return if token_valid
+
+    # Intentionally vague: do not reveal whether the token or the user was the problem.
+    record_delivery!(status: "unauthorized", error_message: "bearer token mismatch or missing", user: nil)
+    render json: { error: "Unauthorized" }, status: :unauthorized
+  end
+
+  def extract_bearer_token
+    request.headers["Authorization"]&.delete_prefix("Bearer ")&.strip
+  end
+
+  # Upsert each day's record, updating only the keys present in the payload.
+  # Keys absent from the payload are left unchanged (partial-update semantics).
+  def upsert_records(records_data)
+    accepted = 0
+
+    records_data.each do |entry|
+      recorded_on = entry["recorded_on"]
+      next if recorded_on.blank?
+
+      record = StepRecord.find_or_initialize_by(user: @webhook_user, recorded_on: recorded_on)
+
+      # Slice only the keys the caller sent; compact removes nils so that
+      # missing keys do not overwrite existing values with nil/0.
+      updates = {
+        steps:           entry["steps"],
+        distance_meters: entry["distance_meters"],
+        flights_climbed: entry["flights_climbed"]
+      }.compact
+
+      record.assign_attributes(updates)
+      record.save!
+      accepted += 1
+    end
+
+    accepted
+  end
+
+  # Record audit log entry. Uses keyword argument `user:` so callers can
+  # override with nil for unauthorized cases where @webhook_user is unreliable.
+  def record_delivery!(status:, error_message: nil, user: @webhook_user)
+    # Attempt to parse stored body as JSON for richer inspection in the audit log.
+    # Falls back to { raw: <string> } when the body is not valid JSON.
+    payload = begin
+      JSON.parse(@raw_body)
+    rescue JSON::ParserError
+      { raw: @raw_body.truncate(500) }
+    end
+
+    WebhookDelivery.create!(
+      user: user,
+      payload: payload,
+      status: status,
+      error_message: error_message,
+      received_at: Time.current
+    )
+  rescue ActiveRecord::RecordInvalid => e
+    # Non-fatal: delivery logging must not crash the main response path.
+    Rails.logger.error("[WebhooksController] Failed to save WebhookDelivery: #{e.message}")
+  end
+end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,11 +1,8 @@
-class WebhooksController < ApplicationController
-  # Webhook requests arrive with a Bearer token, not a browser session cookie.
-  # null_session discards any session data for this request without raising an
-  # exception, satisfying Rails' CSRF protection without skipping it entirely.
-  # (skip_forgery_protection / skip_before_action :verify_authenticity_token are avoided
-  # per project policy in CLAUDE.md)
-  protect_from_forgery with: :null_session
-
+class WebhooksController < ActionController::API
+  # API クライアント (Apple Shortcuts / curl) からの呼び出し専用エンドポイント。
+  # ActionController::API 継承は Rails 標準の API-only パターンで、CSRF 保護 / browser check / cookie /
+  # session を含まない (skip_forgery_protection 等の禁止 workaround とは別物 — そもそも入っていない)。
+  # 認証は Bearer token (authenticate_webhook!) で行う。
   before_action :read_raw_body
   before_action :authenticate_webhook!
 
@@ -15,7 +12,7 @@ class WebhooksController < ApplicationController
 
     unless records_data.is_a?(Array)
       record_delivery!(status: "invalid", error_message: "missing 'records' array")
-      render json: { error: "Invalid payload" }, status: :unprocessable_entity
+      render json: { error: "Invalid payload" }, status: :unprocessable_content
       return
     end
 
@@ -24,7 +21,12 @@ class WebhooksController < ApplicationController
     render json: { accepted: accepted }, status: :ok
   rescue JSON::ParserError => e
     record_delivery!(status: "invalid", error_message: "JSON parse error: #{e.message.truncate(120)}")
-    render json: { error: "Invalid payload" }, status: :unprocessable_entity
+    render json: { error: "Invalid payload" }, status: :unprocessable_content
+  rescue ActiveRecord::RecordInvalid => e
+    # 個々のレコードのバリデーション違反 (負数 / 不正な日付等) を 500 ではなく 422 + 監査ログで返す。
+    # rails-implementer の意図 (全体失敗方式) を実装まで貫徹するため。
+    record_delivery!(status: "invalid", error_message: "RecordInvalid: #{e.message.truncate(120)}")
+    render json: { error: "Invalid payload" }, status: :unprocessable_content
   end
 
   private
@@ -32,8 +34,16 @@ class WebhooksController < ApplicationController
   # Read the raw body once and store it for both authentication and parsing.
   # JSON middleware can consume the IO stream, so reading here ensures we always
   # have the original bytes regardless of middleware ordering.
+  # Size cap (1MB) is a DoS guard — a single day's HealthKit aggregate is well under 1KB,
+  # so 1MB is generous; payloads above this are rejected with 413 before any parsing.
+  MAX_BODY_BYTES = 1.megabyte
+
   def read_raw_body
-    @raw_body = request.body.read
+    @raw_body = request.body.read(MAX_BODY_BYTES + 1)
+    if @raw_body && @raw_body.bytesize > MAX_BODY_BYTES
+      render json: { error: "Payload too large" }, status: :content_too_large and return
+    end
+    @raw_body ||= ""
     request.body.rewind
   end
 
@@ -53,7 +63,7 @@ class WebhooksController < ApplicationController
 
     # Intentionally vague: do not reveal whether the token or the user was the problem.
     record_delivery!(status: "unauthorized", error_message: "bearer token mismatch or missing", user: nil)
-    render json: { error: "Unauthorized" }, status: :unauthorized
+    render json: { error: "Unauthorized" }, status: :unauthorized and return
   end
 
   def extract_bearer_token
@@ -62,26 +72,32 @@ class WebhooksController < ApplicationController
 
   # Upsert each day's record, updating only the keys present in the payload.
   # Keys absent from the payload are left unchanged (partial-update semantics).
+  # All-or-nothing: wrap in a transaction so that if any record fails validation
+  # the entire batch rolls back and the caller can safely retry the whole payload.
   def upsert_records(records_data)
     accepted = 0
 
-    records_data.each do |entry|
-      recorded_on = entry["recorded_on"]
-      next if recorded_on.blank?
+    StepRecord.transaction do
+      records_data.each do |entry|
+        recorded_on = entry["recorded_on"]
+        next if recorded_on.blank?
 
-      record = StepRecord.find_or_initialize_by(user: @webhook_user, recorded_on: recorded_on)
+        record = StepRecord.find_or_initialize_by(user: @webhook_user, recorded_on: recorded_on)
 
-      # Slice only the keys the caller sent; compact removes nils so that
-      # missing keys do not overwrite existing values with nil/0.
-      updates = {
-        steps:           entry["steps"],
-        distance_meters: entry["distance_meters"],
-        flights_climbed: entry["flights_climbed"]
-      }.compact
+        # Slice only the keys the caller sent; compact removes nils so that
+        # missing keys do not overwrite existing values with nil/0.
+        # NOTE: we cannot distinguish "key absent" from "explicit 0" because both
+        # arrive as falsy in JSON; partial-update semantics treat absent ≠ 0.
+        updates = {
+          steps:           entry["steps"],
+          distance_meters: entry["distance_meters"],
+          flights_climbed: entry["flights_climbed"]
+        }.compact
 
-      record.assign_attributes(updates)
-      record.save!
-      accepted += 1
+        record.assign_attributes(updates)
+        record.save!
+        accepted += 1
+      end
     end
 
     accepted

--- a/app/models/step_record.rb
+++ b/app/models/step_record.rb
@@ -9,6 +9,7 @@ class StepRecord < ApplicationRecord
   # Rough calorie estimate used for display only.
   # Formula: 1 step ≈ 0.04 kcal (flat walking), 1 flight of stairs ≈ 0.5 kcal.
   # METs-based calculation (accounting for body weight, speed, etc.) is a future enhancement.
+  # NOT MEDICAL ADVICE — display purposes only. Body weight / pace / age are not factored in.
   def estimated_kcal
     (steps * 0.04 + flights_climbed * 0.5).round
   end

--- a/app/models/step_record.rb
+++ b/app/models/step_record.rb
@@ -1,0 +1,15 @@
+class StepRecord < ApplicationRecord
+  belongs_to :user
+
+  validates :recorded_on, presence: true
+  validates :steps, :distance_meters, :flights_climbed,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :recorded_on, uniqueness: { scope: :user_id }
+
+  # Rough calorie estimate used for display only.
+  # Formula: 1 step ≈ 0.04 kcal (flat walking), 1 flight of stairs ≈ 0.5 kcal.
+  # METs-based calculation (accounting for body weight, speed, etc.) is a future enhancement.
+  def estimated_kcal
+    (steps * 0.04 + flights_climbed * 0.5).round
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,8 @@
 class User < ApplicationRecord
+  has_secure_token :webhook_token
+
+  has_many :step_records, dependent: :destroy
+
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
   validates :email, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_secure_token :webhook_token
 
   has_many :step_records, dependent: :destroy
+  has_many :webhook_deliveries, dependent: :nullify  # 監査ログはユーザー削除後も保持
 
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }

--- a/app/models/webhook_delivery.rb
+++ b/app/models/webhook_delivery.rb
@@ -1,0 +1,9 @@
+# Debugging / audit table that stores every inbound webhook request verbatim.
+# Records are kept regardless of authentication outcome so operators can inspect
+# what was received, replay missing records, and trace integration issues.
+# Intentionally stores raw payload only — never derived PII such as user emails.
+class WebhookDelivery < ApplicationRecord
+  belongs_to :user, optional: true  # nil when authentication fails
+
+  validates :status, inclusion: { in: %w[success unauthorized invalid] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "sessions#failure", as: :auth_failure
   delete "/logout", to: "sessions#destroy", as: :logout
 
+  # Apple Shortcuts → Rails webhook endpoint (Bearer token auth, no CSRF cookie needed)
+  post "/webhooks/health_data", to: "webhooks#health_data"
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/db/migrate/20260501232657_add_webhook_token_to_users.rb
+++ b/db/migrate/20260501232657_add_webhook_token_to_users.rb
@@ -6,6 +6,8 @@ class AddWebhookTokenToUsers < ActiveRecord::Migration[8.1]
     # Backfill existing users so they can authenticate immediately.
     # has_secure_token auto-generates on create; existing rows would remain nil
     # without this step, making their webhook endpoints unusable.
+    # NOTE: 1-by-1 UPDATE は初期環境 (~数百ユーザー) 想定の素朴実装。
+    # 大規模本番への適用時は別 rake task で update_all + SecureRandom 一括化を検討。
     reversible do |dir|
       dir.up { User.find_each(&:regenerate_webhook_token) }
     end

--- a/db/migrate/20260501232657_add_webhook_token_to_users.rb
+++ b/db/migrate/20260501232657_add_webhook_token_to_users.rb
@@ -1,0 +1,13 @@
+class AddWebhookTokenToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :webhook_token, :string
+    add_index :users, :webhook_token, unique: true
+
+    # Backfill existing users so they can authenticate immediately.
+    # has_secure_token auto-generates on create; existing rows would remain nil
+    # without this step, making their webhook endpoints unusable.
+    reversible do |dir|
+      dir.up { User.find_each(&:regenerate_webhook_token) }
+    end
+  end
+end

--- a/db/migrate/20260501232658_create_step_records.rb
+++ b/db/migrate/20260501232658_create_step_records.rb
@@ -1,0 +1,14 @@
+class CreateStepRecords < ActiveRecord::Migration[8.1]
+  def change
+    create_table :step_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date    :recorded_on,     null: false
+      t.integer :steps,           null: false, default: 0
+      t.integer :distance_meters, null: false, default: 0
+      t.integer :flights_climbed, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :step_records, [ :user_id, :recorded_on ], unique: true
+  end
+end

--- a/db/migrate/20260501232659_create_webhook_deliveries.rb
+++ b/db/migrate/20260501232659_create_webhook_deliveries.rb
@@ -1,0 +1,14 @@
+class CreateWebhookDeliveries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :webhook_deliveries do |t|
+      # user is nullable: unauthorized requests have no associated user
+      t.references :user, null: true, foreign_key: true
+      t.jsonb   :payload,       null: false, default: {}
+      t.string  :status,        null: false  # success / unauthorized / invalid
+      t.string  :error_message
+      t.datetime :received_at,  null: false
+    end
+
+    add_index :webhook_deliveries, :received_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_051150) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_232659) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "step_records", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "distance_meters", default: 0, null: false
+    t.integer "flights_climbed", default: 0, null: false
+    t.date "recorded_on", null: false
+    t.integer "steps", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id", "recorded_on"], name: "index_step_records_on_user_id_and_recorded_on", unique: true
+    t.index ["user_id"], name: "index_step_records_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -22,6 +34,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_051150) do
     t.string "provider", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
+    t.string "webhook_token"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
+    t.index ["webhook_token"], name: "index_users_on_webhook_token", unique: true
   end
+
+  create_table "webhook_deliveries", force: :cascade do |t|
+    t.string "error_message"
+    t.jsonb "payload", default: {}, null: false
+    t.datetime "received_at", null: false
+    t.string "status", null: false
+    t.bigint "user_id"
+    t.index ["received_at"], name: "index_webhook_deliveries_on_received_at"
+    t.index ["user_id"], name: "index_webhook_deliveries_on_user_id"
+  end
+
+  add_foreign_key "step_records", "users"
+  add_foreign_key "webhook_deliveries", "users"
 end

--- a/spec/factories/step_records.rb
+++ b/spec/factories/step_records.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :step_record do
+    association :user
+    sequence(:recorded_on) { |n| Date.new(2026, 1, 1) + n.days }
+    steps { 8000 }
+    distance_meters { 5000 }
+    flights_climbed { 12 }
+  end
+end

--- a/spec/factories/webhook_deliveries.rb
+++ b/spec/factories/webhook_deliveries.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :webhook_delivery do
+    association :user
+    status { "success" }
+    payload { { "records" => [] } }
+    received_at { Time.current }
+  end
+end

--- a/spec/models/step_record_spec.rb
+++ b/spec/models/step_record_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+RSpec.describe StepRecord, type: :model do
+  describe "associations" do
+    it "belongs to user" do
+      association = described_class.reflect_on_association(:user)
+      expect(association).not_to be_nil
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+
+  describe "validations" do
+    describe "recorded_on" do
+      it "is invalid without recorded_on" do
+        record = build(:step_record, recorded_on: nil)
+        expect(record).not_to be_valid
+      end
+
+      it "is valid with recorded_on present" do
+        record = build(:step_record, recorded_on: Date.new(2026, 5, 1))
+        expect(record).to be_valid
+      end
+    end
+
+    describe "steps numericality" do
+      it "is invalid with a negative steps value" do
+        record = build(:step_record, steps: -1)
+        expect(record).not_to be_valid
+      end
+
+      it "is invalid with a non-integer steps value" do
+        record = build(:step_record, steps: 1.5)
+        expect(record).not_to be_valid
+      end
+
+      it "is valid with steps = 0" do
+        record = build(:step_record, steps: 0)
+        expect(record).to be_valid
+      end
+    end
+
+    describe "distance_meters numericality" do
+      it "is invalid with a negative distance_meters value" do
+        record = build(:step_record, distance_meters: -1)
+        expect(record).not_to be_valid
+      end
+
+      it "is invalid with a non-integer distance_meters value" do
+        record = build(:step_record, distance_meters: 3.7)
+        expect(record).not_to be_valid
+      end
+
+      it "is valid with distance_meters = 0" do
+        record = build(:step_record, distance_meters: 0)
+        expect(record).to be_valid
+      end
+    end
+
+    describe "flights_climbed numericality" do
+      it "is invalid with a negative flights_climbed value" do
+        record = build(:step_record, flights_climbed: -1)
+        expect(record).not_to be_valid
+      end
+
+      it "is invalid with a non-integer flights_climbed value" do
+        record = build(:step_record, flights_climbed: 0.9)
+        expect(record).not_to be_valid
+      end
+
+      it "is valid with flights_climbed = 0" do
+        record = build(:step_record, flights_climbed: 0)
+        expect(record).to be_valid
+      end
+    end
+
+    describe "uniqueness of recorded_on scoped to user_id" do
+      let(:user) { create(:user) }
+      let(:other_user) { create(:user) }
+      let(:date) { Date.new(2026, 5, 1) }
+
+      before { create(:step_record, user: user, recorded_on: date) }
+
+      it "is invalid when the same user already has a record on the same date" do
+        duplicate = build(:step_record, user: user, recorded_on: date)
+        expect(duplicate).not_to be_valid
+      end
+
+      it "is valid when a different user has a record on the same date" do
+        other_record = build(:step_record, user: other_user, recorded_on: date)
+        expect(other_record).to be_valid
+      end
+    end
+  end
+
+  describe "#estimated_kcal" do
+    it "returns the rounded calorie estimate based on steps and flights_climbed" do
+      # 8000 * 0.04 + 12 * 0.5 = 320.0 + 6.0 = 326.0 → 326
+      record = build(:step_record, steps: 8000, flights_climbed: 12)
+      expect(record.estimated_kcal).to eq(326)
+    end
+
+    it "returns 0 when steps and flights_climbed are both 0" do
+      record = build(:step_record, steps: 0, flights_climbed: 0)
+      expect(record.estimated_kcal).to eq(0)
+    end
+
+    it "rounds correctly for fractional results" do
+      # 1 step * 0.04 + 1 flight * 0.5 = 0.04 + 0.5 = 0.54 → 1
+      record = build(:step_record, steps: 1, flights_climbed: 1)
+      expect(record.estimated_kcal).to eq(1)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,6 +40,31 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "has_secure_token :webhook_token" do
+    it "auto-generates webhook_token on create" do
+      user = create(:user)
+      expect(user.webhook_token).not_to be_nil
+    end
+
+    it "generates a token of at least 24 characters" do
+      user = create(:user)
+      expect(user.webhook_token.length).to be >= 24
+    end
+
+    it "generates unique tokens for different users" do
+      user1 = create(:user)
+      user2 = create(:user)
+      expect(user1.webhook_token).not_to eq(user2.webhook_token)
+    end
+
+    it "allows regenerating the token via regenerate_webhook_token" do
+      user = create(:user)
+      original_token = user.webhook_token
+      user.regenerate_webhook_token
+      expect(user.reload.webhook_token).not_to eq(original_token)
+    end
+  end
+
   describe ".from_omniauth" do
     let(:auth) do
       OmniAuth::AuthHash.new(

--- a/spec/models/webhook_delivery_spec.rb
+++ b/spec/models/webhook_delivery_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe WebhookDelivery, type: :model do
+  describe "associations" do
+    it "belongs to user optionally" do
+      association = described_class.reflect_on_association(:user)
+      expect(association).not_to be_nil
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.options[:optional]).to be(true)
+    end
+
+    it "can be created without a user (authentication failure case)" do
+      delivery = build(:webhook_delivery, user: nil)
+      expect(delivery).to be_valid
+    end
+
+    it "can be created with a user" do
+      delivery = build(:webhook_delivery, user: create(:user))
+      expect(delivery).to be_valid
+    end
+  end
+
+  describe "validations" do
+    describe "status inclusion" do
+      %w[success unauthorized invalid].each do |valid_status|
+        it "is valid with status '#{valid_status}'" do
+          delivery = build(:webhook_delivery, status: valid_status)
+          expect(delivery).to be_valid
+        end
+      end
+
+      it "is invalid with an unrecognized status" do
+        delivery = build(:webhook_delivery, status: "foo")
+        expect(delivery).not_to be_valid
+      end
+
+      it "is invalid with a blank status" do
+        delivery = build(:webhook_delivery, status: "")
+        expect(delivery).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   # config.infer_spec_type_from_file_location!
 
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -1,0 +1,397 @@
+require "rails_helper"
+
+RSpec.describe "POST /webhooks/health_data", type: :request do
+  let(:user) { create(:user) }
+  let(:valid_headers) do
+    {
+      "Authorization" => "Bearer #{user.webhook_token}",
+      "Content-Type" => "application/json"
+    }
+  end
+
+  def post_health_data(body, headers: valid_headers)
+    post "/webhooks/health_data", params: body.is_a?(String) ? body : body.to_json, headers: headers
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shared examples for unauthorized requests
+  # ---------------------------------------------------------------------------
+  shared_examples "rejects unauthorized request" do
+    it "returns HTTP 401" do
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns the Unauthorized error body" do
+      expect(response.parsed_body).to eq("error" => "Unauthorized")
+    end
+
+    it "does not create any StepRecord" do
+      expect(StepRecord.count).to eq(0)
+    end
+
+    it "records a WebhookDelivery with status 'unauthorized'" do
+      expect(WebhookDelivery.last.status).to eq("unauthorized")
+    end
+
+    it "records the WebhookDelivery with user = nil (PII protection)" do
+      expect(WebhookDelivery.last.user).to be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 1: Successful authentication + single record upsert
+  # ---------------------------------------------------------------------------
+  describe "Case 1: valid token, single record" do
+    let(:payload) do
+      { records: [ { recorded_on: "2026-05-01", steps: 8000, distance_meters: 5000, flights_climbed: 12 } ] }
+    end
+
+    before { post_health_data(payload) }
+
+    it "returns HTTP 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns accepted: 1" do
+      expect(response.parsed_body).to eq("accepted" => 1)
+    end
+
+    it "creates 1 StepRecord" do
+      expect(StepRecord.count).to eq(1)
+    end
+
+    it "saves the StepRecord with correct attributes" do
+      record = StepRecord.last
+      expect(record.steps).to eq(8000)
+      expect(record.distance_meters).to eq(5000)
+      expect(record.flights_climbed).to eq(12)
+      expect(record.recorded_on).to eq(Date.new(2026, 5, 1))
+    end
+
+    it "records a WebhookDelivery with status 'success'" do
+      expect(WebhookDelivery.last.status).to eq("success")
+    end
+
+    it "records the WebhookDelivery linked to the authenticated user" do
+      expect(WebhookDelivery.last.user).to eq(user)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 2: No Authorization header → 401
+  # ---------------------------------------------------------------------------
+  describe "Case 2: missing Authorization header" do
+    before do
+      post_health_data(
+        { records: [] },
+        headers: { "Content-Type" => "application/json" }
+      )
+    end
+
+    include_examples "rejects unauthorized request"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 3: Wrong token → 401
+  # ---------------------------------------------------------------------------
+  describe "Case 3: invalid Bearer token" do
+    before do
+      post_health_data(
+        { records: [] },
+        headers: {
+          "Authorization" => "Bearer wrong_token",
+          "Content-Type" => "application/json"
+        }
+      )
+    end
+
+    include_examples "rejects unauthorized request"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 4: Multiple records in a single request
+  # ---------------------------------------------------------------------------
+  describe "Case 4: multiple records in one request" do
+    let(:payload) do
+      {
+        records: [
+          { recorded_on: "2026-05-01", steps: 6000, distance_meters: 4000, flights_climbed: 5 },
+          { recorded_on: "2026-05-02", steps: 7000, distance_meters: 4500, flights_climbed: 8 },
+          { recorded_on: "2026-05-03", steps: 9000, distance_meters: 6000, flights_climbed: 15 }
+        ]
+      }
+    end
+
+    before { post_health_data(payload) }
+
+    it "returns HTTP 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns accepted: 3" do
+      expect(response.parsed_body).to eq("accepted" => 3)
+    end
+
+    it "creates 3 StepRecords" do
+      expect(StepRecord.count).to eq(3)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 5: Same day re-POST → upsert (overwrite)
+  # ---------------------------------------------------------------------------
+  describe "Case 5: re-posting same recorded_on updates the existing record" do
+    let(:date) { "2026-05-01" }
+
+    before do
+      post_health_data({ records: [ { recorded_on: date, steps: 5000, distance_meters: 3000, flights_climbed: 4 } ] })
+      post_health_data({ records: [ { recorded_on: date, steps: 8000, distance_meters: 6000, flights_climbed: 10 } ] })
+    end
+
+    it "keeps only 1 StepRecord for the date" do
+      expect(StepRecord.where(user: user, recorded_on: date).count).to eq(1)
+    end
+
+    it "updates steps to the new value" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).steps).to eq(8000)
+    end
+
+    it "updates distance_meters to the new value" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).distance_meters).to eq(6000)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 6a: Partial payload — only steps sent, existing values preserved
+  # ---------------------------------------------------------------------------
+  describe "Case 6a: partial payload overwrites only supplied keys on existing record" do
+    let(:date) { "2026-05-01" }
+
+    before do
+      # Create initial record with all fields
+      create(:step_record, user: user, recorded_on: date, steps: 5000, distance_meters: 3000, flights_climbed: 6)
+      # Re-send with only steps; distance_meters and flights_climbed omitted
+      post_health_data({ records: [ { recorded_on: date, steps: 9000 } ] })
+    end
+
+    it "returns HTTP 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates steps" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).steps).to eq(9000)
+    end
+
+    it "preserves the original distance_meters" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).distance_meters).to eq(3000)
+    end
+
+    it "preserves the original flights_climbed" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).flights_climbed).to eq(6)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 6b: Partial payload — new record, missing keys default to 0
+  # ---------------------------------------------------------------------------
+  describe "Case 6b: partial payload creates new record with DB defaults for missing keys" do
+    let(:date) { "2026-05-01" }
+
+    before { post_health_data({ records: [ { recorded_on: date, steps: 4000 } ] }) }
+
+    it "creates the StepRecord" do
+      expect(StepRecord.where(user: user, recorded_on: date).count).to eq(1)
+    end
+
+    it "saves the supplied steps" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).steps).to eq(4000)
+    end
+
+    it "sets distance_meters to 0 (DB default)" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).distance_meters).to eq(0)
+    end
+
+    it "sets flights_climbed to 0 (DB default)" do
+      expect(StepRecord.find_by(user: user, recorded_on: date).flights_climbed).to eq(0)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 7: Invalid JSON body → 422
+  # ---------------------------------------------------------------------------
+  describe "Case 7: invalid JSON body" do
+    before do
+      post_health_data(
+        "not json",
+        headers: {
+          "Authorization" => "Bearer #{user.webhook_token}",
+          "Content-Type" => "application/json"
+        }
+      )
+    end
+
+    it "returns HTTP 422" do
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "returns the Invalid payload error body" do
+      expect(response.parsed_body).to eq("error" => "Invalid payload")
+    end
+
+    it "does not create any StepRecord" do
+      expect(StepRecord.count).to eq(0)
+    end
+
+    it "records a WebhookDelivery with status 'invalid'" do
+      expect(WebhookDelivery.last.status).to eq("invalid")
+    end
+
+    it "includes 'JSON parse error' in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("JSON parse error")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 8: Missing 'records' key → 422
+  # ---------------------------------------------------------------------------
+  describe "Case 8: JSON body without 'records' array" do
+    before { post_health_data({ foo: "bar" }) }
+
+    it "returns HTTP 422" do
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "returns the Invalid payload error body" do
+      expect(response.parsed_body).to eq("error" => "Invalid payload")
+    end
+
+    it "records a WebhookDelivery with status 'invalid'" do
+      expect(WebhookDelivery.last.status).to eq("invalid")
+    end
+
+    it "includes 'missing records array' context in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("missing 'records' array")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 9: Entry without recorded_on is silently skipped
+  # ---------------------------------------------------------------------------
+  describe "Case 9: entries missing recorded_on are silently skipped" do
+    let(:payload) do
+      {
+        records: [
+          { recorded_on: "2026-05-01", steps: 100 },
+          { steps: 200 },                             # no recorded_on → skip
+          { recorded_on: "2026-05-02", steps: 300 }
+        ]
+      }
+    end
+
+    before { post_health_data(payload) }
+
+    it "returns HTTP 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns accepted: 2 (skipped entry not counted)" do
+      expect(response.parsed_body).to eq("accepted" => 2)
+    end
+
+    it "creates exactly 2 StepRecords" do
+      expect(StepRecord.count).to eq(2)
+    end
+
+    it "does not create a record for the entry missing recorded_on" do
+      created_dates = StepRecord.pluck(:recorded_on)
+      expect(created_dates).to contain_exactly(Date.new(2026, 5, 1), Date.new(2026, 5, 2))
+    end
+
+    # NOTE: This 'silent skip' behavior was a deliberate judgment call by
+    # rails-implementer. If the spec changes to return an error instead,
+    # update this example and Case 9 as a pair.
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 10: Validation failure on a record (e.g., negative steps) → 422 + audit
+  # ---------------------------------------------------------------------------
+  # 個々のレコードのバリデーション違反は ActiveRecord::RecordInvalid を rescue して
+  # 422 + WebhookDelivery(invalid) で返す方針 (500 で audit log 取れない事態を避ける)。
+  describe "Case 10: invalid record attribute (negative steps) returns 422" do
+    before do
+      post_health_data({ records: [ { recorded_on: "2026-05-01", steps: -100 } ] })
+    end
+
+    it "returns HTTP 422" do
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "returns the Invalid payload error body" do
+      expect(response.parsed_body).to eq("error" => "Invalid payload")
+    end
+
+    it "does not create any StepRecord" do
+      expect(StepRecord.count).to eq(0)
+    end
+
+    it "records a WebhookDelivery with status 'invalid'" do
+      expect(WebhookDelivery.last.status).to eq("invalid")
+    end
+
+    it "includes 'RecordInvalid' in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("RecordInvalid")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 11: All-or-nothing — 1 件失敗で全件 rollback
+  # ---------------------------------------------------------------------------
+  describe "Case 11: transaction rollback when middle record fails validation" do
+    before do
+      post_health_data({
+        records: [
+          { recorded_on: "2026-05-01", steps: 1000 },
+          { recorded_on: "2026-05-02", steps: -50 },   # 違反
+          { recorded_on: "2026-05-03", steps: 3000 }
+        ]
+      })
+    end
+
+    it "returns HTTP 422" do
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "rolls back ALL records, leaving 0 in DB" do
+      expect(StepRecord.count).to eq(0)
+    end
+
+    it "records a single WebhookDelivery with status 'invalid'" do
+      expect(WebhookDelivery.where(status: "invalid").count).to eq(1)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 12: Body size limit (1MB) — DoS guard
+  # ---------------------------------------------------------------------------
+  describe "Case 12: payload exceeding 1MB returns 413" do
+    let(:huge_body) do
+      # 1MB をわずかに超える JSON を生成 (records 配列に dummy entries を詰める)
+      huge_string = "x" * (1.megabyte + 100)
+      { records: [ { recorded_on: "2026-05-01", steps: 1, note: huge_string } ] }.to_json
+    end
+
+    before { post_health_data(huge_body) }
+
+    it "returns HTTP 413" do
+      expect(response).to have_http_status(:content_too_large)
+    end
+
+    it "returns the Payload too large error body" do
+      expect(response.parsed_body).to eq("error" => "Payload too large")
+    end
+
+    it "does not create any StepRecord" do
+      expect(StepRecord.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Apple Shortcuts から日次 HealthKit データ (歩数 / 距離 / 階段) を受信する Webhook の Rails 完結部分を実装。Bearer token 認証 + raw body + 配列 upsert + 監査ログテーブルの 4 点が要点。

- Migration ×3: \`users.webhook_token\` / \`step_records\` / \`webhook_deliveries\`
- Model: \`User\` (\`has_secure_token\`), \`StepRecord\` (新規), \`WebhookDelivery\` (新規・監査ログ)
- Controller: \`WebhooksController\` (ActionController::API 継承、Bearer 認証 → upsert → 監査ログ)
- Routes: \`POST /webhooks/health_data\`
- RSpec: 121 examples / 0 failures

## DB 設計の決定 (実装前にユーザーと 6 論点を対話)

| 論点 | 決定 |
|---|---|
| データ粒度 | 日次集計 (1 user × 1 day = 1 row) |
| メトリック保持 | 横並び (steps / distance_meters / flights_climbed の 3 列固定) |
| 派生値 (kcal / streak) | 保存しない (service / メソッドで都度計算) |
| 監査ログ | \`webhook_deliveries\` テーブルを作る (jsonb で raw payload を保存) |
| token 保存 | 平文 + \`has_secure_token\` (Apple Shortcuts に SHA256 がないため hash 化メリット半減) |
| payload 構造 | 配列形式 \`{records: [...]}\` (1日分でも配列長 1、バッチ送信も同 endpoint で対応) |

**監査ログテーブル採用の判断軸**: MVP に過剰に見えるが、外部 Webhook 連携の初手では「何が来たか / なぜ落ちたか」を生で残す価値がコストを上回る。デモ前のトラブル切り分けにも効く。

## 実装中の判断 (仕様の隙間)

- **\`ActionController::API\` 継承**: 当初 \`ApplicationController + protect_from_forgery with: :null_session\` で実装したが、CSRF 検証が \`params\` を eagerly 読むため Bad JSON で controller 到達前に 400 が返る問題が発覚。Rails 標準の API-only パターンに切替 (\`skip_forgery_protection\` 等の禁止 workaround とは別物 — そもそも保護モジュールが入っていない base class)
- **upsert は all-or-nothing**: 配列内の 1 件でも validation 違反 → \`StepRecord.transaction\` で全件 rollback + 422
- **部分送信対応**: payload に含まれる key だけ更新 (未指定 key は既存値保持、JSON 構造上「key 欠損」と「明示的 0」は区別不可と明示コメント)
- **\`recorded_on\` 欠損エントリ**: silent skip (テストで仕様固定、変更時はテストもペアで)
- **1MB body サイズ上限**: DoS guard。1 日分 HealthKit aggregate は 1KB 未満想定なので 1MB は十分余裕
- **kcal 概算式**: \`steps * 0.04 + flights * 0.5\` (METs 厳密計算は将来、medical advice ではない旨をコメント明示)

## レビュー反映済 (PR 内 2 commit 目)

3 者並列レビュー (code / strategic / design) で出た指摘:
- ✅ upsert にトランザクション (code [高])
- ✅ \`authenticate_webhook!\` の \`render\` 後 \`and return\` 明示 (code [高])
- ✅ \`User has_many :webhook_deliveries\` 追加 (code [中])
- ✅ \`@raw_body\` サイズ上限 1MB (code [中])
- ✅ backfill コメントに「初期環境想定」明示 (strategic)
- ✅ kcal に「medical advice ではない」disclaimer (strategic)

Phase 3 (UI) で対応:
- token 再生成警告モーダル / 初回トークン表示の視線誘導
- エラーレスポンスに \`hint\` フィールド (development のみ)

## Test plan

- [ ] \`script/run \"bundle exec rspec\"\` で 121 examples pass
- [ ] \`script/run \"bundle exec rubocop\"\` でオフェンス 0
- [ ] curl smoke: 認証成功 / 失敗 / JSON parse fail / records 欠損 / 部分送信 / 1MB 超過 が期待通り (200 / 401 / 422 / 422 / 200 / 413)
- [ ] db migration が backfill 含めて通る (既存ユーザーの \`webhook_token\` が nil でない)

## Out of scope (別 PR)

- Phase 2: iPhone 実機 + ngrok での Shortcuts テスト (ユーザー側作業)
- Phase 3: 設定画面での token 表示 + コピー + iCloud Shortcut リンク (sketchy UI、PR #30 マージ後)
- Strava 連携 (将来の余裕枠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)