### PR TITLE
fix: webhooks#health_data の recorded_on を厳格パースして fail-fast 化 (#51)

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -3,6 +3,12 @@ class WebhooksController < ActionController::API
   # ActionController::API 継承は Rails 標準の API-only パターンで、CSRF 保護 / browser check / cookie /
   # session を含まない (skip_forgery_protection 等の禁止 workaround とは別物 — そもそも入っていない)。
   # 認証は Bearer token (authenticate_webhook!) で行う。
+
+  # ペイロード形式違反 (recorded_on の形式不正など) を表す内部例外。
+  # JSON::ParserError や RecordInvalid と並列で 422 + 監査ログ経路に流すために導入。
+  # webhook 受信エンドポイントは「機械同士の契約」なので fail-fast (silent 正規化しない) 方針。
+  InvalidPayload = Class.new(StandardError)
+
   before_action :read_raw_body
   before_action :authenticate_webhook!
 
@@ -21,6 +27,9 @@ class WebhooksController < ActionController::API
     render json: { accepted: accepted }, status: :ok
   rescue JSON::ParserError => e
     record_delivery!(status: "invalid", error_message: "JSON parse error: #{e.message.truncate(120)}")
+    render json: { error: "Invalid payload" }, status: :unprocessable_content
+  rescue InvalidPayload => e
+    record_delivery!(status: "invalid", error_message: e.message.truncate(120))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   rescue ActiveRecord::RecordInvalid => e
     # 個々のレコードのバリデーション違反 (負数 / 不正な日付等) を 500 ではなく 422 + 監査ログで返す。
@@ -70,6 +79,29 @@ class WebhooksController < ActionController::API
     request.headers["Authorization"]&.delete_prefix("Bearer ")&.strip
   end
 
+  # Strict ISO 8601 (yyyy-MM-dd) parser. 配布版 Apple Shortcut は yyyy-MM-dd zero-padded で送る契約のため、
+  # それ以外のフォーマット (yyyy/MM/dd, M/d/yyyy 米国式 vs 欧州式) を Date.parse で寛容に解釈すると
+  # 「同じ日のつもりが別日として保存」「2 月のデータが 5 月になる」事故を生むため reject する。
+  #
+  # NOTE: Date.strptime("%Y-%m-%d") は仕様上 zero padding 不足 ("2026-5-3") を許容してしまうため、
+  # 正規表現で「正確に 4-2-2 桁」を先に検査してから Date.strptime に渡す二段構え。
+  ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}\z/
+
+  # truncate を inspect の前にかけることで、攻撃者が巨大な recorded_on 値 (1MB body キャップ内で
+  # 数百 KB を詰める) を送った時に、エラーメッセージ生成段階で巨大文字列が一時的にヒープに乗るのを防ぐ。
+  def parse_recorded_on(raw)
+    raise InvalidPayload, "recorded_on is required" if raw.blank?
+    raw_str = raw.to_s
+    truncated = raw_str.truncate(40).inspect
+    unless raw_str.match?(ISO_DATE_FORMAT)
+      raise InvalidPayload, "recorded_on must be yyyy-MM-dd format: got #{truncated}"
+    end
+    Date.strptime(raw_str, "%Y-%m-%d")
+  rescue Date::Error
+    # 月日の値域違反 (例: "2026-13-99")
+    raise InvalidPayload, "recorded_on must be yyyy-MM-dd format: got #{truncated}"
+  end
+
   # Upsert each day's record, updating only the keys present in the payload.
   # Keys absent from the payload are left unchanged (partial-update semantics).
   # All-or-nothing: wrap in a transaction so that if any record fails validation
@@ -79,8 +111,7 @@ class WebhooksController < ActionController::API
 
     StepRecord.transaction do
       records_data.each do |entry|
-        recorded_on = entry["recorded_on"]
-        next if recorded_on.blank?
+        recorded_on = parse_recorded_on(entry["recorded_on"])
 
         record = StepRecord.find_or_initialize_by(user: @webhook_user, recorded_on: recorded_on)
 

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -275,14 +275,17 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
   end
 
   # ---------------------------------------------------------------------------
-  # Case 9: Entry without recorded_on is silently skipped
+  # Case 9: Entry missing recorded_on → 422 全件 rollback (Issue #51 で silent skip から変更)
   # ---------------------------------------------------------------------------
-  describe "Case 9: entries missing recorded_on are silently skipped" do
+  # 旧仕様: silent skip (= 該当レコードだけ無視して続行)。
+  # 新仕様: webhook は機械同士の契約。recorded_on は必須なので、欠損は契約違反として 422 reject + rollback。
+  # 同種の挙動: Case 11 (record validation 失敗で全件 rollback) と一貫。
+  describe "Case 9: entry missing recorded_on returns 422 and rolls back" do
     let(:payload) do
       {
         records: [
           { recorded_on: "2026-05-01", steps: 100 },
-          { steps: 200 },                             # no recorded_on → skip
+          { steps: 200 },                             # no recorded_on → reject 全体
           { recorded_on: "2026-05-02", steps: 300 }
         ]
       }
@@ -290,26 +293,94 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
 
     before { post_health_data(payload) }
 
-    it "returns HTTP 200" do
-      expect(response).to have_http_status(:ok)
+    it "returns HTTP 422" do
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
-    it "returns accepted: 2 (skipped entry not counted)" do
-      expect(response.parsed_body).to eq("accepted" => 2)
+    it "returns the Invalid payload error body" do
+      expect(response.parsed_body).to eq("error" => "Invalid payload")
     end
 
-    it "creates exactly 2 StepRecords" do
-      expect(StepRecord.count).to eq(2)
+    it "rolls back ALL records, leaving 0 in DB" do
+      expect(StepRecord.count).to eq(0)
     end
 
-    it "does not create a record for the entry missing recorded_on" do
-      created_dates = StepRecord.pluck(:recorded_on)
-      expect(created_dates).to contain_exactly(Date.new(2026, 5, 1), Date.new(2026, 5, 2))
+    it "records a WebhookDelivery with status 'invalid'" do
+      expect(WebhookDelivery.last.status).to eq("invalid")
     end
 
-    # NOTE: This 'silent skip' behavior was a deliberate judgment call by
-    # rails-implementer. If the spec changes to return an error instead,
-    # update this example and Case 9 as a pair.
+    it "includes 'recorded_on is required' in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("recorded_on is required")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 13: recorded_on の形式違反 → 422 (Issue #51)
+  # ---------------------------------------------------------------------------
+  # 配布版 Apple Shortcut は yyyy-MM-dd zero-padded で送る契約。それ以外は Date.strptime が失敗 → 422 reject。
+  # Date.parse の寛容解釈 (例: "5/3/2026" を米国式 May 3 と決めて保存) による silent 事故を防ぐため、
+  # 形式違反は明示的に reject する fail-fast 設計。
+  describe "Case 13: recorded_on format violations return 422" do
+    shared_examples "rejects malformed recorded_on" do |bad_value|
+      describe "with recorded_on = #{bad_value.inspect}" do
+        before { post_health_data({ records: [ { recorded_on: bad_value, steps: 100 } ] }) }
+
+        it "returns HTTP 422" do
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it "does not create any StepRecord" do
+          expect(StepRecord.count).to eq(0)
+        end
+
+        it "records a WebhookDelivery with status 'invalid'" do
+          expect(WebhookDelivery.last.status).to eq("invalid")
+        end
+
+        it "mentions 'recorded_on must be yyyy-MM-dd' in the error_message" do
+          expect(WebhookDelivery.last.error_message).to include("recorded_on must be yyyy-MM-dd")
+        end
+      end
+    end
+
+    # スラッシュ区切り (Apple Shortcuts の locale や別ツール由来でありがち)
+    include_examples "rejects malformed recorded_on", "2026/05/03"
+    # zero padding 不足 (yyyy-M-d)
+    include_examples "rejects malformed recorded_on", "2026-5-3"
+    # 米国式 / 欧州式の解釈分岐リスクあり
+    include_examples "rejects malformed recorded_on", "5/3/2026"
+    # 完全な不正値
+    include_examples "rejects malformed recorded_on", "abc"
+    # 日本語表記
+    include_examples "rejects malformed recorded_on", "2026年5月3日"
+    # 月日の値域違反 (正規表現は通過するが Date::Error rescue ルートに落ちる) — 二段構えの第二段の回帰テスト
+    include_examples "rejects malformed recorded_on", "2026-13-99"
+
+    # 空文字も 422 (Case 9 で nil/未指定はカバー、ここは "" の明示テスト)
+    describe "with recorded_on = \"\"" do
+      before { post_health_data({ records: [ { recorded_on: "", steps: 100 } ] }) }
+
+      it "returns HTTP 422" do
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "mentions 'recorded_on is required' in the error_message (blank check)" do
+        expect(WebhookDelivery.last.error_message).to include("recorded_on is required")
+      end
+    end
+
+    # 正常系の境界値: zero-padded yyyy-MM-dd は引き続き 200 で通る (回帰防止)
+    describe "with recorded_on = \"2026-05-03\" (valid)" do
+      before { post_health_data({ records: [ { recorded_on: "2026-05-03", steps: 100 } ] }) }
+
+      it "returns HTTP 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "creates the StepRecord" do
+        expect(StepRecord.count).to eq(1)
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `recorded_on` を **正規表現 + Date.strptime** の二段構えで yyyy-MM-dd zero-padded のみ受理
- 形式違反 / 欠損は **422 + WebhookDelivery(invalid)** で reject、トランザクション全件 rollback (Case 11 と一貫)
- 仕様変更: 旧「recorded_on 欠損は silent skip」→ 新「422 reject + 全件 rollback」
- Issue #51 body の「400」→「422」に訂正済み (既存 JSON::ParserError / RecordInvalid と HTTP ステータス統一)

Closes #51

## 設計判断: なぜ rails-implementer の "silent skip" を覆したか

旧 spec の `NOTE: This 'silent skip' behavior was a deliberate judgment call by rails-implementer` を覆す判断について、後追い分析できるように根拠 4 点を明記:

1. **配布版 Shortcut 固定**: Day 3-3 改変①で `yyyy-MM-dd` zero-padded 固定が確認済み、blank が来るのは契約違反のサイン
2. **silent 正規化の事故リスク**: `"5/3/2026"` を米国式 May 3 と決めて保存すると、欧州式 March 5 のつもりだったユーザーは「2 月のデータが 5 月になる」が検出不可能
3. **Webhook = 機械同士の契約**: Stripe / Slack / GitHub の慣習も「機械送信は fail-fast」
4. **教材性**: 「想定外を silent に救うか reject するか」の本質的トレードオフを後輩に教材として残す (`feedback_code_as_communication.md` 流儀)

## なぜ正規表現 + Date.strptime の二段構え

Ruby の `Date.strptime("%Y-%m-%d")` は仕様上 zero padding 不足 (`"2026-5-3"`) を許容してしまう (Ruby docs に "forgiving" と明記)。
そのため `\A\d{4}-\d{2}-\d{2}\z` で「正確に 4-2-2 桁」を先に検査してから Date.strptime に渡す二段構え。Date::Error は値域違反 (`"2026-13-99"`) を捕捉して reject。

## 3 者並列レビュー結果

| レビュアー | 判定 | 反映 |
|---|---|---|
| code-reviewer | 🟡 Needs minor fix → 反映後 🟢 | ⚠️ raw.inspect を補間前に truncate(40) / ⚠️ 値域違反テスト追加 |
| strategic-reviewer | 🟢 進めてよい | 🟢 PR description に判断根拠 4 点明記 (このセクション) |
| design-reviewer | 🟢 デモで出せる | 緩和策 A は別 Issue #53 化 |

## Test plan

- [x] `script/run "bundle exec rspec"` 261 examples / 0 failures
- [x] `bundle exec rubocop` 2 files / no offenses
- [x] `grep -rn "recorded_on" spec/` で他テストに「部分成功前提」のものが無いことを確認 (home/settings/services/models/factories はすべて別文脈)
- [ ] **iPhone 実機 + 配布版 Shortcut で 200 OK が引き続き返ること** (= 仕様変更による既存配布版 Shortcut への影響なし確認、マージ後にユーザー実機検証)
- [ ] **本番デプロイ前にこのマージを完了** (= デプロイ後に「silent skip log」が本番で残るのを避けるため)

## Out of scope (別 Issue)

- #53: Settings 画面に WebhookDelivery 履歴表示 (発表会で「ちゃんと届いてるよ」を見せる、design-reviewer 緩和策 A 由来)
- #52: 数値型ガード + accepted カウント記録 (⚠️ 5/5 余裕枠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)