### PR TITLE
feat: Settings Step 3 に HealthKit 権限許可の案内を追加 (#48 指摘 4)

### DIFF
--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -49,7 +49,7 @@
   <div class="sketch-box" style="margin-bottom: 32px;">
     <p class="sketch-h" style="margin-bottom: 8px;">🎉 あとはショートカットを入れるだけ</p>
     <p class="sketch-body-text" style="margin-bottom: 16px;">
-      下のボタンから iPhone に Shortcut を追加 → 初回実行時に Step 1 でコピーした値を貼り付ければ完了です。
+      下のボタンから iPhone に Shortcut を追加 → 初回実行時に「<strong>ヘルスケアへのアクセス</strong>」を許可 → Step 1 でコピーした値を貼り付ければ完了です。
     </p>
     <%= link_to "ショートカットをインストール",
           "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe "Settings", type: :request do
         expect(response.body).to include("ショートカットをインストール")
       end
 
+      it "Step 3 に HealthKit 権限許可の案内文言を含む (= 配布版の必須案内、借りた iPhone 検証で発覚)" do
+        # <strong> 等の HTML 強調タグに依存しないよう、キーワード「ヘルスケアへのアクセス」と「許可」を別々に検査
+        expect(response.body).to include("ヘルスケアへのアクセス")
+        expect(response.body).to include("を許可")
+      end
+
       it "iCloud リンクが target=\"_blank\" + rel=\"noopener noreferrer\" 付きで描画される" do
         # 属性順は Rails / link_to に依存し変動しうるため、a タグ抽出後に個別検査する
         link_tag = response.body[%r{<a\b[^>]*href="https://www\.icloud\.com/shortcuts/[^"]+"[^>]*>}]


### PR DESCRIPTION
## Summary

5/4 午後の借りた iPhone での配布版動作確認時に発覚した致命的ハマりポイントへの対応:

```
ショートカットには歩数データへのアクセス権がありません
```

→ Settings Step 3 本文に **「ヘルスケアへのアクセス」を許可** ステップを追加。

## 変更内容

### show.html.erb (Step 3 本文)

**Before**:
```
下のボタンから iPhone に Shortcut を追加 → 初回実行時に Step 1 でコピーした値を貼り付ければ完了です。
```

**After**:
```
下のボタンから iPhone に Shortcut を追加 → 初回実行時に「<strong>ヘルスケアへのアクセス</strong>」を許可 → Step 1 でコピーした値を貼り付ければ完了です。
```

→ ユーザー行動順 (= 1.追加 / 2.ヘルスケア許可 / 3.token 入力) を 1 文に網羅。
→ `<strong>` で「ヘルスケアへのアクセス」を強調 (= design-reviewer 指摘でスキャン耐性向上)。

### spec
HTML タグ非依存の二段検査で「ヘルスケアへのアクセス」「を許可」を含むことを期待。

## Closes

Issue #48 の **指摘 4 のみ**。他指摘 (0/1/2/3 + design 提案 sketch-small 警告追加) は引き続き残る。

## レビュー体制

- code/strategic-reviewer: skip (= 1 文追加 + spec 1 件、ロジック変更なし)
- design-reviewer: 通過 (= `<strong>` 強調反映、別案 (sketch-small ⚠️ 追加) は Issue #48 に記録)

## Test plan

- [x] `script/run "bundle exec rspec spec/requests/settings_spec.rb"` 37 examples / 0 failures
- [ ] **マージ後、本番 Settings 画面 Step 3 で「ヘルスケアへのアクセス」が太字表示** されることを目視
- [ ] **発表会で同期が触る時の体験**: Step 3 ボタンタップ → ヘルスケア許可ダイアログ → 許可 → token 入力 → 動作、の流れが詰まらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)