### PR TITLE
feat: rails-i18n 導入 + デフォルトロケール :ja 固定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,10 @@ gem "omniauth-rails_csrf_protection"
 # Issue #42: 固定リスト → AI 動的生成への切替、フォールバック付き
 gem "anthropic"
 
+# 日本語ロケール (= time_ago_in_words / number_with_delimiter / 各種フォーマット)
+# 入れないと "about 5 minutes 前" のような英日混在表示になる
+gem "rails-i18n"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -471,6 +474,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.3)
+  rails-i18n
   rspec-rails
   rubocop-rails-omakase
   solid_cable

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,11 @@ module App
     # 表示時刻を JST に統一する。DB 保存は UTC のまま (= active_record.default_timezone デフォルト :utc を維持)。
     # DB を UTC で持つことで、将来海外ユーザー対応や per-user time_zone を導入する際の移行コストがゼロ。
     config.time_zone = "Tokyo"
+
+    # I18n の標準ロケールを日本語に固定 (= rails-i18n gem で日本語化された各種フォーマットが効く)。
+    # 主な効果: time_ago_in_words が「約 5 分」表記に / number_with_delimiter のロケール対応 / I18n.t の :ja 翻訳。
+    # 将来海外展開時は per-user locale 切替を検討、まずは MVP として ja 固定。
+    config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.


### PR DESCRIPTION
## Summary

- Gemfile に `rails-i18n` 追加
- `config.i18n.default_locale = :ja` 設定
- これにより `time_ago_in_words` 等のヘルパーが日本語表示になる

## 経緯

PR #76 (Issue #42 = AI 化) 後の polish 集 PR (= feature/polish-settings-dashboard) で `time_ago_in_words` を使う Issue #58「最終送信: N 分前」を実装中、design-reviewer が **「about 5 minutes 前」のような英日混在表示** を発見。
原因: `rails-i18n` 未導入 + `default_locale` が `:en` のまま。

polish 集 PR より先に i18n 化を main に入れる方が:
- スコープ純粋 (= polish 集と切り離せる)
- 全アプリで日本語化の恩恵 (= 既存の time_ago_in_words / number_with_delimiter 等もまとめて改善)

## Test plan

- [x] `script/run "bundle exec rspec"` 全 312 examples / 0 failures
- [x] Rubocop 影響なし (= config 1 行 + Gemfile 1 行)
- [ ] **マージ後**: 本番 dashboard で `time_ago_in_words` 出る箇所 (= settings 送信ログ等) が日本語表記になることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)