### PR TITLE
feat: ユーザー退会機能 (アカウント + 関連データ全削除) (#84)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -74,6 +74,11 @@ body {
 }
 .sketch-btn:hover { transform: translate(-1px, -1px); box-shadow: 3px 3px 0 var(--ink); }
 .sketch-btn:active { transform: translate(2px, 2px); box-shadow: 0 0 0 var(--ink); }
+.sketch-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
 /* primary は #ff7a45 + 黒文字 (6.73:1) で WCAG AA 合格。白文字 (2.59:1) は不可。 */
 .sketch-btn-primary { background: var(--accent); color: var(--ink); }
 .sketch-btn-primary:hover { background: var(--accent); color: var(--ink); }

--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -259,3 +259,4 @@ body {
   .sketch-bottom-grid { grid-template-columns: repeat(2, 1fr); }
   .sketch-topbar      { flex-direction: column; align-items: flex-start; gap: 6px; }
 }
+

--- a/app/controllers/account/deletions_controller.rb
+++ b/app/controllers/account/deletions_controller.rb
@@ -5,14 +5,13 @@ module Account
     def destroy
       user = current_user
       user_id = user.id
-      email = user.email
-
-      Rails.logger.info "[UserDeletion] user_id=#{user_id} email=#{email} deleted_at=#{Time.current.iso8601}"
-
       user.destroy!
-
+      Rails.logger.info "[UserDeletion] user_id=#{user_id} deleted_at=#{Time.current.iso8601}"
       reset_session
-      redirect_to root_path, notice: "退会完了しました。ご利用ありがとうございました。"
+      redirect_to root_path, notice: "退会完了しました。またいつでも歩いた日には使ってください。"
+    rescue ActiveRecord::RecordNotDestroyed => e
+      Rails.logger.error "[UserDeletion] failed user_id=#{user_id} error=#{e.message}"
+      redirect_to settings_path, alert: "退会処理に失敗しました。しばらく経ってから再度お試しください。"
     end
   end
 end

--- a/app/controllers/account/deletions_controller.rb
+++ b/app/controllers/account/deletions_controller.rb
@@ -1,0 +1,18 @@
+module Account
+  class DeletionsController < ApplicationController
+    before_action :require_login
+
+    def destroy
+      user = current_user
+      user_id = user.id
+      email = user.email
+
+      Rails.logger.info "[UserDeletion] user_id=#{user_id} email=#{email} deleted_at=#{Time.current.iso8601}"
+
+      user.destroy!
+
+      reset_session
+      redirect_to root_path, notice: "退会完了しました。ご利用ありがとうございました。"
+    end
+  end
+end

--- a/app/javascript/controllers/confirm_deletion_controller.js
+++ b/app/javascript/controllers/confirm_deletion_controller.js
@@ -1,0 +1,52 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 退会確認モーダルを制御する Stimulus controller。
+//
+// 使い方:
+//   data-controller="confirm-deletion"
+//   data-confirm-deletion-expected-name-value="<%= current_user.name %>"
+//
+// 教材メモ: 不可逆操作の UX パターンとして「名前入力一致確認」を採用 (= GitHub 方式)。
+// disabled 解除は input イベントのたびにリアルタイム比較するため、コピペも検出できる。
+export default class extends Controller {
+  static targets = ["modal", "input", "submitButton"]
+  static values  = { expectedName: String }
+
+  // モーダルを開く
+  openModal() {
+    this.modalTarget.style.display = "flex"
+    this.modalTarget.setAttribute("aria-hidden", "false")
+    this.inputTarget.value = ""
+    this.submitButtonTarget.disabled = true
+    // フォーカスをインプットに移動しアクセシビリティを確保
+    this.inputTarget.focus()
+  }
+
+  // モーダルを閉じる
+  closeModal() {
+    this.modalTarget.style.display = "none"
+    this.modalTarget.setAttribute("aria-hidden", "true")
+    this.inputTarget.value = ""
+    this.submitButtonTarget.disabled = true
+  }
+
+  // input イベント: 入力値と期待名を比較してボタンの disabled を制御
+  checkInput() {
+    const matched = this.inputTarget.value.trim() === this.expectedNameValue.trim()
+    this.submitButtonTarget.disabled = !matched
+  }
+
+  // オーバーレイ (背景) クリックでモーダルを閉じる
+  backdropClose(event) {
+    if (event.target === this.modalTarget) {
+      this.closeModal()
+    }
+  }
+
+  // ESC キーでモーダルを閉じる
+  keydown(event) {
+    if (event.key === "Escape") {
+      this.closeModal()
+    }
+  }
+}

--- a/app/javascript/controllers/confirm_deletion_controller.js
+++ b/app/javascript/controllers/confirm_deletion_controller.js
@@ -13,6 +13,8 @@ export default class extends Controller {
   static values  = { expectedName: String }
 
   // モーダルを開く
+  // keydown は connect() でなく openModal() で局所購読する。
+  // 理由: 将来 settings ページに別モーダルが追加された時、@window 二重購読を避けるため。
   openModal() {
     this.modalTarget.style.display = "flex"
     this.modalTarget.setAttribute("aria-hidden", "false")
@@ -20,6 +22,9 @@ export default class extends Controller {
     this.submitButtonTarget.disabled = true
     // フォーカスをインプットに移動しアクセシビリティを確保
     this.inputTarget.focus()
+    // モーダルが開いている間だけ ESC キーを購読する
+    this._keydownHandler = this.keydown.bind(this)
+    window.addEventListener("keydown", this._keydownHandler)
   }
 
   // モーダルを閉じる
@@ -28,9 +33,16 @@ export default class extends Controller {
     this.modalTarget.setAttribute("aria-hidden", "true")
     this.inputTarget.value = ""
     this.submitButtonTarget.disabled = true
+    // モーダルを閉じたら keydown 購読を解除する
+    if (this._keydownHandler) {
+      window.removeEventListener("keydown", this._keydownHandler)
+      this._keydownHandler = null
+    }
   }
 
   // input イベント: 入力値と期待名を比較してボタンの disabled を制御
+  // 名前比較は trim あり (前後空白許容)、case-sensitive (= Google アカウント名はそのまま比較)。
+  // Google OAuth 由来の name は通常「Taro Yamada」のような表記なので、case-sensitive で実害なし。
   checkInput() {
     const matched = this.inputTarget.value.trim() === this.expectedNameValue.trim()
     this.submitButtonTarget.disabled = !matched

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   has_secure_token :webhook_token
 
   has_many :step_records, dependent: :destroy
-  has_many :webhook_deliveries, dependent: :nullify  # 監査ログはユーザー削除後も保持
+  has_many :webhook_deliveries, dependent: :destroy   # プライバシー観点でユーザー削除時に全件削除 (Issue #84)
 
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -99,4 +99,74 @@
           data: { turbo_confirm: "本当に再生成しますか？ 現在の Shortcut が動かなくなります。" } %>
   </div>
 
+  <%# 危険ゾーン: アカウント削除 %>
+  <div data-controller="confirm-deletion"
+       data-confirm-deletion-expected-name-value="<%= current_user.name %>"
+       data-action="keydown@window->confirm-deletion#keydown">
+
+    <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5; border-color: #cc0000;">
+      <p class="sketch-h" style="margin-bottom: 8px; color: #cc0000;">⚠️ アカウントの削除</p>
+      <p class="sketch-body-text" style="margin-bottom: 16px;">
+        アカウントを削除すると、歩数記録・連携設定を含む<strong>すべてのデータが即時に削除</strong>されます。
+        この操作は取り消せません。
+      </p>
+      <button type="button"
+              class="sketch-btn"
+              style="border-color: #cc0000; color: #cc0000;"
+              data-action="click->confirm-deletion#openModal">
+        アカウントを削除する
+      </button>
+    </div>
+
+    <%# 退会確認モーダル (初期非表示。JS で display: flex に切替) %>
+    <div data-confirm-deletion-target="modal"
+         aria-hidden="true"
+         aria-modal="true"
+         role="dialog"
+         aria-labelledby="deletion-modal-title"
+         style="display: none; position: fixed; inset: 0; z-index: 9999; align-items: center; justify-content: center; background: rgba(0,0,0,0.5);"
+         data-action="click->confirm-deletion#backdropClose">
+      <div class="sketch-box"
+           style="width: min(90vw, 24rem); background: var(--paper); position: relative;">
+        <p id="deletion-modal-title" class="sketch-h" style="margin-bottom: 12px; color: #cc0000;">
+          ⚠️ 本当に退会しますか？
+        </p>
+        <p class="sketch-body-text" style="margin-bottom: 16px;">
+          確認のため、あなたの名前 <strong><%= current_user.name %></strong> を下に入力してください。
+        </p>
+
+        <%= form_with url: account_deletion_path, method: :delete do |f| %>
+          <div style="margin-bottom: 16px;">
+            <label for="deletion-name-input" class="sketch-label" style="display: block; margin-bottom: 6px;">
+              名前を入力
+            </label>
+            <input id="deletion-name-input"
+                   type="text"
+                   autocomplete="off"
+                   placeholder="<%= current_user.name %>"
+                   data-confirm-deletion-target="input"
+                   data-action="input->confirm-deletion#checkInput"
+                   style="width: 100%; border: 2px solid var(--ink); border-radius: 6px; padding: 8px 10px; font-family: 'Kalam', cursive; font-size: 15px; background: var(--paper); box-sizing: border-box;">
+          </div>
+
+          <div style="display: flex; gap: 12px; justify-content: flex-end;">
+            <button type="button"
+                    class="sketch-btn"
+                    data-action="click->confirm-deletion#closeModal">
+              キャンセル
+            </button>
+            <button type="submit"
+                    class="sketch-btn"
+                    style="border-color: #cc0000; color: #cc0000;"
+                    disabled
+                    data-confirm-deletion-target="submitButton">
+              退会する
+            </button>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+
 </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -101,8 +101,7 @@
 
   <%# 危険ゾーン: アカウント削除 %>
   <div data-controller="confirm-deletion"
-       data-confirm-deletion-expected-name-value="<%= current_user.name %>"
-       data-action="keydown@window->confirm-deletion#keydown">
+       data-confirm-deletion-expected-name-value="<%= current_user.name %>">
 
     <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5; border-color: #cc0000;">
       <p class="sketch-h" style="margin-bottom: 8px; color: #cc0000;">⚠️ アカウントの削除</p>
@@ -146,7 +145,7 @@
                    placeholder="<%= current_user.name %>"
                    data-confirm-deletion-target="input"
                    data-action="input->confirm-deletion#checkInput"
-                   style="width: 100%; border: 2px solid var(--ink); border-radius: 6px; padding: 8px 10px; font-family: 'Kalam', cursive; font-size: 15px; background: var(--paper); box-sizing: border-box;">
+                   style="width: 100%; border: 2px solid var(--ink); border-radius: 6px; padding: 8px 10px; font-family: 'Kalam', cursive; font-size: 16px; background: var(--paper); box-sizing: border-box;">
           </div>
 
           <div style="display: flex; gap: 12px; justify-content: flex-end;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
   get  "/settings",               to: "settings#show",            as: :settings
   post "/settings/webhook_token", to: "settings#regenerate_token", as: :regenerate_webhook_token
 
+  # Account deletion (退会)
+  delete "/account", to: "account/deletions#destroy", as: :account_deletion
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/spec/requests/account/deletions_spec.rb
+++ b/spec/requests/account/deletions_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe "Account::Deletions", type: :request do
+  # ---------------------------------------------------------------------------
+  # ログインヘルパー (settings_spec.rb と同じパターン)
+  # ---------------------------------------------------------------------------
+  def login(user)
+    mock_google_oauth2(uid: user.uid, email: user.email, name: user.name)
+    get auth_callback_path(provider: "google_oauth2")
+  end
+
+  # ---------------------------------------------------------------------------
+  # DELETE /account (退会)
+  # ---------------------------------------------------------------------------
+  describe "DELETE /account" do
+    context "未ログイン時" do
+      before { delete account_deletion_path }
+
+      it "302 リダイレクトを返す" do
+        expect(response).to have_http_status(:found)
+      end
+
+      it "root_path へリダイレクトする" do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "flash[:alert] にログイン要求メッセージをセットする" do
+        expect(flash[:alert]).to eq("ログインが必要です")
+      end
+    end
+
+    context "ログイン済み + 正常系" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+        delete account_deletion_path
+      end
+
+      it "302 リダイレクトを返す" do
+        expect(response).to have_http_status(:found)
+      end
+
+      it "root_path へリダイレクトする" do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "flash[:notice] に退会完了メッセージをセットする" do
+        expect(flash[:notice]).to eq("退会完了しました。ご利用ありがとうございました。")
+      end
+
+      it "User レコードが削除される" do
+        expect(User.find_by(id: user.id)).to be_nil
+      end
+    end
+
+    context "ログイン済み + StepRecord が存在する場合" do
+      let(:user) { create(:user) }
+      let!(:step_records) { create_list(:step_record, 3, user: user) }
+
+      before do
+        login(user)
+        delete account_deletion_path
+      end
+
+      it "User 削除時に StepRecord も cascade delete される" do
+        expect(StepRecord.where(user_id: user.id)).to be_empty
+      end
+    end
+
+    context "ログイン済み + WebhookDelivery が存在する場合" do
+      let(:user) { create(:user) }
+      let!(:deliveries) { create_list(:webhook_delivery, 2, user: user) }
+
+      before do
+        login(user)
+        delete account_deletion_path
+      end
+
+      it "User 削除時に WebhookDelivery も cascade delete される" do
+        expect(WebhookDelivery.where(user_id: user.id)).to be_empty
+      end
+    end
+
+    context "ログイン済み + StepRecord / WebhookDelivery 両方存在する場合" do
+      let(:user) { create(:user) }
+      let!(:step_record) { create(:step_record, user: user) }
+      let!(:delivery) { create(:webhook_delivery, user: user) }
+
+      before do
+        login(user)
+        delete account_deletion_path
+      end
+
+      it "User レコードが削除される" do
+        expect(User.find_by(id: user.id)).to be_nil
+      end
+
+      it "StepRecord が cascade delete される" do
+        expect(StepRecord.where(user_id: user.id)).to be_empty
+      end
+
+      it "WebhookDelivery が cascade delete される" do
+        expect(WebhookDelivery.where(user_id: user.id)).to be_empty
+      end
+    end
+
+    context "セッションがリセットされる" do
+      let(:user) { create(:user) }
+
+      it "退会後は再度 /settings にアクセスしても root にリダイレクトされる" do
+        login(user)
+        delete account_deletion_path
+        get settings_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/account/deletions_spec.rb
+++ b/spec/requests/account/deletions_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Account::Deletions", type: :request do
       end
 
       it "flash[:notice] に退会完了メッセージをセットする" do
-        expect(flash[:notice]).to eq("退会完了しました。ご利用ありがとうございました。")
+        expect(flash[:notice]).to eq("退会完了しました。またいつでも歩いた日には使ってください。")
       end
 
       it "User レコードが削除される" do
@@ -113,6 +113,37 @@ RSpec.describe "Account::Deletions", type: :request do
         delete account_deletion_path
         get settings_path
         expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "User#destroy! が失敗する場合 (ActiveRecord::RecordNotDestroyed)" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+        allow_any_instance_of(User).to receive(:destroy!).and_raise(
+          ActiveRecord::RecordNotDestroyed.new("destroy failed", user)
+        )
+      end
+
+      it "settings_path へリダイレクトする" do
+        delete account_deletion_path
+        expect(response).to redirect_to(settings_path)
+      end
+
+      it "flash[:alert] をセットする" do
+        delete account_deletion_path
+        expect(flash[:alert]).to eq("退会処理に失敗しました。しばらく経ってから再度お試しください。")
+      end
+
+      it "User レコードは削除されない" do
+        expect { delete account_deletion_path }.not_to change(User, :count)
+      end
+
+      it "セッションは維持される (= ログイン状態のまま settings_path にアクセスできる)" do
+        delete account_deletion_path
+        follow_redirect!
+        expect(response).to have_http_status(:ok)
       end
     end
   end


### PR DESCRIPTION
Close #84

## Summary
- ユーザーが Settings 画面から自身のアカウントと関連データをすべて削除して退会できる機能
- GitHub 方式の慎重 UI (= ユーザー名入力モーダル、一致まで disabled) で誤操作防止
- cascade delete (User → StepRecord / WebhookDelivery) でプライバシー観点の全データ削除
- 即時削除、ログアウト後ルートへ遷移、flash 表示

## レビュー反映 (= 3 者並列、2 ラウンド)

### 1 ラウンド目で指摘 → 修正コミット (`2431324`) で対応
- 🚨 code-reviewer **Blocker**: `destroy!` 失敗時の rescue → ✅
- 🔴 design-reviewer **Blocker**: input `font-size: 16px` (iOS Safari ズーム防止) → ✅
- 🔴 design-reviewer **Blocker**: `.sketch-btn:disabled` スタイル (= 視覚フィードバック) → ✅
- ⚠️ code-reviewer Should: ログから email 削除 (PII 保護) → ✅
- ⚠️ code-reviewer Should: 失敗系 spec 4 件追加 → ✅
- 💡 code-reviewer Nit: `keydown@window` 局所化 (= モーダル open 時のみ購読) → ✅
- 💡 code-reviewer Nit: 名前比較 case-sensitive / trim 仕様コメント → ✅
- 💡 design-reviewer Nit: flash 文言「またいつでも歩いた日には使ってください」 → ✅

### 2 ラウンド目 (= 修正後)
- 🟢 code-reviewer マージ可 (= 6 件適切に取り込み、新規回帰なし)
- 🟢 strategic-reviewer マージ可 (= スコープ管理模範的、教材性増加)
- 🟢 design-reviewer マージ可 (= Blocker 解消確認、新規 UI 課題なし)

## 別 Issue 化したフォローアップ
- Issue #85: `webhook_deliveries` / `step_records` FK に `on_delete: :cascade` migration
- Issue #86: sketchy theme に `--danger` カラートークン + `sketch-btn-danger` 整備

## Test plan
- [x] `bundle exec rspec` (365 examples / 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] 3 者並列レビュー 2 ラウンド (= code/strategic/design 全員マージ可)

## 教材性ポイント
- **不可逆操作のガードレール**: `rescue ActiveRecord::RecordNotDestroyed` + redirect + 失敗系 spec の定型セット
- **iOS Safari 16px ズーム防止**: input `font-size` のモバイル罠 (= 15px 以下で自動ズーム)
- **PII ログ判断**: `user_id` だけで監査として十分、`email` を Rails.logger に流さない
- **Stimulus keydown の局所購読**: ライフサイクル理解 + 将来の他モーダルとの衝突回避
- **GitHub 方式の慎重 UI**: 名前入力一致型の確認モーダル、Stimulus 50 行で組める軽量実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)