### PR TITLE
feat: Settings Step 3 に iCloud Shortcut 配布リンクを差し込む (#36)

### DIFF
--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -44,14 +44,19 @@
     </div>
   </div>
 
-  <%# Step 3: 完了メッセージ。iCloud Shortcut 公開リンクは Phase 2 で実機作成後に差し込む。 %>
+  <%# Step 3: iCloud 公開済み Shortcut の配布リンク %>
   <p class="sketch-label" style="margin-bottom: 6px;">Step 3</p>
   <div class="sketch-box" style="margin-bottom: 32px;">
-    <p class="sketch-h" style="margin-bottom: 8px;">🎉 以上で設定完了です</p>
-    <p class="sketch-body-text">
-      あとは iPhone のショートカットアプリを開いて、Step 1 と Step 2 でコピーした内容を貼り付けるだけ。<br>
-      事前作成済み Shortcut の配布リンクは現在準備中、近日中にここに表示されます。
+    <p class="sketch-h" style="margin-bottom: 8px;">🎉 あとはショートカットを入れるだけ</p>
+    <p class="sketch-body-text" style="margin-bottom: 16px;">
+      下のボタンから iPhone に Shortcut を追加 → 初回実行時に Step 1 でコピーした値を貼り付ければ完了です。
     </p>
+    <%= link_to "ショートカットをインストール",
+          "https://www.icloud.com/shortcuts/d2fb3cca3a3e47549577231a011dffee",
+          class: "sketch-btn sketch-btn-primary",
+          target: "_blank",
+          rel: "noopener noreferrer" %>
+    <p class="sketch-small" style="margin: 8px 0 0;">タップで iCloud が開きます</p>
   </div>
 
   <%# 危険ゾーン: トークン再生成 %>

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -69,6 +69,22 @@ RSpec.describe "Settings", type: :request do
       it "レスポンスボディに「Step 3」を含む" do
         expect(response.body).to include("Step 3")
       end
+
+      it "Step 3 に iCloud Shortcut の配布リンクを含む" do
+        expect(response.body).to include("https://www.icloud.com/shortcuts/d2fb3cca3a3e47549577231a011dffee")
+      end
+
+      it "Step 3 のボタン文言が「ショートカットをインストール」である" do
+        expect(response.body).to include("ショートカットをインストール")
+      end
+
+      it "iCloud リンクが target=\"_blank\" + rel=\"noopener noreferrer\" 付きで描画される" do
+        # 属性順は Rails / link_to に依存し変動しうるため、a タグ抽出後に個別検査する
+        link_tag = response.body[%r{<a\b[^>]*href="https://www\.icloud\.com/shortcuts/[^"]+"[^>]*>}]
+        expect(link_tag).not_to be_nil, "iCloud Shortcut リンクの a タグが見つからない"
+        expect(link_tag).to include('target="_blank"')
+        expect(link_tag).to include('rel="noopener noreferrer"')
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Settings 画面 Step 3 のプレースホルダー文言を、iCloud 公開リンク付きの `sketch-btn` に置換
- 外部リンクは `target=_blank` + `rel=noopener noreferrer` でタブナッピング対策
- design-reviewer 指摘 2 点反映: 「トークン」→「コピーした値」にニュートラル化、ボタン下に「タップで iCloud が開きます」の小注釈

Closes #36

## 設計判断

### URL のハードコード

iCloud Shortcut URL (`https://www.icloud.com/shortcuts/d2fb3cca3a3e47549577231a011dffee`) は秘密ではない公開リンク・1 ヶ所利用・環境差なし、で View 直書き。将来「ユーザーごと配布」に進化したら config 化を検討するが、MVP では YAGNI 適用。

### 属性順に依存しない spec

`link_to` の出力する `target` / `rel` 属性順は Rails / helper 実装に依存し変動しうるため、`include` ではなく **a タグを正規表現で抽出 → 属性を個別検査** という形にした (`spec/requests/settings_spec.rb:79-85`)。後輩が外部リンクを書く際のサンプルとして残す。

## 3 者並列レビュー結果

| レビュアー | 判定 |
|---|---|
| code-reviewer | 🟢 Approve (Nit 1 件のみ・許容範囲) |
| strategic-reviewer | 🟢 進めてよい (順序・スコープ・教材性すべて合格) |
| design-reviewer | 🟡 修正後 OK (6 件指摘、うち 2 件をこの PR で反映、残 4 件は別 Issue 化予定) |

## Test plan

- [x] `script/run "bundle exec rspec spec/requests/settings_spec.rb"` 22 examples / 0 failures
- [x] `bundle exec rubocop spec/requests/settings_spec.rb` no offenses
- [ ] **iPhone Safari で実機確認** (settings 画面のインストールボタンタップ → iCloud Shortcut 追加画面が開くこと) — マージ後にユーザー実機検証

## Out of scope (別 Issue 化予定)

design-reviewer 指摘のうちこの PR で反映しなかった 4 件:
- `sketch-btn` 全体のタップ領域 44px 化 (Step 1/2 も同じクラスのため別 Issue で全体修正)
- 危険ゾーンとの視覚的区切り線
- 見出しコピー微調整
- インストール後の追加案内文 (MVP スコープ膨張回避)

🤖 Generated with [Claude Code](https://claude.com/claude-code)