### PR TITLE
fix: config.time_zone = Tokyo + JST 表示統一 (#57)

### DIFF
--- a/app/views/settings/_webhook_delivery_history.html.erb
+++ b/app/views/settings/_webhook_delivery_history.html.erb
@@ -14,7 +14,7 @@
             <%= webhook_status_label(delivery.status) %>
           </span>
           <span class="sketch-webhook-history-time"
-                title="<%= delivery.received_at.strftime("%Y-%m-%d %H:%M") %>">
+                title="<%= delivery.received_at.strftime("%Y-%m-%d %H:%M JST") %>">
             <%= time_ago_in_words(delivery.received_at) %>前
           </span>
           <% count = webhook_record_count_for_display(delivery) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,9 @@ module App
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    # 表示時刻を JST に統一する。DB 保存は UTC のまま (= active_record.default_timezone デフォルト :utc を維持)。
+    # DB を UTC で持つことで、将来海外ユーザー対応や per-user time_zone を導入する際の移行コストがゼロ。
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.


### PR DESCRIPTION
## Summary

- `config/application.rb` の `config.time_zone = "Tokyo"` を有効化 (= UTC → JST に表示統一)
- DB 保存は UTC 維持 (`active_record.default_timezone` デフォルト)、表示層のみ JST に変換される Rails 流儀
- ついで対応: Settings 受信ログの `strftime` に「JST」表記を明記 (= PC Chrome ホバーで TZ を曖昧にしない)

Closes #57

## なぜこのタイミングか (= 本番デプロイ前の前提タスク)

PR #59 (Issue #53) で Settings 画面に **WebhookDelivery 受信時刻の絶対表示** を追加したが、現状 Rails アプリは UTC で動いているため、**本番デプロイ後は「いま 18:30 JST に送ったログが 09:30 と表示される」9 時間ズレ問題** が起きる。

デプロイ後に当てると初回ユーザー (= 採点者 / 同期) に UTC 表示を見せてしまうため、**Issue #37 (本番デプロイ) の前** に独立 PR で当てる順序を選択。

## 設計判断

### DB は UTC 維持

`config.active_record.default_timezone` はデフォルト :utc のまま (= 明示せず Rails 流儀)。
DB を JST にしない理由: 海外展開や per-user time_zone を導入する時の移行コストがゼロになる。

### Time.now / Date.today / DateTime.now を排除済み

app/ 配下を grep して `Time.now` `DateTime.now` `Date.today` のヒットゼロを確認 (= すべて `Time.current` `Date.current` で TimeWithZone 経由)。OS の TZ 環境変数に依存するコードパスがないため、container OS が UTC のままでも JST 表示は保証される。

### Solid Queue / Solid Cache への影響

両ライブラリは内部で UTC を直接使用 (= `Time.now.utc` 相当)、`config.time_zone` の影響を受けない。アプリコード側でも `scheduled_at` / `expires_at` を手書きしている箇所はゼロ。

## 3 者並列レビュー結果

| レビュアー | 判定 | 反映 |
|---|---|---|
| code-reviewer | 🟢 Approve | 💡 Nit: WHY コメント 2 行目を WHAT → WHY に書き換え (反映済み) |
| strategic-reviewer | 🟢 進めてよい | 💡 教材性向上: 「DB UTC で海外展開時も移行コスト 0」のコメント (反映済み) |
| design-reviewer | 🟢 デモで出せる | 💡 推奨: title 属性に "JST" 明示 (ついで反映済み) |

## Test plan

- [x] `script/run "bundle exec rspec"` 全 275 examples / 0 failures (= 86 箇所の時刻依存 spec が壊れていない)
- [x] app/ 配下に `Time.now` `DateTime.now` `Date.today` がゼロ (= grep 確認済み)
- [ ] **本番デプロイ後に Settings 画面で「いま JST 時刻」と一致する受信時刻表示を確認**
- [ ] **iPhone 実機 + ngrok で Webhook 送信 → Settings の受信時刻が JST で出るか目視**

## Out of scope

per-user time_zone 設定は MVP では考えない (= 全員 JST 固定)。将来必要になったら #55 系 preferences の対象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)