### PR TITLE
feat: Settings 画面に Shortcut からの送信ログを表示 (#53)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -90,6 +90,33 @@ body {
 .sketch-box.accent .sketch-label,
 .sketch-box.accent .sketch-small { color: var(--ink-2); }
 
+/* ---------- webhook delivery history (Settings 画面) ---------- */
+/* 受信履歴の各行を縦並びリストで表示。time / status / count / error_message を flex で配置。
+   配色は status 別 (success=緑系 / invalid=オレンジ系 / unauthorized=赤系) で WCAG AA 黒文字コントラスト。 */
+.sketch-webhook-history { list-style: none; padding: 0; margin: 0; }
+.sketch-webhook-history-item {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  padding: 8px 0; border-bottom: 1px dashed var(--muted);
+  font-family: 'Kalam', cursive; font-size: 14px; color: var(--ink-2);
+}
+.sketch-webhook-history-item:last-child { border-bottom: none; }
+.sketch-webhook-history-time { color: var(--ink-2); }
+.sketch-webhook-history-count { color: var(--muted); }
+.sketch-webhook-history-error {
+  flex-basis: 100%; margin: 4px 0 0; padding: 4px 8px;
+  background: var(--paper-2); border-radius: 4px;
+  color: var(--ink-2); font-size: 13px; line-height: 1.4;
+}
+
+/* status バッジ。border-radius + padding + 黒文字 (6.73:1 / 7:1+) で AA 確実。 */
+.sketch-status {
+  display: inline-block; padding: 2px 8px; border: 1px solid var(--ink); border-radius: 4px;
+  font-family: 'Kalam', cursive; font-size: 13px; line-height: 1.2; color: var(--ink);
+}
+.sketch-status-success      { background: var(--accent-4); }   /* 緑 (#7ac74f) + 黒文字 = AA */
+.sketch-status-invalid      { background: var(--accent); }     /* オレンジ (#ff7a45) + 黒文字 6.73:1 = AA */
+.sketch-status-unauthorized { background: #ffd9d9; }            /* 赤系。MVP では非表示だが将来 #55 で使う */
+
 /* ---------- typography ---------- */
 .sketch-h  { font-family: 'Caveat', cursive; font-weight: 700; font-size: 24px; margin: 0 0 6px; line-height: 1.1; }
 .sketch-hh { font-family: 'Caveat', cursive; font-size: 30px; margin: 0; line-height: 1.1; }

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,11 +1,17 @@
 class SettingsController < ApplicationController
   before_action :require_login
 
+  WEBHOOK_HISTORY_LIMIT = 5
+
   def show
     @webhook_token = current_user.webhook_token
     # _url ヘルパは request 由来で絶対 URL を組み立てるため、host 引数は不要 (二重指定リスク回避)。
     # 本番デプロイ時は config.action_controller.default_url_options or config.hosts でホスト解決を制御する。
     @webhook_url = webhooks_health_data_url
+    # unauthorized 試行 (user_id = nil) は MVP では非表示。設定で切替可能化は #55 で対応予定。
+    @webhook_deliveries = current_user.webhook_deliveries
+                                      .order(received_at: :desc)
+                                      .limit(WEBHOOK_HISTORY_LIMIT)
   end
 
   def regenerate_token

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,34 @@
+module SettingsHelper
+  WEBHOOK_STATUS_LABELS = {
+    "success"      => "成功",
+    "invalid"      => "エラー",
+    "unauthorized" => "認証失敗"
+  }.freeze
+
+  # WebhookDelivery#status を Settings 画面表示用の日本語ラベルに変換する。
+  # 設計判断: ロジックを view 直書きにしないのは「他画面 (将来の admin/dashboard 等) でも同じラベルが要る」
+  # 想定 + view から日本語文字列リテラルを排除したいから (= I18n 化への準備)。
+  def webhook_status_label(status)
+    WEBHOOK_STATUS_LABELS.fetch(status, status.to_s)
+  end
+
+  # CSS クラス名に補間する modifier を許可リスト経由で返す。
+  # DB を直接書き換えられた場合などに status カラムに想定外文字列が入っても、CSS クラス補間で
+  # 属性破壊や HTML インジェクションが起きないよう許可リスト外は "unknown" にフォールバック。
+  def webhook_status_css_modifier(status)
+    WEBHOOK_STATUS_LABELS.key?(status) ? status : "unknown"
+  end
+
+  # WebhookDelivery から送信件数を抽出 (success 時のみ意味があるため status で分岐)。
+  # PR #54 で all-or-nothing rollback 化したため success 時の送信件数 = 保存件数で意味が一致する。
+  # invalid 時は「1 件試したが 0 件保存された」となり「1 件」表示が誤読を生むため非表示にする。
+  # payload が JSON parse 失敗 (= { raw: "..." }) の場合も nil を返し、view 側で件数表示を省略する。
+  def webhook_record_count_for_display(delivery)
+    return nil unless delivery.status == "success"
+    payload = delivery.payload
+    return nil unless payload.is_a?(Hash)
+    records = payload["records"]
+    return nil unless records.is_a?(Array)
+    records.size
+  end
+end

--- a/app/views/settings/_webhook_delivery_history.html.erb
+++ b/app/views/settings/_webhook_delivery_history.html.erb
@@ -1,0 +1,34 @@
+<%# 送信ログ (直近 5 件)。Apple Shortcuts のクライアントは Webhook 422 を「ネットワーク切れ」と
+    誤表示するため (Day 3-3 既知バグ)、ここでログを見せて自己解決を助ける。 %>
+<p class="sketch-label" style="margin-bottom: 6px;">Shortcut からの送信ログ (直近 <%= SettingsController::WEBHOOK_HISTORY_LIMIT %> 件)</p>
+<div class="sketch-box" style="margin-bottom: 24px;">
+  <% if @webhook_deliveries.empty? %>
+    <p class="sketch-body-text" style="margin: 0;">
+      まだ Shortcut からの送信はありません。Step 3 のボタンからインストールしてください。
+    </p>
+  <% else %>
+    <ul class="sketch-webhook-history">
+      <% @webhook_deliveries.each do |delivery| %>
+        <li class="sketch-webhook-history-item">
+          <span class="sketch-status sketch-status-<%= webhook_status_css_modifier(delivery.status) %>">
+            <%= webhook_status_label(delivery.status) %>
+          </span>
+          <span class="sketch-webhook-history-time"
+                title="<%= delivery.received_at.strftime("%Y-%m-%d %H:%M") %>">
+            <%= time_ago_in_words(delivery.received_at) %>前
+          </span>
+          <% count = webhook_record_count_for_display(delivery) %>
+          <% if count %>
+            <span class="sketch-webhook-history-count"><%= count %> 件</span>
+          <% end %>
+          <% if delivery.error_message.present? %>
+            <p class="sketch-webhook-history-error">
+              <%# モバイル Safari は title 属性のホバー表示が効かないため、truncate せず全文表示 (sketch-box 内で自然折り返し)。 %>
+              <%= delivery.error_message %>
+            </p>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -59,6 +59,8 @@
     <p class="sketch-small" style="margin: 8px 0 0;">タップで iCloud が開きます</p>
   </div>
 
+  <%= render "webhook_delivery_history" %>
+
   <%# 危険ゾーン: トークン再生成 %>
   <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5;">
     <p class="sketch-h" style="margin-bottom: 8px;">トークンの再生成</p>

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -86,6 +86,129 @@ RSpec.describe "Settings", type: :request do
         expect(link_tag).to include('rel="noopener noreferrer"')
       end
     end
+
+    # -------------------------------------------------------------------------
+    # 受信履歴セクション (Issue #53)
+    # -------------------------------------------------------------------------
+    context "ログイン時 (受信履歴セクション)" do
+      let(:user) { create(:user) }
+
+      before { login(user) }
+
+      context "WebhookDelivery が 0 件のとき" do
+        before { get settings_path }
+
+        it "「送信ログ」見出しを表示する" do
+          expect(response.body).to include("送信ログ")
+        end
+
+        it "プレースホルダー「まだ Shortcut からの送信はありません」を表示する" do
+          expect(response.body).to include("まだ Shortcut からの送信はありません")
+        end
+      end
+
+      context "success の WebhookDelivery が 1 件あるとき" do
+        let!(:delivery) do
+          create(:webhook_delivery, user: user, status: "success",
+                                    payload: { "records" => [ { "recorded_on" => "2026-05-03", "steps" => 8000 } ] },
+                                    received_at: 5.minutes.ago)
+        end
+
+        before { get settings_path }
+
+        it "ステータスラベル「成功」を表示する" do
+          expect(response.body).to include("成功")
+        end
+
+        it "件数 (1 件) を表示する" do
+          expect(response.body).to include("1 件")
+        end
+
+        it "sketch-status-success クラスを描画する" do
+          expect(response.body).to include("sketch-status-success")
+        end
+
+        it "プレースホルダーを表示しない" do
+          expect(response.body).not_to include("まだ Shortcut からの送信はありません")
+        end
+      end
+
+      context "invalid の WebhookDelivery が 1 件あるとき" do
+        let!(:delivery) do
+          create(:webhook_delivery, user: user, status: "invalid",
+                                    payload: { "records" => [ { "recorded_on" => "bad" } ] },
+                                    error_message: "recorded_on must be yyyy-MM-dd format: got \"bad\"",
+                                    received_at: 1.hour.ago)
+        end
+
+        before { get settings_path }
+
+        it "ステータスラベル「エラー」を表示する" do
+          expect(response.body).to include("エラー")
+        end
+
+        it "sketch-status-invalid クラスを描画する" do
+          expect(response.body).to include("sketch-status-invalid")
+        end
+
+        it "件数表示は省略する (= invalid 時の '1 件' は誤読を生むため非表示)" do
+          expect(response.body).not_to include("sketch-webhook-history-count")
+        end
+
+        it "error_message を全文表示する (truncate なし、モバイル hover 不可問題対応)" do
+          expect(response.body).to include("recorded_on must be yyyy-MM-dd format: got")
+        end
+      end
+
+      context "unauthorized の WebhookDelivery (user_id = nil) があるとき" do
+        let!(:unauthorized_delivery) do
+          create(:webhook_delivery, user: nil, status: "unauthorized",
+                                    payload: { "records" => [] },
+                                    received_at: 10.minutes.ago)
+        end
+
+        before { get settings_path }
+
+        it "unauthorized 行は表示しない (MVP デフォルト、#55 で設定化予定)" do
+          expect(response.body).not_to include("認証失敗")
+        end
+
+        it "0 件扱いでプレースホルダーを表示する" do
+          expect(response.body).to include("まだ Shortcut からの送信はありません")
+        end
+      end
+
+      context "WebhookDelivery が 6 件以上あるとき" do
+        before do
+          7.times do |i|
+            create(:webhook_delivery, user: user, status: "success",
+                                      payload: { "records" => [ { "recorded_on" => "2026-05-#{i + 1}" } ] },
+                                      received_at: i.hours.ago)
+          end
+          get settings_path
+        end
+
+        it "直近 5 件のみ描画する (= sketch-status-success の出現回数が 5)" do
+          expect(response.body.scan(/sketch-status-success/).size).to eq(5)
+        end
+      end
+
+      context "payload の records が配列でないとき (= 不正 payload)" do
+        let!(:delivery) do
+          create(:webhook_delivery, user: user, status: "invalid",
+                                    payload: { "raw" => "not json" },
+                                    error_message: "JSON parse error",
+                                    received_at: 5.minutes.ago)
+        end
+
+        before { get settings_path }
+
+        it "件数表示用の sketch-webhook-history-count クラスは描画されない" do
+          # タイトル「受信履歴 (直近 5 件)」とぶつからないよう、件数バッジの class 出現数で判定
+          expect(response.body).not_to include("sketch-webhook-history-count")
+        end
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Settings 画面 (Step 3 と危険ゾーンの間) に **Shortcut からの送信ログ (直近 5 件)** を partial で追加
- status バッジ (緑=成功 / オレンジ=エラー) + 受信時刻 (相対 + 絶対 title) + 件数 (success 時のみ) + error_message (全文)
- 0 件時は「まだ Shortcut からの送信はありません。Step 3 のボタンからインストールしてください。」のプレースホルダー
- unauthorized は MVP 非表示 (= #55 で preferences として切替可能化予定)

Closes #53

## 設計判断

### なぜ件数を success 時のみ表示するか

PR #54 の all-or-nothing rollback 化により:
- success 時の `payload["records"].size` = 保存件数 (意味が一致)
- invalid 時の `payload["records"].size` = 試行件数 (0 件保存) → **「エラー: 1 件」が「1 件保存できた」と誤読される**

→ helper `webhook_record_count_for_display(delivery)` で status を見て分岐。

### なぜ error_message を全文表示 (truncate なし) にしたか

design-reviewer 指摘: モバイル Safari は `title` 属性のホバー表示が機能しない。
40 字 truncate + title 属性は **デスクトップ専用挙動** で、モバイルで「40 字で切れた先が読めない」問題が出る。
→ truncate 外して全文表示、sketch-box 内で自然に折り返し。

### XSS 防御: webhook_status_css_modifier を許可リスト経由

`<%= delivery.status %>` を CSS クラス補間に直接使うと、DB 直接操作などで status に想定外文字列が入った場合に属性破壊リスク。
モデル `validates :status, inclusion:` で守られているが衛生原則として helper で許可リスト経由 (success/invalid/unauthorized 以外は `unknown` フォールバック)。

### unauthorized 非表示 (MVP)

`current_user.webhook_deliveries` スコープで自然に user_id=nil が除外される。`where.not` 不要。
preferences 機能化 (= ON で表示) は #55 で対応。

## 3 者並列レビュー結果

| レビュアー | 判定 | 反映 |
|---|---|---|
| code-reviewer | 🟡 → 🟢 | ⚠️ status 補間 XSS → helper 経由化 (反映) / ⚠️ time_zone → 別 Issue #57 化 |
| strategic-reviewer | 🟢 進めてよい | デプロイ後に Step 2 URL 確認推奨 (Test plan 記載) |
| design-reviewer | 🟡 → 🟢 | error_message 全文表示 (反映) / 件数を success 時のみ (反映) / 「受信履歴」→「送信ログ」(反映) |

## Test plan

- [x] `script/run "bundle exec rspec"` 全 275 examples / 0 failures
- [x] `bundle exec rubocop` 3 files / no offenses
- [ ] **iPhone Safari + 配布版 Shortcut で Webhook 送信 → Settings 画面で履歴表示確認** (= マージ後にユーザー実機検証)
- [ ] **375px で flex-wrap 縦折りが正常か目視** (status バッジ + 時刻 + 件数の並び)
- [ ] **本番デプロイ後に Step 2 URL が本番ホストになっているか確認** (= strategic-reviewer 指摘)

## Out of scope (別 Issue)

- #55 user preferences 機能 + unauthorized 表示オン/オフ (MVP 後)
- #56 ViewComponent 導入検討 (コンポーネント増加時)
- #57 config.time_zone を Tokyo に設定 (本番デプロイ前提タスク 🚨)
- #58 セクション冒頭に「最終送信: N 分前」(デモ向上)

🤖 Generated with [Claude Code](https://claude.com/claude-code)