### PR TITLE
feat: Render Free Tier への本番デプロイ環境を構築 (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 
 # Ignore key files for decrypting credentials and more.
 /config/*.key
+# environment-specific credentials (Rails 6+) の master key も除外。
+# `bin/rails credentials:edit -e production` で生成される production.key 等を git に乗せないため。
+/config/credentials/*.key
 
 
 /app/assets/builds/*

--- a/README.md
+++ b/README.md
@@ -428,21 +428,21 @@ Infrastructure as Code として `render.yaml` でこの構成を定義 (= Rende
 
 ### 11-4. 初回デプロイ手順
 
-1. **ローカルで credentials を編集** (Google OAuth client_id / secret を入れる)
+1. **ローカルで production-specific credentials を編集** (Google OAuth client_id / secret を入れる)
    ```bash
    # VS Code 派 (推奨):
    EDITOR="code --wait" bin/rails credentials:edit -e production
    # vim 派:
    EDITOR=vim bin/rails credentials:edit -e production
-
-   git add config/credentials/production.yml.enc && git commit -m "..."
-   git push origin main
    ```
-2. **`config/master.key` の中身を控える** (= デプロイ後の Render 環境変数で必要)
+   - 生成される `config/credentials/production.yml.enc` (= 暗号化済み) は **commit する**
+   - 生成される `config/credentials/production.key` (= 復号 key) は **`.gitignore` で除外、絶対 commit しない**
+   - 編集 → 保存 → 別ブランチで commit & push & PR (= main 直 push はガードでブロックされる)
+2. **`config/credentials/production.key` の中身を控える** (= デプロイ後の Render 環境変数で必要)
 3. **Google OAuth Console** で本番 redirect URI (`https://<your-render-domain>/auth/google_oauth2/callback`) を許可リストに追加
 4. **Render Dashboard** で `New Blueprint` → 本リポジトリを指定 → `render.yaml` が自動検出される
 5. **環境変数を設定** (Render Dashboard → 該当 Service → Environment):
-   - `RAILS_MASTER_KEY` = ローカルの `config/master.key` の中身
+   - `RAILS_MASTER_KEY` = ローカルの `config/credentials/production.key` の中身
    - `APP_HOST` = Render が割り当てたドメイン (例: `weight-dialy.onrender.com`)
 6. **デプロイ完了後**: ブラウザで `https://<your-render-domain>/` にアクセス → 200 OK 確認
 7. **Google ログイン** → ダッシュボード遷移確認

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Section 7 で予告した目玉機能。仕様の核:
 
 **インフラ・運用**
 - **Solid Trifecta** (= キャッシュ・ジョブ・ケーブルをすべて DB で賄う Rails 8 標準セット。Solid Queue / Solid Cache / Solid Cable) — 外部 Redis 等不要
-- Kamal / Render / Fly.io から Day 5 で確定予定
+- **Render** (= デプロイ先、詳細は §11)
 - Dev Container (`.devcontainer/`)
 
 **外部連携**
@@ -368,3 +368,88 @@ Section 7 で予告した目玉機能。仕様の核:
 2. **AI API 連携**: プロンプトエンジニアリング + コスト管理 + レイテンシ対策の総合的な学習が必要。試作版を別ブランチで小さく作ってから本体に統合する段階的アプローチを取る想定。
 
 これらは MVP のスコープ外なので、**発表会には影響しない**。本リリース版開発時に、機能リリース計画と並行して学習計画を立てる予定。
+
+---
+
+## 11. デプロイ環境
+
+### 11-1. 採用: Render (Free Tier)
+
+| 候補 | 無料枠 | 半日完了 | 採用 |
+|---|---|---|:---:|
+| **Render** | ⭕ Web Service Free + Postgres Free | ⭐⭐⭐⭐⭐ | ✅ |
+| Kamal + さくら VPS / Hetzner | ❌ VPS 月額必須 | ⭐⭐ | (将来) |
+| Fly.io | △ Trial credit 制 (変動あり) | ⭐⭐⭐ |  |
+
+**採用根拠 4 点**:
+
+1. **完全無料枠** で MVP / 発表会用途を完結できる (スクール期間中の費用ゼロ)
+2. **半日でデプロイ完了可能** (= Day 5 の本番デプロイタスクを後ろ倒さない)
+3. **Render の運用経験あり** (= 詰まり時間の最小化)
+4. **将来の DB 分離運用への移行が楽** (= Free Tier では Solid Trifecta を 1 DB に同居させるが、有料化したら `database.yml` の url を切り替えるだけで Rails 8 標準の 4 DB 構成に戻せる、§11-3 参照)
+
+### 11-2. 構成
+
+```
+[Render Web Service: weight-dialy]   ← Ruby 3.4.9 + Rails 8.1.3
+            │
+            ├─ buildCommand: bin/render-build.sh
+            │      (bundle install / assets:precompile / db:prepare)
+            │
+            └─ startCommand: bundle exec rails server -p $PORT -e production
+                                           │
+                                           ▼
+[Render Postgres Free: weight-dialy-db]
+└── app_production
+    ├── users / step_records / webhook_deliveries     ← アプリデータ
+    ├── solid_cache_entries                           ← Solid Cache 同居
+    ├── solid_queue_*                                 ← Solid Queue 同居
+    └── solid_cable_messages                          ← Solid Cable 同居
+```
+
+Infrastructure as Code として `render.yaml` でこの構成を定義 (= Render Dashboard で「New Blueprint」→ リポジトリ指定で自動構築される)。
+
+### 11-3. Solid Trifecta を 1 DB に同居させた判断 (= Free Tier 制約)
+
+**Rails 8 デフォルト**: `primary` / `cache` / `queue` / `cable` の 4 つの database に分離 (負荷分離 + vacuum 影響回避が目的)。
+
+**今回**: Render Postgres Free Tier は 1 インスタンス 1 database のため、**全部を `app_production` に同居** させる構成を採用 (`config/database.yml` の production セクション参照)。
+
+- テーブル名は prefix (`solid_*`) で名前空間が分かれているので衝突しない
+- 個人開発 / 小規模 (< 数千ユーザー) では負荷分離の効果が誤差レベル
+- DHH も「最初は same-DB で十分、後から分離」を推奨
+
+**有料プラン化時の移行パス** (引き返せるパス):
+- Render UI で Postgres を 3 つ追加 (cache / queue / cable 用)
+- `database.yml` の各セクションの url を新 ENV (`CACHE_DATABASE_URL` 等) に切替
+- `bin/rails db:migrate:cache` 等で新 DB に Solid テーブルを作成
+- `migrations_paths` の構造は同居時も維持しているため、移行時に追加作業ゼロ
+- 所要時間 ~1.5 時間
+
+### 11-4. 初回デプロイ手順
+
+1. **ローカルで credentials を編集** (Google OAuth client_id / secret を入れる)
+   ```bash
+   # VS Code 派 (推奨):
+   EDITOR="code --wait" bin/rails credentials:edit -e production
+   # vim 派:
+   EDITOR=vim bin/rails credentials:edit -e production
+
+   git add config/credentials/production.yml.enc && git commit -m "..."
+   git push origin main
+   ```
+2. **`config/master.key` の中身を控える** (= デプロイ後の Render 環境変数で必要)
+3. **Google OAuth Console** で本番 redirect URI (`https://<your-render-domain>/auth/google_oauth2/callback`) を許可リストに追加
+4. **Render Dashboard** で `New Blueprint` → 本リポジトリを指定 → `render.yaml` が自動検出される
+5. **環境変数を設定** (Render Dashboard → 該当 Service → Environment):
+   - `RAILS_MASTER_KEY` = ローカルの `config/master.key` の中身
+   - `APP_HOST` = Render が割り当てたドメイン (例: `weight-dialy.onrender.com`)
+6. **デプロイ完了後**: ブラウザで `https://<your-render-domain>/` にアクセス → 200 OK 確認
+7. **Google ログイン** → ダッシュボード遷移確認
+
+### 11-5. Sleep 対策 (Free Tier の cold start 回避)
+
+Render Free Tier は **15 分非アクセスで sleep** → 初回アクセス cold start ~30 秒。
+発表会で致命的なため、**GAS (Google Apps Script) で 10 分間隔の warmup ping** を仕込む。詳細は Issue #61 で運用設定済み。
+
+**当日朝の必須チェック**: 発表会当日朝に **GAS の実行ログ** (Apps Script 画面の「実行数」) を確認し、最後の ping が想定通り 10 分以内に動いていることを目視で確認する。warmup が止まっていると iPhone Safari のデフォルト 60 秒タイムアウトに対し cold start 25-40 秒の幅が問題になる可能性がある。

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Render の buildCommand から呼ばれるビルドスクリプト。
+# render.yaml の buildCommand に書くと長くなるため別ファイルに切り出している。
+# errexit: 途中失敗で即座にビルド失敗扱いにする (= 不完全な状態で start させない)。
+
+set -o errexit
+
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+# db:prepare = 「DB が無ければ create + 全 database (primary/cache/queue/cable) を migrate、
+#               あれば migrate のみ」。初回デプロイと再デプロイ両方を 1 コマンドで対応。
+bundle exec rails db:prepare

--- a/config/database.yml
+++ b/config/database.yml
@@ -90,20 +90,18 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
+  # Render Free Tier の 1 Postgres インスタンス制約に合わせ、Solid Trifecta (cache/queue/cable) を
+  # primary DB に同居させる。Solid 系テーブルは prefix (solid_*) で名前空間が分かれており衝突しない。
+  # 将来有料プラン化したら、各 url を個別 ENV (CACHE_DATABASE_URL 等) に切り替えるだけで分離可能 (= migrations_paths は維持)。
   primary: &primary_production
     <<: *default
-    database: app_production
-    username: app
-    password: <%= ENV["APP_DATABASE_PASSWORD"] %>
+    url: <%= ENV["DATABASE_URL"] %>
   cache:
     <<: *primary_production
-    database: app_production_cache
     migrations_paths: db/cache_migrate
   queue:
     <<: *primary_production
-    database: app_production_queue
     migrations_paths: db/queue_migrate
   cable:
     <<: *primary_production
-    database: app_production_cable
     migrations_paths: db/cable_migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,14 +24,14 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # Render は SSL 終端を代行する (= Rails には HTTP で届く) ため、reverse proxy 前提で SSL 仮定する。
+  config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  # 全アクセスを HTTPS に揃え、Strict-Transport-Security と secure cookie を有効化。
+  config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # /up (Rails デフォルトの health check) は HTTPS リダイレクトをスキップ (= Render の health check が HTTP 経由のため)。
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
@@ -57,8 +57,11 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  # Settings 画面の Webhook URL や mailer リンクで使う本番ホスト。Render 上では APP_HOST 環境変数で渡す。
+  # フォールバックは Render が割当てるデフォルトドメイン (= 開発者がドメイン未設定でもデプロイ後即動作する)。
+  app_host = ENV.fetch("APP_HOST", "weight-dialy.onrender.com")
+  config.action_controller.default_url_options = { host: app_host, protocol: "https" }
+  config.action_mailer.default_url_options     = { host: app_host, protocol: "https" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -79,12 +82,11 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # DNS rebinding 対策。Render が割当てるドメイン + APP_HOST 設定値を許可。
+  # 独自ドメイン後付け時は APP_HOST を変更すれば対応可能。
+  config.hosts << app_host
+  config.hosts << /\A[a-z0-9-]+\.onrender\.com\z/
+
+  # /up (health check) は host チェックをスキップ (Render の health check で必要)。
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,45 @@
+# Render Blueprint (Infrastructure as Code).
+# 初回デプロイ: Render Dashboard で「New Blueprint」→ 本リポジトリを指定。
+# 継続デプロイ: main への push を Render が検知して自動デプロイ。
+#
+# 環境変数の sync: false は「Render Dashboard で手動入力」の意味 (= secret は YAML に書かない)。
+# RAILS_MASTER_KEY: ローカルの config/master.key の中身を Dashboard に貼り付け。
+# APP_HOST: Render が発行するドメイン (例: weight-dialy.onrender.com)、確定後に手動設定。
+
+services:
+  - type: web
+    name: weight-dialy
+    runtime: ruby
+    region: singapore   # 日本に最も近いリージョン (= Free Tier で選択可能)
+    plan: free
+    buildCommand: ./bin/render-build.sh
+    startCommand: bundle exec rails server -p $PORT -e production
+    healthCheckPath: /up
+    envVars:
+      - key: RAILS_MASTER_KEY
+        sync: false
+      - key: RAILS_LOG_TO_STDOUT
+        value: "true"
+      - key: RAILS_SERVE_STATIC_FILES
+        value: "true"
+      - key: APP_HOST
+        sync: false
+      - key: DATABASE_URL
+        fromDatabase:
+          name: weight-dialy-db
+          property: connectionString
+      # Free Tier 512MB RAM では worker 1 が安全 (worker 2 + threads 3 = 6 スレッドで OOM リスク)。
+      # Connection pool 合計 (worker 1 × 4 database × 3 threads = 12) も Free Postgres の 97 接続上限内に収まる。
+      - key: WEB_CONCURRENCY
+        value: "1"
+      # Solid Queue を Puma プロセス内に同居させる (= 別 worker service を契約しない、Free Tier 制約)。
+      # config/puma.rb の `plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]` を有効化する。
+      - key: SOLID_QUEUE_IN_PUMA
+        value: "true"
+
+databases:
+  - name: weight-dialy-db
+    plan: free
+    databaseName: app_production
+    user: app
+    region: singapore   # Web Service と同リージョンに揃えてレイテンシ最小化


### PR DESCRIPTION
## Summary

- `render.yaml` で Web Service + Postgres を IaC 化 (Render Dashboard で「New Blueprint」→ 自動構築可能)
- `bin/render-build.sh` で `assets:precompile` + `db:prepare` を自動実行
- `production.rb` に SSL / hosts / default_url_options 設定 (Render の SSL 終端前提)
- `database.yml` の Solid Trifecta を **A 案 (1 DB 同居) で構成** (Free Tier 1 instance 制約対応)
- README §11 にデプロイ環境セクション追加 (採用根拠 + 構成図 + 移行パス + 手順 + sleep 対策)

Closes #37

## 設計判断

詳細は **README §11** に永続化。要点:

### Render 採用根拠 4 点
1. 完全無料枠で MVP / 発表会用途を完結 (スクール期間中の費用ゼロ)
2. 半日で確実に完了 (= 残作業の本番デプロイを後ろ倒さない)
3. Render の運用経験あり (詰まり時間最小化)
4. **将来の DB 分離運用への移行が楽** (= `database.yml` の url を切り替えるだけで Rails 8 標準の 4 DB 構成に戻せる、§11-3 参照)

### A 案 (Solid Trifecta 1 DB 同居) を選んだ理由
Render Postgres Free Tier は 1 インスタンス 1 database 制約のため、4 DB 分離は不可能。
Solid 系テーブルは prefix (`solid_*`) で名前空間が分かれ衝突しない。個人開発 / 小規模では負荷分離効果が誤差レベル。`migrations_paths` を維持しているため、有料化時の移行コストは ~1.5h (= `database.yml` の url 切替のみ)。

## 3 者並列レビュー結果

| レビュアー | 当初判定 | 反映後 |
|---|---|---|
| code-reviewer | ❌ Major rework (Blocker 2 件) | 🟢 (Blocker [1] 反映 / [2] 誤検知 確認済) |
| strategic-reviewer | 🟡 設計見直し (Solid Queue worker 問題) | 🟢 (SOLID_QUEUE_IN_PUMA 反映) |
| design-reviewer | 🟡 修正後 OK | 🟢 (§11-5 当日朝 GAS 確認、§11-4 EDITOR 並記 反映) |

### 反映済み修正
- 🚨 `SOLID_QUEUE_IN_PUMA=true` を render.yaml に追加 (= ジョブ実行 supervisor を Puma 同居)
- ⚠️ `WEB_CONCURRENCY` 2 → 1 (Free Tier 512MB 安全側、connection pool 24 → 12)
- 💡 `config.hosts` 正規表現を `/\A[a-z0-9-]+\.onrender\.com\z/` に厳格化
- 💡 README に当日朝 GAS 確認 + EDITOR 並記

### 別 Issue 化
- Issue #48 拡張: Settings Step 2 の Webhook URL 表示 font-size 調整 (本番 URL 47 文字対応)
- Issue #61: GAS warmup 設定 (本番 URL 確定後にユーザー作業)

## Test plan

### Claude 側 (PR レベル)
- [x] `script/run "bundle exec rspec"` 全 275 examples / 0 failures
- [x] `bundle exec rubocop config/environments/production.rb` no offenses
- [x] `ruby -ryaml -e "YAML.load_file('render.yaml')"` syntax OK
- [x] `bash -n bin/render-build.sh` syntax OK
- [x] `db/cache_schema.rb` `db/queue_schema.rb` `db/cable_schema.rb` 存在確認 (= db:prepare が schema:load 経路で動く前提)
- [x] credentials.yml.enc が git 追跡済み + master.key は ignore 確認

### ユーザー側 (マージ後の手作業、詳細手順は README §11-4)
- [ ] **ローカル credentials 編集**: `EDITOR="code --wait" bin/rails credentials:edit -e production` で Google OAuth client_id/secret 入力 → commit & push
- [ ] **`config/master.key` の中身を控える**
- [ ] **Google OAuth Console** で本番 redirect URI (`https://<your-render-domain>/auth/google_oauth2/callback`) 追加
- [ ] **Render Dashboard** で New Blueprint → 本リポジトリ指定
- [ ] **環境変数設定**: `RAILS_MASTER_KEY` + `APP_HOST`
- [ ] **動作確認**: `https://<your-render-domain>/` 200 OK + Google ログイン成功 + `/up` health check OK
- [ ] **iPad Shortcut の URL** を本番 URL に切替 + 200 OK 確認
- [ ] **Issue #61 (GAS warmup)** に着手して 10 分間隔 ping を開始

🤖 Generated with [Claude Code](https://claude.com/claude-code)