### PR TITLE
refactor + feat: CalorieSavingsService class << self 化 + 月初ゼロ励まし (#70 #73)

### DIFF
--- a/app/services/calorie_savings_service.rb
+++ b/app/services/calorie_savings_service.rb
@@ -17,35 +17,37 @@
 class CalorieSavingsService
   CALORIES_PER_STEP = 0.04
 
-  # @param records [Array<#recorded_on, #steps>] StepRecord または DemoRecord の配列 (全期間想定)
-  # @return [Hash{Symbol=>Integer}] { this_month:, last_month:, total: } 各 kcal を整数で返す
-  def self.call(records)
-    return zero_result if records.blank?
+  class << self
+    # @param records [Array<#recorded_on, #steps>] StepRecord または DemoRecord の配列 (全期間想定)
+    # @return [Hash{Symbol=>Integer}] { this_month:, last_month:, total: } 各 kcal を整数で返す
+    def call(records)
+      return zero_result if records.blank?
 
-    today = Date.current
-    this_month_range = today.beginning_of_month..today.end_of_month
-    last_month_date  = today - 1.month
-    last_month_range = last_month_date.beginning_of_month..last_month_date.end_of_month
+      today = Date.current
+      this_month_range = today.beginning_of_month..today.end_of_month
+      last_month_date  = today - 1.month
+      last_month_range = last_month_date.beginning_of_month..last_month_date.end_of_month
 
-    {
-      this_month: kcal_in_range(records, this_month_range),
-      last_month: kcal_in_range(records, last_month_range),
-      total:      kcal_total(records)
-    }
+      {
+        this_month: kcal_in_range(records, this_month_range),
+        last_month: kcal_in_range(records, last_month_range),
+        total:      kcal_total(records)
+      }
+    end
+
+    private
+
+    def zero_result
+      { this_month: 0, last_month: 0, total: 0 }
+    end
+
+    def kcal_in_range(records, range)
+      steps_sum = records.select { |r| range.cover?(r.recorded_on) }.sum(&:steps)
+      (steps_sum * CALORIES_PER_STEP).round
+    end
+
+    def kcal_total(records)
+      (records.sum(&:steps) * CALORIES_PER_STEP).round
+    end
   end
-
-  def self.zero_result
-    { this_month: 0, last_month: 0, total: 0 }
-  end
-
-  def self.kcal_in_range(records, range)
-    steps_sum = records.select { |r| range.cover?(r.recorded_on) }.sum(&:steps)
-    (steps_sum * CALORIES_PER_STEP).round
-  end
-
-  def self.kcal_total(records)
-    (records.sum(&:steps) * CALORIES_PER_STEP).round
-  end
-
-  private_class_method :zero_result, :kcal_in_range, :kcal_total
 end

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -90,16 +90,25 @@
 </div>
 
 <%# ---- 貯カロリー (Issue #41: アプリ哲学のステップ① 核機能。月リセット + 累計の二段構造)
-     数値プレッシャー回避: 矢印・色分け・前月比計算なし、並列表示のみ (= memory three_step_philosophy 参照)。 %>
+     数値プレッシャー回避: 矢印・色分け・前月比計算なし、並列表示のみ (= memory three_step_philosophy 参照)。
+     number_with_delimiter は delimiter "," を明示 (= ja ロケール由来の自動切替で誤って "." に変わる事故を防ぐ、Issue #73)。 %>
 <div class="sketch-box sketch-savings" style="margin-bottom: 14px;">
   <div class="sketch-label">今月の貯カロリー</div>
   <div class="sketch-savings-main">
-    <%= number_with_delimiter(calorie_savings[:this_month]) %>
+    <%= number_with_delimiter(calorie_savings[:this_month], delimiter: ",") %>
     <span class="sketch-small">kcal</span>
   </div>
+  <% if calorie_savings[:this_month].zero? && calorie_savings[:total].positive? %>
+    <%# Issue #70: 月初に「今月: 0 kcal」が出るガッカリ感を、累計を頼みに能動的に解消する。
+        強要表現は使わず「これまでの合計が支えてくれる」というニュートラルな励ましに留める。 %>
+    <p class="sketch-small" style="margin: 4px 0 0; color: var(--ink-2);">
+      月の始まり。今日の一歩が貯まりはじめる。
+      これまでの合計 <strong><%= number_with_delimiter(calorie_savings[:total], delimiter: ",") %> kcal</strong> が支えてくれます。
+    </p>
+  <% end %>
   <div class="sketch-small" style="margin-top: 6px;">
-    前月: <%= number_with_delimiter(calorie_savings[:last_month]) %> kcal ／
-    これまでの合計: <%= number_with_delimiter(calorie_savings[:total]) %> kcal
+    前月: <%= number_with_delimiter(calorie_savings[:last_month], delimiter: ",") %> kcal ／
+    これまでの合計: <%= number_with_delimiter(calorie_savings[:total], delimiter: ",") %> kcal
   </div>
 </div>
 
@@ -283,7 +292,7 @@
 
   <div class="sketch-box accent">
     <div class="sketch-label">きょうの合計歩数</div>
-    <div class="sketch-hh"><%= number_with_delimiter(today_steps) %></div>
+    <div class="sketch-hh"><%= number_with_delimiter(today_steps, delimiter: ",") %></div>
     <div class="sketch-small">スマホ連携で自動記録</div>
   </div>
 </div>

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -170,6 +170,39 @@ RSpec.describe "Home", type: :request do
       it "累計表示「これまでの合計:」の文言を含む (= カジュアル層配慮、design-reviewer 指摘)" do
         expect(response.body).to include("これまでの合計:")
       end
+
+      # Issue #70: 月初ゼロ励まし。今月のレコードがある = this_month が 0 ではないので励ましは出ない。
+      it "今月の貯カロリーがある (this_month > 0) ので月初励ましは表示されない" do
+        expect(response.body).not_to include("月の始まり。今日の一歩が貯まりはじめる")
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 状態 :iphone_with_data かつ「今月のレコードがゼロ + 累計あり」 (= 月初励まし発火条件、Issue #70)
+    # ─────────────────────────────────────────────────
+    context "状態 :iphone_with_data + 今月 0 + 累計あり (= 月初励まし発火条件、Issue #70)" do
+      # travel_to で日付を固定して月境界 issue を予防 (= code-reviewer 指摘)。
+      # CI が月末/月初に走った時の偶発バグを防ぎ、再現性を担保する。
+      around { |ex| travel_to(Date.new(2026, 5, 15)) { ex.run } }
+
+      let(:user) { create(:user) }
+      # 先月の StepRecord のみ作成 → this_month = 0、total > 0
+      let!(:last_month_record) do
+        create(:step_record, user: user, recorded_on: Date.new(2026, 4, 15), steps: 5000)
+      end
+
+      before do
+        login_as(user)
+        get root_path, headers: { "User-Agent" => iphone_ua }
+      end
+
+      it "月初励ましメッセージを表示する" do
+        expect(response.body).to include("月の始まり。今日の一歩が貯まりはじめる")
+      end
+
+      it "累計値 200 kcal (= 5000 * 0.04) が励まし内に表示される" do
+        expect(response.body).to include("200")
+      end
     end
 
     # ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

軽量 2 件まとめ PR。発表会前のコード品質 polish。

| Issue | 内容 |
|---|---|
| #73 | CalorieSavingsService を `class << self / private` 構成に refactor + dashboard の `number_with_delimiter` 全 5 箇所に `delimiter: ","` 明示 |
| #70 | 「今月: 0 kcal + 累計あり」の時に励ましメッセージ表示 (= 6/1 月初発火、強要表現禁止) |

Closes #70 #73

## 設計判断

### #73 class << self 化
従来: `def self.xxx` 4 つ + 末尾 `private_class_method :a, :b, :c`
変更後: `class << self / public def call / private def xxx` ブロック構成

→ 公開 API が `call` のみと一目で分かる、追加メソッドの private 境界が自明、Rails Way / Ruby 慣習に整合。

### #73 delimiter 明示
PR #79 (rails-i18n) で ja ロケールが入ったため、将来の locale 切替で区切り文字が誤って変わる懸念。
`number_with_delimiter(value, delimiter: ",")` で **区切り文字を明示的に固定**。
全 5 箇所に統一適用 (= today_steps を含む)。

### #70 月初励ましの表示条件
```ruby
if calorie_savings[:this_month].zero? && calorie_savings[:total].positive?
```

- `this_month = 0`: 月初の数日 + 今月歩いていない時
- `total > 0`: 過去に歩いた実績あり (= 「累計が支えてくれる」が成立する)
- → 初回ユーザー (= 累計も 0) には励まし非表示で「0 への追い打ち」を回避

### #70 文言設計
> 月の始まり。今日の一歩が貯まりはじめる。これまでの合計 X kcal が支えてくれます。

3 ステップ思想 + 数値プレッシャー回避と完全整合:
- 「がんばって」「目標達成」等の強要禁止
- 「累計が支えてくれる」 = 過去の頑張りを能動的に肯定
- ニュートラルなトーン

## 3 者並列レビュー結果

| レビュアー | 当初判定 | 反映後 |
|---|---|---|
| code | 🟡 Should fix 2 件 (delimiter 漏れ + travel_to) | 🟢 (両方反映) |
| strategic | 🟡 「#70 は発表会で発火しない」優先度ミスマッチ指摘 | 🟢 (ユーザー判断尊重: すぐ終わる + 発表会後も価値継続) |
| design | 🟢 OK + デモ向上提案 (sketch-hl-yellow) | 🟢 (発表会で見えないため反映スキップ) |

## Test plan

- [x] `script/run "bundle exec rspec"` 全 323 examples / 0 failures (= 既存 320 + 新規 3)
- [x] `bundle exec rubocop` 2 files / no offenses
- [x] CalorieSavingsService 既存 15 examples が refactor 後も全緑 (= 動作変更なし)
- [x] 月初励ましの表示/非表示を 2 context で回帰 (`travel_to(2026-05-15)` で月境界 issue 予防)
- [ ] **マージ後**: 本番 dashboard で number_with_delimiter が `1,234 kcal` 表記 (= delimiter ',' 効果)
- [ ] **6/1 月初発火確認**: その時点で「月の始まり。今日の一歩が…」が表示されるはず

## Out of scope

- design 提案 (sketch-hl-yellow ハイライト) は発表会で見えないためスルー
- code Nit (= 合計値二重表示の整理) は別 Issue 候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)