### PR TITLE
feat: Settings/dashboard polish 4 件まとめ (#48 #58 #75)

### DIFF
--- a/app/services/calorie_advice_service.rb
+++ b/app/services/calorie_advice_service.rb
@@ -8,7 +8,9 @@
 # - 数値プレッシャー回避: AI 出力にも「強要表現禁止」をプロンプトで指示
 # - 詳細根拠: memory project_weight_dialy_three_step_philosophy.md
 class CalorieAdviceService
-  Result = Struct.new(:headline, :items, :button_label, keyword_init: true)
+  # ai_used: AI 経路で生成されたかのフラグ。dashboard で「Powered by Claude」バッジ表示の出し分けに使う (Issue #75)。
+  # AI 成功時 true / Static フォールバック時 false。ユーザーには UI 出力にしか影響せず PII は含めない。
+  Result = Struct.new(:headline, :items, :button_label, :ai_used, keyword_init: true)
   Item   = Struct.new(:name, :kcal, :label, keyword_init: true)
 
   # ヘッドラインは固定 (= AI 生成にせず一貫したブランドトーンを維持、レイテンシ短縮)。
@@ -23,16 +25,17 @@ class CalorieAdviceService
     if ai_available?
       items = Ai.call(estimated_kcal)
       Rails.logger.info("[CalorieAdviceService] AI suggestion ok (kcal=#{estimated_kcal}, items=#{items.size})")
+      Result.new(headline: HEADLINE, items: items, button_label: BUTTON_LABEL, ai_used: true)
     else
       items = Static.call(estimated_kcal)
+      Result.new(headline: HEADLINE, items: items, button_label: BUTTON_LABEL, ai_used: false)
     end
-    Result.new(headline: HEADLINE, items: items, button_label: BUTTON_LABEL)
   rescue StandardError => e
     # API failure / timeout / rate limit / JSON parse error すべて広く受けてフォールバック。
     # 細粒度の制御 (= 例外別の retry 等) は polish フェーズで Issue 化して別途。
     Rails.logger.warn("[CalorieAdviceService] AI failed (#{e.class}: #{e.message.truncate(120)}), falling back to static")
     static_items = Static.call(estimated_kcal)
-    Result.new(headline: HEADLINE, items: static_items, button_label: BUTTON_LABEL)
+    Result.new(headline: HEADLINE, items: static_items, button_label: BUTTON_LABEL, ai_used: false)
   end
 
   def self.ai_available?

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -197,6 +197,13 @@
               </li>
             <% end %>
           </ul>
+          <%# Issue #75: AI 経路で生成された時のみ「Powered by Claude」を控えめに表示 (= フォールバック時は隠す)。
+              ユーザーへの透明性 + 発表会での教材性アピール用。 %>
+          <% if advice.ai_used %>
+            <div class="sketch-small" style="margin-top: 6px; color: var(--muted); font-size: 12px;">
+              Powered by Claude (Anthropic)
+            </div>
+          <% end %>
           <div style="margin-top: 10px;">
             <span class="sketch-btn" style="cursor: default; opacity: 0.6;"
                   title="この機能は近日公開予定です">

--- a/app/views/settings/_webhook_delivery_history.html.erb
+++ b/app/views/settings/_webhook_delivery_history.html.erb
@@ -7,6 +7,11 @@
       まだ Shortcut からの送信はありません。Step 3 のボタンからインストールしてください。
     </p>
   <% else %>
+    <%# Issue #58: セクション冒頭に最終送信時刻を 1 行で表示 (= 直近状態が即座に把握できる)。
+        @webhook_deliveries は received_at desc 順で取得済みなので first が最新。 %>
+    <p class="sketch-small" style="margin: 0 0 10px; color: var(--ink-2);">
+      最終送信: <strong><%= time_ago_in_words(@webhook_deliveries.first.received_at) %>前</strong>
+    </p>
     <ul class="sketch-webhook-history">
       <% @webhook_deliveries.each do |delivery| %>
         <li class="sketch-webhook-history-item">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -32,7 +32,8 @@
     <p class="sketch-label" style="margin-bottom: 8px;">iPhone のショートカットアプリで使う URL</p>
 
     <div data-controller="copy" data-copy-text-value="<%= @webhook_url %>">
-      <code style="display: block; font-size: 15px; word-break: break-all; background: var(--paper-2); border: 1px solid var(--ink); border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; font-family: monospace; line-height: 1.4;">
+      <%# 本番 URL は 47 文字あり 375px モバイル幅で 3-4 行に折り返すため font-size は 13px に詰める (Issue #48 指摘 1) %>
+      <code style="display: block; font-size: 13px; word-break: break-all; background: var(--paper-2); border: 1px solid var(--ink); border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; font-family: monospace; line-height: 1.4;">
         <%= @webhook_url %>
       </code>
       <button type="button"
@@ -44,22 +45,45 @@
     </div>
   </div>
 
-  <%# Step 3: iCloud 公開済み Shortcut の配布リンク %>
-  <p class="sketch-label" style="margin-bottom: 6px;">Step 3</p>
-  <div class="sketch-box" style="margin-bottom: 32px;">
-    <p class="sketch-h" style="margin-bottom: 8px;">🎉 あとはショートカットを入れるだけ</p>
-    <p class="sketch-body-text" style="margin-bottom: 16px;">
-      下のボタンから iPhone に Shortcut を追加 → 初回実行時に「<strong>ヘルスケアへのアクセス</strong>」を許可 → Step 1 でコピーした値を貼り付ければ完了です。
-    </p>
-    <%= link_to "ショートカットをインストール",
-          "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",
-          class: "sketch-btn sketch-btn-primary",
-          target: "_blank",
-          rel: "noopener noreferrer" %>
-    <p class="sketch-small" style="margin: 8px 0 0;">タップで iCloud が開きます</p>
-  </div>
+  <%# Step 3: iCloud 公開済み Shortcut の配布リンク。
+      Issue #48 指摘 0: 受信ログがある = 既に Shortcut 導入済みなので、フルサイズ案内は隠す。
+      代わりに送信ログセクションの後に「別の端末で再追加したい場合はこちら」の小リンクを出して再追加導線を確保。
+
+      ⚠️ 仕様メモ: @webhook_deliveries は SettingsController で WEBHOOK_HISTORY_LIMIT (= 5) 件のみ取得しているため、
+      この `empty?` 判定は「全期間の受信履歴有無」ではなく「直近 5 件の窓に何かあるか」の判定。
+      全件 1000+ あっても直近 5 件が unauthorized 状態 (= 表示対象外) なら Step 3 が再表示される設計。
+      意図: 「直近に動作している実績があるか」を見たい (= 古い履歴より最近の動作実績を信頼)。
+      `current_user.webhook_deliveries.exists?` に変えれば全件判定になるが、追加クエリ発生 + 「最近壊れてる人にも案内出ない」問題があるため不採用。 %>
+  <% if @webhook_deliveries.empty? %>
+    <p class="sketch-label" style="margin-bottom: 6px;">Step 3</p>
+    <div class="sketch-box" style="margin-bottom: 32px;">
+      <p class="sketch-h" style="margin-bottom: 8px;">🎉 あとはショートカットを入れるだけ</p>
+      <p class="sketch-body-text" style="margin-bottom: 16px;">
+        下のボタンから iPhone に Shortcut を追加 → 初回実行時に「<strong>ヘルスケアへのアクセス</strong>」を許可 → Step 1 でコピーした値を貼り付ければ完了です。
+      </p>
+      <%= link_to "ショートカットをインストール",
+            "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",
+            class: "sketch-btn sketch-btn-primary",
+            target: "_blank",
+            rel: "noopener noreferrer" %>
+      <p class="sketch-small" style="margin: 8px 0 0;">タップで iCloud が開きます</p>
+    </div>
+  <% end %>
 
   <%= render "webhook_delivery_history" %>
+
+  <% if @webhook_deliveries.any? %>
+    <%# 受信ログがある時の再追加導線 (= Issue #48 指摘 0)。
+        Step 3 を非表示にした代わりに、別端末でも追加したい人向けの控えめなリンク。 %>
+    <p class="sketch-small" style="text-align: center; margin: 8px 0 24px; color: var(--muted);">
+      ショートカットを別の端末に追加したい場合は
+      <%= link_to "こちら",
+            "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",
+            target: "_blank",
+            rel: "noopener noreferrer",
+            style: "color: var(--ink); text-decoration: underline;" %>
+    </p>
+  <% end %>
 
   <%# 危険ゾーン: トークン再生成 %>
   <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5;">

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -111,6 +111,15 @@ RSpec.describe "Settings", type: :request do
         it "プレースホルダー「まだ Shortcut からの送信はありません」を表示する" do
           expect(response.body).to include("まだ Shortcut からの送信はありません")
         end
+
+        # Issue #48 指摘 0: 受信ログ無しなら従来通り Step 3 をフルサイズ表示
+        it "Step 3 のフル案内 (= 「あとはショートカットを入れるだけ」) を表示する" do
+          expect(response.body).to include("あとはショートカットを入れるだけ")
+        end
+
+        it "Step 3 非表示時の再追加リンク (= 「別の端末に追加したい」) は表示しない" do
+          expect(response.body).not_to include("別の端末に追加したい")
+        end
       end
 
       context "success の WebhookDelivery が 1 件あるとき" do
@@ -136,6 +145,21 @@ RSpec.describe "Settings", type: :request do
 
         it "プレースホルダーを表示しない" do
           expect(response.body).not_to include("まだ Shortcut からの送信はありません")
+        end
+
+        # Issue #58: 受信ログがある時はセクション冒頭に「最終送信」表示
+        it "「最終送信:」の文言を表示する" do
+          expect(response.body).to include("最終送信:")
+        end
+
+        # Issue #48 指摘 0: 受信ログがある = Step 3 のフル案内を非表示にする
+        it "Step 3 のフル案内 (= 「あとはショートカットを入れるだけ」) を表示しない" do
+          expect(response.body).not_to include("あとはショートカットを入れるだけ")
+        end
+
+        # Issue #48 指摘 0: 代わりに再追加導線リンクを控えめに表示
+        it "「別の端末に追加したい場合はこちら」の再追加リンクを表示する" do
+          expect(response.body).to include("別の端末に追加したい")
         end
       end
 

--- a/spec/services/calorie_advice_service_spec.rb
+++ b/spec/services/calorie_advice_service_spec.rb
@@ -145,6 +145,10 @@ RSpec.describe CalorieAdviceService do
         allow(Rails.logger).to receive(:info)
       end
 
+      it "Result.ai_used が true (= Powered by Claude バッジ表示用、Issue #75)" do
+        expect(CalorieAdviceService.call(kcal).ai_used).to be true
+      end
+
       it "AI が返した items をそのまま Result.items に詰める" do
         expect(CalorieAdviceService.call(kcal).items.map(&:name)).to eq([ "AI 提案 A", "AI 提案 B", "AI 提案 C" ])
       end
@@ -168,6 +172,10 @@ RSpec.describe CalorieAdviceService do
         CalorieAdviceService.call(kcal)
         expect(Rails.logger).to have_received(:warn).with(/AI failed.*falling back to static/)
       end
+
+      it "Result.ai_used が false (= Powered by Claude バッジ非表示、Issue #75)" do
+        expect(CalorieAdviceService.call(kcal).ai_used).to be false
+      end
     end
 
     context "credentials に api_key が無い時 (= test/development デフォルト)" do
@@ -180,6 +188,10 @@ RSpec.describe CalorieAdviceService do
         expect(CalorieAdviceService::Ai).not_to receive(:call)
         result = CalorieAdviceService.call(kcal)
         expect(result.items.size).to eq(3)
+      end
+
+      it "Result.ai_used が false" do
+        expect(CalorieAdviceService.call(kcal).ai_used).to be false
       end
     end
   end


### PR DESCRIPTION
## Summary

発表会前最終仕上げ。性格が近い polish 4 件を 1 PR にまとめて時間効率化。

| 項目 | Issue | 内容 |
|---|---|---|
| A | #48 指摘 1 | Step 2 URL の font-size 15px → 13px (= 本番 47 文字 URL のモバイル折り返し対策) |
| B | #75 | dashboard AI カードに「Powered by Claude」バッジ (= AI 成功時のみ、教材性 + 発表会アピール) |
| C | #58 | 送信ログセクション冒頭に「最終送信: 約 X 分前」表示 |
| D | #48 指摘 0 | 受信ログあり時に Step 3 完全非表示 + 「別の端末に追加したい場合はこちら」再追加リンク |

Closes #48 #58 #75

## 設計判断

### B (ai_used フラグ) の Result Struct 拡張
`CalorieAdviceService::Result` に `:ai_used` を keyword_init で追加。AI 成功時 true / Static フォールバック時 false。view で 1 行 if 分岐で出し分けが可能、将来 v1.1 で activity log 追加時に `:source` enum 化への進化パスも自然。

### D (Step 3 動的表示) の 5 件窓判定
`@webhook_deliveries.empty?` は SettingsController の `WEBHOOK_HISTORY_LIMIT (= 5)` 件取得の中での判定 = 全件判定ではない。

**意図的な仕様**: 「直近に動作している実績があるか」を見たい (= 古い履歴より最近の動作実績を信頼)。`exists?` への変更は (a) 追加クエリ発生 + (b) 「最近壊れてる人にも案内出ない」問題があるため不採用。WHY コメントで明示。

## 3 者並列レビュー結果

| レビュアー | 当初判定 | 反映後 |
|---|---|---|
| code-reviewer | 🟡 D の 5 件窓判定の仕様明示要 + Nit 2 件 | 🟢 (仕様 WHY コメント追記、Nit は別 Issue 候補) |
| strategic-reviewer | 🟢 進めてよい | 🟢 (4 件まとめの判断 = 性格同質性で OK、ai_used フラグの将来拡張性高評価) |
| design-reviewer | 🟡 i18n 英語表示問題 | 🟢 (**PR #79 で先に main に投入済み**、本 PR で「約 5 分前」表記が出る) |

### Out of scope (別 Issue)
- code Nit: empty?/any? の重複統合 (= unless/else 1 ブロック化)
- design 任意: B コピー「Built with Claude API」変更
- design 推奨: D 再追加リンクのタップ領域拡大

## Test plan

- [x] `script/run "bundle exec rspec"` 全 320 examples / 0 failures (= 既存 312 + 新規 8)
- [x] `bundle exec rubocop` 3 files / no offenses
- [x] AI 成功 / フォールバック / credentials 未設定 の 3 パターンで Result.ai_used を spec で検証
- [x] Step 3 表示/非表示 + 最終送信文言 + 再追加リンクを request spec で回帰
- [ ] **マージ後**: 本番 dashboard で「Powered by Claude」が AI 動作時に表示
- [ ] **マージ後**: 本番 Settings の送信ログで「最終送信: 約 X 分前」が日本語表記
- [ ] **iPhone Safari 375px** で全 4 件の表示崩れなし目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)