### PR TITLE
feat: webhook 数値型ガード + accepted_count 記録 (#52)

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -17,24 +17,24 @@ class WebhooksController < ActionController::API
     records_data = parsed["records"]
 
     unless records_data.is_a?(Array)
-      record_delivery!(status: "invalid", error_message: "missing 'records' array")
+      record_delivery!(status: "invalid", accepted_count: 0, error_message: "missing 'records' array")
       render json: { error: "Invalid payload" }, status: :unprocessable_content
       return
     end
 
     accepted = upsert_records(records_data)
-    record_delivery!(status: "success")
+    record_delivery!(status: "success", accepted_count: accepted)
     render json: { accepted: accepted }, status: :ok
   rescue JSON::ParserError => e
-    record_delivery!(status: "invalid", error_message: "JSON parse error: #{e.message.truncate(120)}")
+    record_delivery!(status: "invalid", accepted_count: 0, error_message: "JSON parse error: #{e.message.truncate(120)}")
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   rescue InvalidPayload => e
-    record_delivery!(status: "invalid", error_message: e.message.truncate(120))
+    record_delivery!(status: "invalid", accepted_count: 0, error_message: e.message.truncate(120))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   rescue ActiveRecord::RecordInvalid => e
     # 個々のレコードのバリデーション違反 (負数 / 不正な日付等) を 500 ではなく 422 + 監査ログで返す。
     # rails-implementer の意図 (全体失敗方式) を実装まで貫徹するため。
-    record_delivery!(status: "invalid", error_message: "RecordInvalid: #{e.message.truncate(120)}")
+    record_delivery!(status: "invalid", accepted_count: 0, error_message: "RecordInvalid: #{e.message.truncate(120)}")
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   end
 
@@ -102,6 +102,27 @@ class WebhooksController < ActionController::API
     raise InvalidPayload, "recorded_on must be yyyy-MM-dd format: got #{truncated}"
   end
 
+  # 数値フィールド (steps / distance_meters / flights_climbed) を厳格パースする (Issue #52)。
+  # nil は許容 (= partial-update セマンティクス維持) するが、Hash や String など Integer/Float でない型は reject。
+  # 防ぎたい事故: Apple HealthKit Sample object `{ value: 12345, unit: "count" }` が来た時に、
+  # AR の type cast で silent に 0 として保存される (= 「動いてるけど中身がゼロ」の見えないバグ温床)。
+  #
+  # Float は「整数値の Float」(例: 8000.0) のみ許容する。9999.9 のような小数は silent に切り捨てられて
+  # 1 歩ぶん失われる事故を防ぐため reject する (= Apple Shortcuts が JSON 数値を 8000.0 で送る可能性を残しつつ、
+  # 真の小数値は reject、code-reviewer 指摘 ⚠️)。
+  def parse_numeric(raw, field_name)
+    return nil if raw.nil?
+    case raw
+    when Integer
+      raw
+    when Float
+      raise InvalidPayload, "#{field_name} must be a whole number, got Float #{raw}" unless raw == raw.to_i
+      raw.to_i
+    else
+      raise InvalidPayload, "#{field_name} must be a number, got #{raw.class}: #{raw.to_s.truncate(40).inspect}"
+    end
+  end
+
   # Upsert each day's record, updating only the keys present in the payload.
   # Keys absent from the payload are left unchanged (partial-update semantics).
   # All-or-nothing: wrap in a transaction so that if any record fails validation
@@ -120,9 +141,9 @@ class WebhooksController < ActionController::API
         # NOTE: we cannot distinguish "key absent" from "explicit 0" because both
         # arrive as falsy in JSON; partial-update semantics treat absent ≠ 0.
         updates = {
-          steps:           entry["steps"],
-          distance_meters: entry["distance_meters"],
-          flights_climbed: entry["flights_climbed"]
+          steps:           parse_numeric(entry["steps"], "steps"),
+          distance_meters: parse_numeric(entry["distance_meters"], "distance_meters"),
+          flights_climbed: parse_numeric(entry["flights_climbed"], "flights_climbed")
         }.compact
 
         record.assign_attributes(updates)
@@ -136,7 +157,8 @@ class WebhooksController < ActionController::API
 
   # Record audit log entry. Uses keyword argument `user:` so callers can
   # override with nil for unauthorized cases where @webhook_user is unreliable.
-  def record_delivery!(status:, error_message: nil, user: @webhook_user)
+  # accepted_count: Issue #52 で追加。何件保存されたかを記録、success 時の中身が空ペイロードかを後追い分析可能にする。
+  def record_delivery!(status:, accepted_count: nil, error_message: nil, user: @webhook_user)
     # Attempt to parse stored body as JSON for richer inspection in the audit log.
     # Falls back to { raw: <string> } when the body is not valid JSON.
     payload = begin
@@ -149,6 +171,7 @@ class WebhooksController < ActionController::API
       user: user,
       payload: payload,
       status: status,
+      accepted_count: accepted_count,
       error_message: error_message,
       received_at: Time.current
     )

--- a/db/migrate/20260504063009_add_accepted_count_to_webhook_deliveries.rb
+++ b/db/migrate/20260504063009_add_accepted_count_to_webhook_deliveries.rb
@@ -1,0 +1,9 @@
+class AddAcceptedCountToWebhookDeliveries < ActiveRecord::Migration[8.1]
+  # WebhookDelivery 1 件で「何件保存できたか」を記録する。
+  # success 時は upsert_records が返した accepted 数、reject 時は 0 (or nil)。
+  # success ログに accepted_count = 0 が混ざると「実質意味のないペイロード」(= 全件 silent skip 等) を後追い分析できる。
+  # Issue #52 (= Day 3-3 の code-reviewer 指摘 ⚠️3 由来)。
+  def change
+    add_column :webhook_deliveries, :accepted_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_232659) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_063009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_232659) do
   end
 
   create_table "webhook_deliveries", force: :cascade do |t|
+    t.integer "accepted_count"
     t.string "error_message"
     t.jsonb "payload", default: {}, null: false
     t.datetime "received_at", null: false

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -465,4 +465,100 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
       expect(StepRecord.count).to eq(0)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Case 14: 数値フィールドの型違反 → 422 (Issue #52)
+  # ---------------------------------------------------------------------------
+  # 防ぎたい事故: Apple HealthKit Sample object `{ value: 12345, unit: "count" }` が来た時に
+  # AR の type cast で silent に 0 として保存される。「動いてるけど中身がゼロ」の見えないバグ温床。
+  describe "Case 14: numeric field type violations return 422 (#52)" do
+    shared_examples "rejects malformed numeric field" do |field, bad_value|
+      describe "with #{field} = #{bad_value.inspect}" do
+        let(:payload) { { records: [ { recorded_on: "2026-05-01", field => bad_value } ] } }
+
+        before { post_health_data(payload) }
+
+        it "returns HTTP 422" do
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it "does not create any StepRecord" do
+          expect(StepRecord.count).to eq(0)
+        end
+
+        it "records WebhookDelivery with status 'invalid'" do
+          expect(WebhookDelivery.last.status).to eq("invalid")
+        end
+
+        it "mentions the field name in error_message" do
+          expect(WebhookDelivery.last.error_message).to include(field.to_s)
+        end
+      end
+    end
+
+    # Apple HealthKit Sample object 構造 (= 主要な事故パターン)
+    include_examples "rejects malformed numeric field", :steps, { value: 12345, unit: "count" }
+    # 文字列 (= 一般的な型ミス)
+    include_examples "rejects malformed numeric field", :steps, "12345"
+    # 配列 (= 開発者の typo / 誤った payload 構築)
+    include_examples "rejects malformed numeric field", :distance_meters, [ 5000 ]
+    # boolean (= silent に 0 / 1 化される事故)
+    include_examples "rejects malformed numeric field", :flights_climbed, true
+    # 真の小数値 (= silent 切り捨てで 1 歩ロス、code-reviewer ⚠️ 指摘)
+    include_examples "rejects malformed numeric field", :steps, 9999.5
+
+    # 整数値の Float (例: Apple Shortcuts が steps を 8000.0 で送るケース) は許容
+    context "with steps = 8000.0 (= 整数値の Float)" do
+      let(:payload) { { records: [ { recorded_on: "2026-05-01", steps: 8000.0 } ] } }
+
+      before { post_health_data(payload) }
+
+      it "200 OK を返す (= 整数値 Float は許容)" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "StepRecord.steps = 8000 として保存" do
+        expect(StepRecord.last.steps).to eq(8000)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case 15: accepted_count を WebhookDelivery に記録 (Issue #52)
+  # ---------------------------------------------------------------------------
+  describe "Case 15: WebhookDelivery records accepted_count (#52)" do
+    context "success 時 (= 3 件保存)" do
+      let(:payload) do
+        {
+          records: [
+            { recorded_on: "2026-05-01", steps: 6000, distance_meters: 4000, flights_climbed: 5 },
+            { recorded_on: "2026-05-02", steps: 7000, distance_meters: 4500, flights_climbed: 8 },
+            { recorded_on: "2026-05-03", steps: 9000, distance_meters: 6000, flights_climbed: 15 }
+          ]
+        }
+      end
+
+      before { post_health_data(payload) }
+
+      it "WebhookDelivery.accepted_count に 3 が記録される" do
+        expect(WebhookDelivery.last.accepted_count).to eq(3)
+      end
+    end
+
+    context "invalid 時 (= 全件 rollback)" do
+      before { post_health_data({ records: [ { recorded_on: "bad-date", steps: 100 } ] }) }
+
+      it "WebhookDelivery.accepted_count に 0 が記録される (= silent 0 success との区別がつく)" do
+        expect(WebhookDelivery.last.accepted_count).to eq(0)
+      end
+    end
+
+    context "missing 'records' array" do
+      before { post_health_data({ foo: "bar" }) }
+
+      it "WebhookDelivery.accepted_count に 0 が記録される" do
+        expect(WebhookDelivery.last.accepted_count).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Close #52

## Summary
- **数値型ガード (`parse_numeric`)**: `steps` / `distance_meters` / `flights_climbed` を厳格にパース。Apple HealthKit の Sample Object (`{value: 12345, unit: \"count\"}`) のような Hash/String 型が来た時に AR の type cast で silent に 0 として保存される事故を `422 Invalid payload` で fail-fast。
- **Float は整数値のみ許容**: Apple Shortcuts が JSON 数値を `8000.0` で送る可能性を残しつつ、`9999.9` のような真の小数値は reject (= silent 切り捨てで 1 歩失う事故防止)。
- **`accepted_count` カラム追加**: `WebhookDelivery` に何件保存したかを記録。success ログに `accepted_count: 0` が混ざると「実質意味のないペイロード」(全件 silent skip / 空 `records`) を後追い分析可能。

## レビュー反映
- 🟡 code-reviewer ⚠️ Float silent truncation → **修正**: `raw == raw.to_i` チェックで真の小数値を reject
- 🟡 strategic-reviewer 「21 PR 目には行かない、出発前 1h は merge 確認 + デモリハ」→ **本 PR をもって Day 4 打ち止め**
- 🟢 design-reviewer issue なし (UI 影響なし)

## Test plan
- [x] `bundle exec rspec spec/requests/webhooks_spec.rb` (108 examples / 0 failures)
- [x] `bundle exec rspec` (348 examples / 0 failures)
- [x] `bundle exec rubocop app/controllers/webhooks_controller.rb db/migrate/20260504063009_add_accepted_count_to_webhook_deliveries.rb spec/requests/webhooks_spec.rb` (no offenses)
- [x] migration 適用済み (`db/schema.rb` 更新確認)

## 教材性ポイント
- **fail-fast 設計**: 「機械同士の契約」(webhook) では silent 正規化せず `422 + 監査ログ` で返すパターン。
- **永続コメントで意図を残す**: `parse_numeric` 内に「なぜ Hash を reject するのか」「なぜ Float の小数値も reject するのか」を Apple HealthKit の Sample Object 例とともに記載。

🤖 Generated with [Claude Code](https://claude.com/claude-code)