### PR TITLE
fix: render-build.sh で npm install を実行して daisyUI を解決

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -6,6 +6,10 @@
 set -o errexit
 
 bundle install
+# Tailwind 4 + daisyUI 構成では `app/assets/tailwind/application.css` で `@plugin "daisyui";` を参照しており、
+# tailwindcss:build (= assets:precompile の中で走る) が node_modules/daisyui を解決する必要がある。
+# Render の Ruby buildpack は Node.js を同梱するが npm install は自動実行しないため、ここで明示する。
+npm install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 # db:prepare = 「DB が無ければ create + 全 database (primary/cache/queue/cable) を migrate、


### PR DESCRIPTION
## Summary

PR #62 後の Render 初回デプロイで `Error: Can't resolve 'daisyui'` で詰まったため hotfix。

## 原因

- `app/assets/tailwind/application.css` で `@plugin "daisyui";` を参照
- daisyUI は `package.json` の devDependencies (npm package)
- Render の Ruby buildpack は Node.js を同梱するが **`npm install` を自動で走らせない**
- → ビルド時に node_modules/daisyui が無く、tailwindcss:build (assets:precompile 配下) で解決失敗

## 修正

`bin/render-build.sh` に `npm install` を 1 行追加 (= bundle install と assets:precompile の間)。
WHY コメントも添えて後輩教材性を担保。

## Test plan

- [x] `bash -n bin/render-build.sh` syntax OK
- [ ] マージ後、Render 自動再デプロイで `assets:precompile` が通ること
- [ ] `==> Your service is live` が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)