### PR TITLE
fix: sketch-btn のタップ領域を 44px (WCAG/HIG) に拡大する (#47)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -61,9 +61,13 @@ body {
 
 /* ---------- button ---------- */
 /* button_to が <form> でラップするため :active のずれを安定させる工夫が必要 */
+/* padding は WCAG 2.5.5 / Apple HIG が定める最小タップ領域 44×44px を満たすために拡大している。
+   border-box 環境 (Tailwind 4 preflight 適用) で font-size 18px × line-height 1.4 + 上下 padding 20px ≒ 45px。
+   縮める誘惑が出たときは iPhone 実機で誤タップが増えることを思い出すこと。
+   line-height を 1.4 未満に変えた場合は `min-height: 44px;` を追加して保険をかけること。 */
 .sketch-btn {
   display: inline-block; border: 2px solid var(--ink); background: var(--paper);
-  font-family: 'Caveat', cursive; font-size: 18px; padding: 4px 14px; border-radius: 6px;
+  font-family: 'Caveat', cursive; font-size: 18px; padding: 10px 16px; border-radius: 6px;
   color: var(--ink); text-decoration: none; cursor: pointer;
   box-shadow: 2px 2px 0 var(--ink);
   transition: transform .08s ease, box-shadow .08s ease;


### PR DESCRIPTION
## Summary

- `app/assets/stylesheets/sketchy.css` の `.sketch-btn` の `padding: 4px 14px` → `10px 16px` (高さ約 33px → 45px)
- WCAG 2.5.5 + Apple HIG が定める **最小タップ領域 44×44px** に準拠
- 影響範囲: 全 sketch-btn 10 箇所 (Settings 4 + Home 4 + About 1 + navbar 2)

Closes #47

## 設計判断

### `min-height: 44px` を入れない理由

font-size 18px × line-height 1.4 + padding 20px ≒ 45px で 1px の余裕しかないが、border-box 環境 (Tailwind 4 preflight) で常時 45px 確保される。`min-height` は冗長。

ただし将来 line-height を 1.4 未満に変えた場合は 44px を切るリスクがあるため、**コメントで line-height 変更時の保険ガイドを明記**。

### navbar 内ボタンも一括で 44px 化する判断

「navbar だけ高さ抑制」案 (`padding-block: 6px`) は Issue #47 のゴール (= 全ボタン 44px タップ領域) と直接矛盾するため不採用。
navbar 高さが約 12px 膨張する副作用は別 Issue #49 (UI 最終 polish フェーズ) に判断保留。

## 3 者並列レビュー結果

| レビュアー | 判定 | 主な指摘 |
|---|---|---|
| code-reviewer | 🟢 Approve | Nit 1: コメント数式の border 計上誤り → 修正済み |
| strategic-reviewer | 🟢 進めてよい | navbar 実機確認推奨 → Issue #49 |
| design-reviewer | 🟢 デモで出せる | navbar 膨張 + line-height ガイド追加 → 後者は反映済み、前者は Issue #49 |

## Test plan

- [x] `script/run "bundle exec rspec"` 232 examples / 0 failures
- [x] CSS 1 ブロック + コメントのみのため lint 影響なし
- [ ] **iPhone Safari 実機で sketch-btn 全 10 箇所のタップ精度を確認** (= マージ前 or マージ後にユーザー実機検証)
- [ ] **375px / 414px / iPad / Mac で Settings の Step 1/2 横並びが崩れないか目視** (実機 or DevTools)
- [ ] **navbar 「設定」「ログアウト」の縦余白が許容範囲か確認** (許容外なら Issue #49 着手)

## Out of scope (別 Issue)

- #49: navbar 高さ膨張の対応 (UI 最終 polish フェーズで判断)
- #48: Settings Step 3 周りの polish 3 件 (UI 最終 polish フェーズで判断)

🤖 Generated with [Claude Code](https://claude.com/claude-code)