### PR TITLE
fix: Settings Step 3 の iCloud Shortcut リンクを本番 URL 版に更新 (#67)

### DIFF
--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -52,7 +52,7 @@
       下のボタンから iPhone に Shortcut を追加 → 初回実行時に Step 1 でコピーした値を貼り付ければ完了です。
     </p>
     <%= link_to "ショートカットをインストール",
-          "https://www.icloud.com/shortcuts/d2fb3cca3a3e47549577231a011dffee",
+          "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",
           class: "sketch-btn sketch-btn-primary",
           target: "_blank",
           rel: "noopener noreferrer" %>

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Settings", type: :request do
       end
 
       it "Step 3 に iCloud Shortcut の配布リンクを含む" do
-        expect(response.body).to include("https://www.icloud.com/shortcuts/d2fb3cca3a3e47549577231a011dffee")
+        expect(response.body).to include("https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564")
       end
 
       it "Step 3 のボタン文言が「ショートカットをインストール」である" do


### PR DESCRIPTION
## Summary

配布リンク `d2fb3cca...` (= ngrok 時代のスナップショット) を、本番 URL 版を iCloud 再公開して取得した新リンク `7e0199f4...` に更新。

Closes #67

## 経緯

借りた iPhone で配布版 Shortcut 動作確認時に発覚:
```
The endpoint unvaried-ideally-contour.ngrok-free.dev is offline. (ERR_NGROK_3200)
```

iCloud Shortcut の配布版はスナップショット = 古いリンクから追加した Shortcut は ngrok を見続ける。発表会クリティカルなので即時対応。

## Test plan

- [x] `script/run "bundle exec rspec spec/requests/settings_spec.rb"` 36 examples / 0 failures
- [x] `grep -rn "d2fb3cca3a3e47549577231a011dffee"` ヒットゼロ (= 全駆除確認、`feedback_grep_zero_after_fix.md` 流儀)
- [ ] **マージ後、Render 自動再デプロイ完了**
- [ ] **借りた iPhone で**:
  - 古い配布版 Shortcut を削除
  - Settings 画面 → Step 3 のインストールボタンから新リンクで再追加
  - 実行 → クイックルックで `{"accepted": 1}` 確認
- [ ] **本番 Settings 画面の送信ログに反映** されることを確認

## Out of scope

- 古い iCloud リンクの停止操作 (Apple 仕様上無効化されない、放置)
- 新リンクからの初回 HealthKit 権限承認の案内 (= Issue #48 指摘 4 で対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)