### PR TITLE
feat: カロリー貯金システム v1.0 (= 貯カロリー) を実装 (#41)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -190,6 +190,16 @@ body {
   border-bottom: 2px solid var(--ink); padding-bottom: 14px;
 }
 
+/* ---- 貯カロリー (Issue #41 = アプリ哲学のステップ① 核機能) ----
+   メイン KPI として大きく表示。矢印・色分けは「数値プレッシャー回避」の原則で意図的に持たない。
+   flex + flex-wrap で 6 桁以上 (= 100,000 kcal+) になっても数値と単位「kcal」が綺麗に折り返す。 */
+.sketch-savings-main {
+  display: flex; align-items: baseline; flex-wrap: wrap; gap: 4px;
+  font-family: 'Caveat', cursive; font-weight: 700;
+  font-size: 48px; line-height: 1.1; color: var(--ink);
+  margin-top: 4px;
+}
+
 /* ---- メイングリッド (チャート 1.5fr + サイドパネル 1fr) ---- */
 .sketch-main-grid {
   display: grid;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,9 @@ class HomeController < ApplicationController
     @today_record    = @records.find { |r| r.recorded_on == Date.current } || @records.last
     @streak          = StreakCalculatorService.call(@records)
     @advice          = CalorieAdviceService.call(@today_record&.estimated_kcal.to_i)
+    # 貯カロリー (= 月リセット + 累計の二段構造) はチャート用 30 日 records とは別に
+    # 全期間 records を渡して算出する (= 累計 total は全期間でないと意味が出ないため)。
+    @calorie_savings = CalorieSavingsService.call(fetch_calorie_records(@dashboard_state))
   end
 
   private
@@ -27,6 +30,16 @@ class HomeController < ApplicationController
                   .where(recorded_on: 30.days.ago.to_date..Date.current)
                   .order(:recorded_on)
                   .to_a
+    else
+      DemoDataService.call
+    end
+  end
+
+  # 貯カロリー算出用の records は 全期間 を返す (= 累計 total を正確に計算するため)。
+  # demo state では demo の 30 日分 (= fetch_records と同一) で代替。
+  def fetch_calorie_records(state)
+    if state == :iphone_with_data
+      current_user.step_records.order(:recorded_on).to_a
     else
       DemoDataService.call
     end

--- a/app/services/calorie_savings_service.rb
+++ b/app/services/calorie_savings_service.rb
@@ -1,0 +1,51 @@
+# 歩数記録配列から「貯カロリー」(= 歩数を kcal 換算した累積) を算出する。
+#
+# 設計思想:
+#   - アプリの 3 ステップ思想 (① 罪悪感を減らす → ② 習慣化 → ③ ガチ運動) のステップ ① の核機能。
+#   - 「貯カロリー」直球造語で「kcal = 罪」を「kcal = 貯めるもの」に能動的反転。
+#   - 月リセット + 累計の二段構造で、ステップ ① (累計達成感) と ステップ ② (月単位習慣化) 両対応。
+#
+# 数値プレッシャー回避:
+#   - 戻り値は this_month / last_month / total の 3 値だけ (= 並列表示用)。
+#   - 前月比 / 矢印 / 色分けはこの service では計算しない (= UI 側でも提示しない方針)。
+#   - 詳細根拠: memory project_weight_dialy_three_step_philosophy.md
+#
+# 換算式:
+#   - 1 歩 = 0.04 kcal (= 体重 70kg 前提のおおよその平均値)
+#   - 体重設定を要求しないことで、ステップ ① の人を「面倒くさい → 離脱」から守る。
+#   - 精密化は v1.3+ (Issue #43 ガチ運動モード) で別 service として分岐予定。
+class CalorieSavingsService
+  CALORIES_PER_STEP = 0.04
+
+  # @param records [Array<#recorded_on, #steps>] StepRecord または DemoRecord の配列 (全期間想定)
+  # @return [Hash{Symbol=>Integer}] { this_month:, last_month:, total: } 各 kcal を整数で返す
+  def self.call(records)
+    return zero_result if records.blank?
+
+    today = Date.current
+    this_month_range = today.beginning_of_month..today.end_of_month
+    last_month_date  = today - 1.month
+    last_month_range = last_month_date.beginning_of_month..last_month_date.end_of_month
+
+    {
+      this_month: kcal_in_range(records, this_month_range),
+      last_month: kcal_in_range(records, last_month_range),
+      total:      kcal_total(records)
+    }
+  end
+
+  def self.zero_result
+    { this_month: 0, last_month: 0, total: 0 }
+  end
+
+  def self.kcal_in_range(records, range)
+    steps_sum = records.select { |r| range.cover?(r.recorded_on) }.sum(&:steps)
+    (steps_sum * CALORIES_PER_STEP).round
+  end
+
+  def self.kcal_total(records)
+    (records.sum(&:steps) * CALORIES_PER_STEP).round
+  end
+
+  private_class_method :zero_result, :kcal_in_range, :kcal_total
+end

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -1,7 +1,8 @@
 <%#
   Dashboard partial — Wireframe v3 の sketchy 再現版。
-  ローカル変数: display_name, records, today_record, streak, advice
+  ローカル変数: display_name, records, today_record, streak, advice, calorie_savings
   duck typing: records の各要素は recorded_on / steps / distance_meters / flights_climbed / estimated_kcal を持つ。
+  calorie_savings: { this_month:, last_month:, total: } 各 kcal を整数で保持 (CalorieSavingsService 由来)。
 %>
 
 <%# ---- SVG チャート計算 ---- %>
@@ -85,6 +86,20 @@
   <div style="text-align: right;">
     <div class="sketch-small">きょうの消費</div>
     <div class="sketch-hh">+<%= today_kcal %> <span class="sketch-hl-yellow">kcal</span></div>
+  </div>
+</div>
+
+<%# ---- 貯カロリー (Issue #41: アプリ哲学のステップ① 核機能。月リセット + 累計の二段構造)
+     数値プレッシャー回避: 矢印・色分け・前月比計算なし、並列表示のみ (= memory three_step_philosophy 参照)。 %>
+<div class="sketch-box sketch-savings" style="margin-bottom: 14px;">
+  <div class="sketch-label">今月の貯カロリー</div>
+  <div class="sketch-savings-main">
+    <%= number_with_delimiter(calorie_savings[:this_month]) %>
+    <span class="sketch-small">kcal</span>
+  </div>
+  <div class="sketch-small" style="margin-top: 6px;">
+    前月: <%= number_with_delimiter(calorie_savings[:last_month]) %> kcal ／
+    これまでの合計: <%= number_with_delimiter(calorie_savings[:total]) %> kcal
   </div>
 </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,9 +23,10 @@
 <%# Dashboard 本体 (全状態共通) %>
 <div class="sketch-dashboard">
   <%= render "dashboard",
-        display_name: @display_name,
-        records:      @records,
-        today_record: @today_record,
-        streak:       @streak,
-        advice:       @advice %>
+        display_name:    @display_name,
+        records:         @records,
+        today_record:    @today_record,
+        streak:          @streak,
+        advice:          @advice,
+        calorie_savings: @calorie_savings %>
 </div>

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -153,6 +153,23 @@ RSpec.describe "Home", type: :request do
       it "ログアウトボタンを表示する" do
         expect(response.body).to include("ログアウト")
       end
+
+      # 貯カロリー (Issue #41): 9000 歩 * 0.04 = 360 kcal
+      it "「今月の貯カロリー」見出しを表示する" do
+        expect(response.body).to include("今月の貯カロリー")
+      end
+
+      it "貯カロリーのメイン数値 (sketch-savings-main) を描画する" do
+        expect(response.body).to include("sketch-savings-main")
+      end
+
+      it "今月の貯カロリー値 360 kcal を含む (= 9000 歩 * 0.04 を四捨五入で number_with_delimiter)" do
+        expect(response.body).to include("360")
+      end
+
+      it "累計表示「これまでの合計:」の文言を含む (= カジュアル層配慮、design-reviewer 指摘)" do
+        expect(response.body).to include("これまでの合計:")
+      end
     end
 
     # ─────────────────────────────────────────────────

--- a/spec/services/calorie_savings_service_spec.rb
+++ b/spec/services/calorie_savings_service_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe CalorieSavingsService do
+  # DemoDataService::DemoRecord は recorded_on / steps / distance_meters / flights_climbed を持つ Struct
+  # (= duck type で StepRecord と互換)。トップレベル定数化すると streak spec と衝突するため直接参照する。
+
+  let(:today)         { Date.current }
+  let(:this_month_15) { today.beginning_of_month + 14.days }
+  let(:last_month_15) { (today - 1.month).beginning_of_month + 14.days }
+  let(:two_months_ago_day) { (today - 2.months).beginning_of_month + 4.days }
+
+  def build_record(date, steps)
+    DemoDataService::DemoRecord.new(date, steps, 0, 0)
+  end
+
+  describe ".call" do
+    context "空配列" do
+      it "全 0 のハッシュを返す" do
+        expect(CalorieSavingsService.call([])).to eq(this_month: 0, last_month: 0, total: 0)
+      end
+    end
+
+    context "今月のみ 1 件 (1000 歩)" do
+      let(:records) { [ build_record(this_month_15, 1000) ] }
+
+      it "this_month = 40 kcal (= 1000 * 0.04)" do
+        expect(CalorieSavingsService.call(records)[:this_month]).to eq(40)
+      end
+
+      it "last_month = 0 kcal" do
+        expect(CalorieSavingsService.call(records)[:last_month]).to eq(0)
+      end
+
+      it "total = 40 kcal (= this_month と一致)" do
+        expect(CalorieSavingsService.call(records)[:total]).to eq(40)
+      end
+    end
+
+    context "前月のみ 1 件 (5000 歩)" do
+      let(:records) { [ build_record(last_month_15, 5000) ] }
+
+      it "this_month = 0 kcal" do
+        expect(CalorieSavingsService.call(records)[:this_month]).to eq(0)
+      end
+
+      it "last_month = 200 kcal (= 5000 * 0.04)" do
+        expect(CalorieSavingsService.call(records)[:last_month]).to eq(200)
+      end
+
+      it "total = 200 kcal" do
+        expect(CalorieSavingsService.call(records)[:total]).to eq(200)
+      end
+    end
+
+    context "今月 + 前月 + 2 ヶ月前 の混在" do
+      let(:records) do
+        [
+          build_record(two_months_ago_day, 10000),  # 2 ヶ月前: 400 kcal
+          build_record(last_month_15, 5000),         # 前月:    200 kcal
+          build_record(this_month_15, 2500)          # 今月:    100 kcal
+        ]
+      end
+
+      it "this_month は今月分のみ (100 kcal)" do
+        expect(CalorieSavingsService.call(records)[:this_month]).to eq(100)
+      end
+
+      it "last_month は前月分のみ (200 kcal)" do
+        expect(CalorieSavingsService.call(records)[:last_month]).to eq(200)
+      end
+
+      it "total は全期間 (700 kcal)" do
+        expect(CalorieSavingsService.call(records)[:total]).to eq(700)
+      end
+    end
+
+    context "1 歩 = 0.04 kcal の換算式 (整数四捨五入)" do
+      it "12 歩 → 0 kcal (12 * 0.04 = 0.48 → 0)" do
+        records = [ build_record(this_month_15, 12) ]
+        expect(CalorieSavingsService.call(records)[:total]).to eq(0)
+      end
+
+      it "13 歩 → 1 kcal (13 * 0.04 = 0.52 → 1)" do
+        records = [ build_record(this_month_15, 13) ]
+        expect(CalorieSavingsService.call(records)[:total]).to eq(1)
+      end
+
+      it "10000 歩 → 400 kcal (10000 * 0.04 = 400.0)" do
+        records = [ build_record(this_month_15, 10000) ]
+        expect(CalorieSavingsService.call(records)[:total]).to eq(400)
+      end
+    end
+
+    context "今月の月初 (= today.beginning_of_month) の境界値" do
+      it "月初 1 日のレコードも this_month に含む" do
+        records = [ build_record(today.beginning_of_month, 1000) ]
+        expect(CalorieSavingsService.call(records)[:this_month]).to eq(40)
+      end
+    end
+
+    context "前月の月末 (= 1 ヶ月前の月末) の境界値" do
+      it "前月末日のレコードを last_month に含む" do
+        last_month_end = (today - 1.month).end_of_month
+        records = [ build_record(last_month_end, 1000) ]
+        expect(CalorieSavingsService.call(records)[:last_month]).to eq(40)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

アプリの **3 ステップ思想 (= ① 罪悪感を減らす → ② 習慣化 → ③ ガチ運動) のステップ ① 核機能** を実装。
歩数を kcal 換算 (`1 歩 = 0.04 kcal`) し、月リセット + 累計の二段構造でダッシュボードに **「貯カロリー」** として大きく表示する。

Closes #41

## 設計判断 (= memory `project_weight_dialy_three_step_philosophy.md` 参照)

### 採用したもの
- **コピー「貯カロリー」直球造語**: 「貯金: 円」より直感、weight_dialy 独自ブランド語、「kcal = 罪」を「kcal = 貯めるもの」に能動的反転
- **月リセット + 累計の二段**: ステップ ① 累計達成感 + ステップ ② 月単位習慣化 両対応 (= ユーザー判断 c)
- **数値プレッシャー回避**: 矢印 / 色分け / 前月比計算なし、並列表示のみ ("前月比はそういう考え方もできるというラインで留める")
- **固定換算式 `1 歩 = 0.04 kcal`**: 体重設定を要求しない (= ステップ ① の人を「面倒くさい → 離脱」から守る)

### 不採用にしたもの (永続記録)
- **案 D 銀行口座シミュレーション**: ゲーム化が苦手な人を疎外、ステップ ① と矛盾、永続不採用
- **案 B 残高式 (摂取カロリー出金)**: v1.2 以降 (食事記録機能必要のため)

## 実装

| 層 | ファイル | 内容 |
|---|---|---|
| service | `app/services/calorie_savings_service.rb` (新規) | records 配列ベース、duck typing で StepRecord/DemoRecord 両対応、`{ this_month:, last_month:, total: }` を返す |
| controller | `app/controllers/home_controller.rb` | `@calorie_savings` 追加、全期間 records を fetch |
| view | `app/views/home/_dashboard.html.erb` | トップバー直下に「今月の貯カロリー」セクション、48px Caveat で主役表示 |
| view | `app/views/home/index.html.erb` | render "dashboard" の local 変数に `calorie_savings` 追加 |
| CSS | `app/assets/stylesheets/sketchy.css` | `.sketch-savings-main` 新規 (= flex baseline + flex-wrap でモバイル数値折り返し対応) |
| spec | `spec/services/calorie_savings_service_spec.rb` (新規) | 15 examples (= 空配列 / 単一月 / 月跨ぎ / 換算精度 / 月境界値) |
| spec | `spec/requests/home_spec.rb` | 4 examples 追加 (= 「今月の貯カロリー」見出し / sketch-savings-main / 360 kcal / これまでの合計) |

## 3 者並列レビュー結果

| レビュアー | 当初判定 | 反映後 |
|---|---|---|
| code-reviewer | 🟡 Should fix 1 件 + Nit 3 件 | 🟢 (Should fix は #72 別 Issue 化、Nit のうち 2 件は反映 / 1 件は #73 別 Issue 化) |
| strategic-reviewer | 🟢 進めてよい | 🟢 (思想とコード整合性「ほぼ完璧」評価、「思想を 3 箇所にコメント」が教材性最大化) |
| design-reviewer | 🟡 Should fix 2 件 + 提案 2 件 | 🟢 (モバイル折り返し対策 / 累計→これまでの合計 反映、励ましコピー = #70 / 食べ物換算 = #71 別 Issue 化) |

### 反映済み修正
- ⚠️ モバイル折り返し対策: `.sketch-savings-main` に `display: flex; align-items: baseline; flex-wrap: wrap; gap: 4px` 追加 (= 6 桁以上で崩れ予防)
- ⚠️ 「累計:」→「これまでの合計:」 (= カジュアル層配慮)

## Test plan

- [x] `script/run "bundle exec rspec"` 全 295 examples / 0 failures
- [x] `bundle exec rubocop` 4 files / no offenses
- [x] CalorieSavingsService 単体 spec 15 examples (空配列 / 月跨ぎ / 換算精度 / 月境界値)
- [x] dashboard request spec 4 examples (見出し / クラス / 値 / コピー)
- [ ] **マージ後、本番ダッシュボードで「今月の貯カロリー」が大きく表示されることを目視**
- [ ] **iPhone Safari で 375px 折り返しが発生しないことを確認**
- [ ] **次の月初 (= 6/1) に「今月: 0 kcal」表示が出てきた時の体験**を観察 → 必要なら #70 着手判断

## Out of scope (別 Issue 化済み)

- #70 月初ゼロ励ましコピー (polish)
- #71 食べ物換算 (feature 拡張、CalorieEquivalentService 新規)
- #72 home_controller の SQL 集計化 (perf 改善、長期運用時)
- #73 service refactor (class << self 統一 + i18n delimiter 明示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)