### PR TITLE
feat: 設定画面で webhook_token のコピー / 再生成を実装する (Phase 3)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,10 @@ class ApplicationController < ActionController::Base
   def logged_in?
     current_user.present?
   end
+
+  def require_login
+    return if logged_in?
+
+    redirect_to root_path, alert: "ログインが必要です"
+  end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,13 @@
+class SettingsController < ApplicationController
+  before_action :require_login
+
+  def show
+    @webhook_token = current_user.webhook_token
+    @webhook_url = webhooks_health_data_url(host: request.base_url)
+  end
+
+  def regenerate_token
+    current_user.regenerate_webhook_token
+    redirect_to settings_path, notice: "Webhook トークンを再生成しました。Apple Shortcuts 側の設定も更新してください。"
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -3,11 +3,16 @@ class SettingsController < ApplicationController
 
   def show
     @webhook_token = current_user.webhook_token
-    @webhook_url = webhooks_health_data_url(host: request.base_url)
+    # _url ヘルパは request 由来で絶対 URL を組み立てるため、host 引数は不要 (二重指定リスク回避)。
+    # 本番デプロイ時は config.action_controller.default_url_options or config.hosts でホスト解決を制御する。
+    @webhook_url = webhooks_health_data_url
   end
 
   def regenerate_token
     current_user.regenerate_webhook_token
     redirect_to settings_path, notice: "Webhook トークンを再生成しました。Apple Shortcuts 側の設定も更新してください。"
+  rescue ActiveRecord::ActiveRecordError
+    # has_secure_token の uniqueness 衝突 / DB 接続エラー等の保険。発表会前の安全策。
+    redirect_to settings_path, alert: "再生成に失敗しました。時間をおいて再度お試しください。"
   end
 end

--- a/app/javascript/controllers/copy_controller.js
+++ b/app/javascript/controllers/copy_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+// コピーボタン汎用コントローラー。
+// data-copy-text-value にコピー対象テキストをセットし、
+// data-action="click->copy#copy" をボタンに付けるだけで動く。
+// クリック後 2 秒間「コピー済み✓」に切り替え、その後元のラベルに戻す。
+// navigator.clipboard は HTTPS または localhost でのみ有効。HTTP 本番運用時は要確認。
+export default class extends Controller {
+  static values = { text: String }
+  static targets = [ "button" ]
+
+  copy() {
+    navigator.clipboard.writeText(this.textValue).then(() => {
+      this.#swapLabel("コピー済み✓", 2000)
+    }).catch(() => {
+      alert("コピーに失敗しました")
+    })
+  }
+
+  // private
+
+  #swapLabel(tempLabel, durationMs) {
+    const btn = this.buttonTarget
+    const original = btn.textContent
+    btn.textContent = tempLabel
+    clearTimeout(this.restoreTimeout)
+    this.restoreTimeout = setTimeout(() => {
+      btn.textContent = original
+    }, durationMs)
+  }
+
+  disconnect() {
+    clearTimeout(this.restoreTimeout)
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,7 @@
       <div class="sketch-navbar-right">
         <% if logged_in? %>
           <span class="sketch-navbar-name"><%= current_user.name %></span>
+          <%= link_to "設定", settings_path, class: "sketch-btn" %>
           <%= button_to "ログアウト", logout_path, method: :delete, class: "sketch-btn" %>
         <% end %>
       </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, "設定 — weight daily." %>
+
+<div class="sketch-page-narrow" style="max-width: 36rem;">
+
+  <%# ヘッダー %>
+  <h1 class="sketch-hh" style="margin-bottom: 6px;">Apple Shortcuts 連携</h1>
+  <p class="sketch-body-text" style="margin-bottom: 24px;">
+    iPhone のショートカットアプリと連携して、毎日の歩数を自動で取り込みます。
+  </p>
+
+  <%# Step 1: Webhook トークン %>
+  <p class="sketch-label" style="margin-bottom: 6px;">Step 1</p>
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <p class="sketch-label" style="margin-bottom: 8px;">あなた専用のトークン（秘密にしてください）</p>
+
+    <div data-controller="copy" data-copy-text-value="<%= @webhook_token %>">
+      <code style="display: block; font-size: 20px; word-break: break-all; background: var(--paper-2); border: 1px solid var(--ink); border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; font-family: monospace; line-height: 1.4;">
+        <%= @webhook_token %>
+      </code>
+      <button type="button"
+              class="sketch-btn sketch-btn-primary"
+              data-copy-target="button"
+              data-action="click->copy#copy">
+        コピー
+      </button>
+    </div>
+  </div>
+
+  <%# Step 2: エンドポイント URL %>
+  <p class="sketch-label" style="margin-bottom: 6px;">Step 2</p>
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <p class="sketch-label" style="margin-bottom: 8px;">Shortcut の "Get Contents of URL" に貼り付ける URL</p>
+
+    <div data-controller="copy" data-copy-text-value="<%= @webhook_url %>">
+      <code style="display: block; font-size: 15px; word-break: break-all; background: var(--paper-2); border: 1px solid var(--ink); border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; font-family: monospace; line-height: 1.4;">
+        <%= @webhook_url %>
+      </code>
+      <button type="button"
+              class="sketch-btn sketch-btn-primary"
+              data-copy-target="button"
+              data-action="click->copy#copy">
+        コピー
+      </button>
+    </div>
+  </div>
+
+  <%# Step 3: iCloud Shortcut リンク (プレースホルダ) %>
+  <p class="sketch-label" style="margin-bottom: 6px;">Step 3</p>
+  <div class="sketch-box" style="margin-bottom: 32px;">
+    <p class="sketch-label" style="margin-bottom: 8px;">事前作成済み Shortcut</p>
+    <p class="sketch-body-text">現在準備中です。手動セットアップガイドは後日公開予定。</p>
+  </div>
+
+  <%# 危険ゾーン: トークン再生成 %>
+  <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5;">
+    <p class="sketch-h" style="margin-bottom: 8px;">トークンの再生成</p>
+    <p class="sketch-body-text" style="margin-bottom: 16px;">
+      ⚠️ <strong>トークンを再生成すると、現在 Apple Shortcuts に設定済みのトークンは無効になります。</strong>
+      再生成後は Shortcut 側の設定も更新する必要があります。
+    </p>
+    <%= button_to "トークンを再生成する",
+          regenerate_webhook_token_path,
+          method: :post,
+          class: "sketch-btn",
+          data: { confirm: "本当に再生成しますか？ 現在の Shortcut が動かなくなります。" } %>
+  </div>
+
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -29,7 +29,7 @@
   <%# Step 2: エンドポイント URL %>
   <p class="sketch-label" style="margin-bottom: 6px;">Step 2</p>
   <div class="sketch-box" style="margin-bottom: 20px;">
-    <p class="sketch-label" style="margin-bottom: 8px;">Shortcut の "Get Contents of URL" に貼り付ける URL</p>
+    <p class="sketch-label" style="margin-bottom: 8px;">iPhone のショートカットアプリで使う URL</p>
 
     <div data-controller="copy" data-copy-text-value="<%= @webhook_url %>">
       <code style="display: block; font-size: 15px; word-break: break-all; background: var(--paper-2); border: 1px solid var(--ink); border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; font-family: monospace; line-height: 1.4;">
@@ -44,11 +44,14 @@
     </div>
   </div>
 
-  <%# Step 3: iCloud Shortcut リンク (プレースホルダ) %>
+  <%# Step 3: 完了メッセージ。iCloud Shortcut 公開リンクは Phase 2 で実機作成後に差し込む。 %>
   <p class="sketch-label" style="margin-bottom: 6px;">Step 3</p>
   <div class="sketch-box" style="margin-bottom: 32px;">
-    <p class="sketch-label" style="margin-bottom: 8px;">事前作成済み Shortcut</p>
-    <p class="sketch-body-text">現在準備中です。手動セットアップガイドは後日公開予定。</p>
+    <p class="sketch-h" style="margin-bottom: 8px;">🎉 以上で設定完了です</p>
+    <p class="sketch-body-text">
+      あとは iPhone のショートカットアプリを開いて、Step 1 と Step 2 でコピーした内容を貼り付けるだけ。<br>
+      事前作成済み Shortcut の配布リンクは現在準備中、近日中にここに表示されます。
+    </p>
   </div>
 
   <%# 危険ゾーン: トークン再生成 %>
@@ -62,7 +65,7 @@
           regenerate_webhook_token_path,
           method: :post,
           class: "sketch-btn",
-          data: { confirm: "本当に再生成しますか？ 現在の Shortcut が動かなくなります。" } %>
+          data: { turbo_confirm: "本当に再生成しますか？ 現在の Shortcut が動かなくなります。" } %>
   </div>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ Rails.application.routes.draw do
   # Apple Shortcuts → Rails webhook endpoint (Bearer token auth, no CSRF cookie needed)
   post "/webhooks/health_data", to: "webhooks#health_data"
 
+  # Settings: webhook token 表示 / 再生成
+  get  "/settings",               to: "settings#show",            as: :settings
+  post "/settings/webhook_token", to: "settings#regenerate_token", as: :regenerate_webhook_token
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   delete "/logout", to: "sessions#destroy", as: :logout
 
   # Apple Shortcuts → Rails webhook endpoint (Bearer token auth, no CSRF cookie needed)
-  post "/webhooks/health_data", to: "webhooks#health_data"
+  post "/webhooks/health_data", to: "webhooks#health_data", as: :webhooks_health_data
 
   # Settings: webhook token 表示 / 再生成
   get  "/settings",               to: "settings#show",            as: :settings

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe "Home", type: :request do
       end
 
       it "ようこそメッセージにユーザー名を含む" do
-        expect(response.body).to include("ようこそ、#{user.name}さん。")
+        # PR #30 (sketchy 化) で <b>name</b> でラップ + 半角スペース挿入する形に変更されたため、
+        # 文字列完全一致ではなく構成要素を独立して検証する。
+        expect(response.body).to include("ようこそ、")
+        expect(response.body).to include(user.name)
       end
 
       it "Google でログインボタンをどこにも表示しない" do

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+RSpec.describe "Settings", type: :request do
+  # ---------------------------------------------------------------------------
+  # ログインヘルパー
+  #
+  # sessions_spec.rb / home_spec.rb と同じパターン:
+  # mock_google_oauth2 で OmniAuth モックをセットしてから
+  # GET /auth/google_oauth2/callback を叩き、実際のログインフローを通す。
+  # これにより session[:user_id] が張られた状態になる。
+  # ---------------------------------------------------------------------------
+  def login(user)
+    mock_google_oauth2(uid: user.uid, email: user.email, name: user.name)
+    get auth_callback_path(provider: "google_oauth2")
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /settings
+  # ---------------------------------------------------------------------------
+  describe "GET /settings" do
+    context "未ログイン時" do
+      before { get settings_path }
+
+      it "302 リダイレクトを返す" do
+        expect(response).to have_http_status(:found)
+      end
+
+      it "root_path へリダイレクトする" do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "flash[:alert] にログイン要求メッセージをセットする" do
+        expect(flash[:alert]).to eq("ログインが必要です")
+      end
+    end
+
+    context "ログイン時" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+        get settings_path
+      end
+
+      it "200 OK を返す" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "レスポンスボディに current_user の webhook_token を含む" do
+        expect(response.body).to include(user.webhook_token)
+      end
+
+      it "レスポンスボディに webhook URL を含む" do
+        expect(response.body).to include(webhooks_health_data_url)
+      end
+
+      it "レスポンスボディに「Apple Shortcuts 連携」を含む" do
+        expect(response.body).to include("Apple Shortcuts 連携")
+      end
+
+      it "レスポンスボディに「Step 1」を含む" do
+        expect(response.body).to include("Step 1")
+      end
+
+      it "レスポンスボディに「Step 2」を含む" do
+        expect(response.body).to include("Step 2")
+      end
+
+      it "レスポンスボディに「Step 3」を含む" do
+        expect(response.body).to include("Step 3")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /settings/webhook_token (トークン再生成)
+  # ---------------------------------------------------------------------------
+  describe "POST /settings/webhook_token" do
+    context "未ログイン時" do
+      let(:user) { create(:user) }
+      let(:original_token) { user.webhook_token }
+
+      before do
+        original_token # let を評価して DB に確定させる
+        post regenerate_webhook_token_path
+      end
+
+      it "302 リダイレクトを返す" do
+        expect(response).to have_http_status(:found)
+      end
+
+      it "root_path へリダイレクトする" do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "webhook_token が変更されない" do
+        expect(user.reload.webhook_token).to eq(original_token)
+      end
+    end
+
+    context "ログイン時" do
+      let(:user) { create(:user) }
+      let(:original_token) { user.webhook_token }
+
+      before do
+        original_token # let を評価して DB に確定させる
+        login(user)
+        post regenerate_webhook_token_path
+      end
+
+      it "302 リダイレクトを返す" do
+        expect(response).to have_http_status(:found)
+      end
+
+      it "settings_path へリダイレクトする" do
+        expect(response).to redirect_to(settings_path)
+      end
+
+      it "flash[:notice] に再生成完了メッセージをセットする" do
+        expect(flash[:notice]).to include("再生成")
+      end
+
+      it "webhook_token が元の値と異なる値に変更される" do
+        expect(user.reload.webhook_token).not_to eq(original_token)
+      end
+
+      context "既存の StepRecord が保持される" do
+        let!(:step_record) { create(:step_record, user: user, recorded_on: "2026-05-01", steps: 8000) }
+
+        it "トークン再生成後も StepRecord が残っている" do
+          expect(StepRecord.where(user: user)).to exist
+        end
+
+        it "トークン再生成後も StepRecord の steps 値が変わらない" do
+          expect(StepRecord.find_by(user: user, recorded_on: "2026-05-01").steps).to eq(8000)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 2 (iPhone Shortcuts 実機テスト) の前提となる **設定画面 (`/settings`)** を実装。ユーザーが webhook_token と endpoint URL をコピーできる UI を sketchy 風で構築。

- ルート: GET /settings, POST /settings/webhook_token
- Controller: SettingsController (要ログイン)
- View: 3 ステップ構成 (token コピー / URL コピー / 完了メッセージ) + 危険ゾーン (token 再生成)
- Stimulus: copy_controller.js (Clipboard API + フィードバック)
- 認証ガード基盤: ApplicationController に require_login ヘルパー追加
- navbar に「設定」リンク追加 (ログイン時のみ)

## なぜ今これか (締切観点)

README PR #32 で「初回設定こそが唯一の山。ここを越えれば一生ゼロ」と公約済み。**この設定画面がその「山」の体験そのもの**。Phase 2 (iPhone 実機テスト) には token をコピーする UI が必須なので、Phase 3 を Phase 2 より先に倒す順序判断。

## UX 設計の判断

### 3 ステップ構成 + 危険ゾーン
- Step 1: token コピー (大きく表示 + コピーボタン)
- Step 2: endpoint URL コピー
- Step 3: **「🎉 以上で設定完了です」締めメッセージ** ← レビューで「準備中プレースホルダだと UX の崖になる」指摘を受けて改訂
- 危険ゾーン: token 再生成 (薄ピンク背景 + ⚠️ 警告 + JS confirm())

### 教材性: 「危険ゾーン = 画面上の永続警告 + data-turbo-confirm の二段構え」
sketchy モーダル化を捨てた理由 = MVP では JS confirm() で十分、UI 専用 modal 実装コスト > リスク低減効果。後輩が同じ判断を再現できるようコメントで意図明示。

## レビュー反映

3 者並列レビュー (code / strategic / design) で出た指摘:
- ✅ \`webhooks_health_data_url\` の host: 引数を削除 (二重指定リスク回避) — code Should
- ✅ \`regenerate_token\` に rescue ActiveRecord::ActiveRecordError 追加 — code Should
- ✅ Step 3 を「準備中」→「🎉 以上で設定完了です」締めに改訂 — strategic 最重要 + design 高
- ✅ Step 2 ラベル「Shortcut の Get Contents of URL...」→「iPhone のショートカットアプリで使う URL」 — design 中

スキップ (低優先 / 別 PR / 別タスク):
- sketch-label 13px → 15px (sketchy.css 改修、レスポンシブ対応と一緒に)
- navbar 設定 vs ログアウト視覚階層
- インラインスタイル多用、intended URL 保持
- default_url_options 設定 (Day 5 デプロイタスク)

## 便乗修正 (規定の「スコープ便乗」明示)

- \`spec/requests/home_spec.rb\`: PR #30 (sketchy 化) で welcome 文の構造が変わった regression を修正 (文字列完全一致 → 構成要素分離)

## Phase 2 への申し送り

- Step 3 の「事前作成済み Shortcut 配布リンク」は現状プレースホルダ
- ユーザー (=開発者本人) が iPhone で iCloud Shortcut を組んで公開リンクを生成 → **別 PR で Step 3 にリンク差込**
- ngrok / Cloudflare Tunnel で localhost を一時公開して実機検証

## Test plan

- [ ] \`/settings\` 未ログイン時に root にリダイレクト + flash[:alert]
- [ ] ログイン時に token / URL / 完了メッセージ表示
- [ ] コピーボタンで Clipboard に書き込まれて「コピー済み✓」表示
- [ ] 再生成ボタンで JS confirm() 起動 → 拒否で何も起きない、承認で token 変更 + flash[:notice]
- [ ] navbar の「設定」リンクが sketchy ボタンとして表示される
- [ ] \`bundle exec rspec\` で 140 examples 全部 pass
- [ ] \`bundle exec rubocop\` で 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)