### PR TITLE
fix: A 案同居で Solid Trifecta schema を primary DB に明示 load (Render 502 修正)

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -12,6 +12,26 @@ bundle install
 npm install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-# db:prepare = 「DB が無ければ create + 全 database (primary/cache/queue/cable) を migrate、
-#               あれば migrate のみ」。初回デプロイと再デプロイ両方を 1 コマンドで対応。
+# primary database (app_production) を作成 + schema 反映 + migration 実行。
 bundle exec rails db:prepare
+
+# A 案 (Solid Trifecta cache/queue/cable を primary DB に同居) の場合、`db:prepare` は
+# cache/queue/cable の DATABASE_URL が primary と同じであることを「同 DB 処理済み」と判定して
+# 各 _schema.rb をロードしない (Rails の multi-db 仕様)。
+# 結果として solid_queue_jobs / solid_cache_entries / solid_cable_messages が作られず、
+# Solid Queue supervisor が起動できず Puma 再起動ループに陥る。
+# ここで明示的に各 schema を primary DB に load し、marker テーブル存在チェックで冪等性も確保する。
+bundle exec rails runner '
+  marker_tables = { cache: "solid_cache_entries", queue: "solid_queue_jobs", cable: "solid_cable_messages" }
+  marker_tables.each do |db_name, marker|
+    if ActiveRecord::Base.connection.table_exists?(marker)
+      puts "[#{db_name}] schema already loaded, skipping"
+    else
+      schema_file = Rails.root.join("db/#{db_name}_schema.rb")
+      if schema_file.exist?
+        load schema_file
+        puts "[#{db_name}] loaded #{schema_file.basename}"
+      end
+    end
+  end
+'


### PR DESCRIPTION
## Summary

PR #62 (Issue #37) 後の Render デプロイで **Solid Queue 関連テーブルが作られず** Puma 再起動ループ → 502 Bad Gateway。
A 案 (Solid Trifecta 同居) 固有の Rails multi-db 仕様の罠を回避する hotfix。

## エラーログ

```
PG::UndefinedTable: relation "solid_queue_recurring_tasks" does not exist
[69] Detected Solid Queue has gone away, stopping Puma...
[69] === puma shutdown ===
```

## 原因

A 案では `database.yml` の cache/queue/cable セクションが全て同じ `DATABASE_URL` を参照する。
`db:prepare` は **「同じ DB は処理済み」** と判定して、cache_schema.rb / queue_schema.rb / cable_schema.rb を **load しない** (Rails multi-db の仕様)。
結果、`solid_queue_*` `solid_cache_entries` `solid_cable_messages` テーブルが作られない → Solid Queue supervisor 起動失敗。

## 修正

`bin/render-build.sh` の `db:prepare` の後に、各 schema を **primary DB に明示的に load** する処理を追加。
marker テーブルの存在チェックで冪等性も確保 (= 再デプロイで重複作成しない、データロスなし)。

## 将来の撤退ポイント (= 教材性記録)

有料プラン化で cache/queue/cable を別 DB 化したら、この明示 load ブロックは削除可能。
`db:prepare` だけで完結する Rails 標準構成に戻せる。コメントで該当箇所明示。

## Test plan

- [x] `bash -n bin/render-build.sh` syntax OK
- [ ] マージ後、Render 再デプロイで `[cache] loaded cache_schema.rb` 等のログが出ること
- [ ] `==> Your service is live` の後、Puma が再起動ループに陥らない
- [ ] `https://weight-dialy.onrender.com/up` が 200 を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)