### PR TITLE
feat: プライバシーポリシー / 利用規約ページを追加 (#38)

### DIFF
--- a/app/controllers/legal_controller.rb
+++ b/app/controllers/legal_controller.rb
@@ -1,0 +1,7 @@
+class LegalController < ApplicationController
+  def privacy
+  end
+
+  def terms
+  end
+end

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -13,6 +13,11 @@
       <div style="margin-top: 16px;">
         <%= link_to "ホームへ戻る", root_path, class: "sketch-btn sketch-btn-primary" %>
       </div>
+      <p class="sketch-small" style="margin-top: 20px; color: var(--muted);">
+        <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--muted); text-decoration: underline;" %>
+        /
+        <%= link_to "利用規約", terms_path, style: "color: var(--muted); text-decoration: underline;" %>
+      </p>
     </div>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -30,3 +30,12 @@
         advice:          @advice,
         calorie_savings: @calorie_savings %>
 </div>
+
+<%# ポリシーフッター (= 未ログインでも到達できる経路) %>
+<div style="margin-top: 2rem; padding: 1rem; text-align: center;">
+  <p class="sketch-small" style="color: var(--muted)">
+    <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--muted); text-decoration: underline;" %>
+    /
+    <%= link_to "利用規約", terms_path, style: "color: var(--muted); text-decoration: underline;" %>
+  </p>
+</div>

--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -1,0 +1,97 @@
+<% content_for :title, "プライバシーポリシー — weight daily." %>
+
+<div class="sketch-page-narrow" style="max-width: 40rem;">
+
+  <h1 class="sketch-hh" style="margin-bottom: 4px;">プライバシーポリシー</h1>
+  <p class="sketch-small" style="margin-bottom: 16px;">最終更新: 2026年5月5日</p>
+
+  <p class="sketch-body-text" style="margin-bottom: 24px;">
+    weight daily（以下「本サービス」）は、ユーザーから取得する個人情報および利用情報を以下のとおり取り扱います。
+  </p>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">1. 取得する情報</h2>
+    <p class="sketch-body-text" style="margin-bottom: 8px;">本サービスは、サービス提供のため以下の情報を取得します。</p>
+    <ul class="sketch-body-text" style="padding-left: 1.5em; margin-bottom: 8px;">
+      <li>Google アカウントから取得する情報: 氏名、メールアドレス、プロフィール画像</li>
+      <li>ユーザーが Apple Shortcuts 経由で送信する情報: 歩数、距離 (m)、上った階数、記録日</li>
+    </ul>
+    <p class="sketch-body-text">ヘルスケアデータの生データ (GPS、心拍、生体情報など) は取得しません。</p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">2. 利用目的</h2>
+    <p class="sketch-body-text" style="margin-bottom: 8px;">取得した情報は、以下の目的にのみ利用します。</p>
+    <ul class="sketch-body-text" style="padding-left: 1.5em; margin-bottom: 8px;">
+      <li>アプリ画面でのダッシュボード表示</li>
+      <li>AI による行動提案メッセージの生成</li>
+    </ul>
+    <p class="sketch-body-text">
+      なお、AI 提案の生成にあたっては、Anthropic 社の API (Claude) に対し、当日の合計歩数・距離・階数から算出した数値情報のみを送信します。氏名、メールアドレス、その他の個人情報は送信しません。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">3. 第三者提供</h2>
+    <p class="sketch-body-text" style="margin-bottom: 8px;">
+      本サービスは、利用者の個人情報を第三者に販売したり、広告目的で提供したりすることはありません。
+    </p>
+    <p class="sketch-body-text" style="margin-bottom: 8px;">
+      ただし、サービスを運営するため、以下のクラウドサービス事業者にデータの保管・処理を委託しています。
+    </p>
+    <ul class="sketch-body-text" style="padding-left: 1.5em; margin-bottom: 8px;">
+      <li>Render (ホスティング、米国)</li>
+      <li>Anthropic (AI による提案メッセージ生成、米国、送信内容は数値情報のみ)</li>
+      <li>Google (OAuth 認証時の氏名・メールアドレス取得)</li>
+    </ul>
+    <p class="sketch-body-text">
+      なお、Anthropic 社のサービスにおいて、API 経由で送信されたデータが学習目的に使用されることはありません。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">4. データ保持期間</h2>
+    <p class="sketch-body-text" style="margin-bottom: 8px;">
+      取得した情報は、ユーザーが本サービスを利用している期間中保持します。
+    </p>
+    <p class="sketch-body-text">
+      ユーザーが退会した場合、当該ユーザーに紐づくすべてのデータ (プロフィール情報、歩数記録、Webhook 配信ログ等) を即時削除します。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">5. Cookie</h2>
+    <p class="sketch-body-text">
+      本サービスは、ログインセッションを維持するための cookie のみを使用します。アクセス解析や広告配信を目的とした cookie は使用していません。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">6. ユーザーの権利</h2>
+    <p class="sketch-body-text">
+      ユーザーは、設定画面の「アカウント削除」機能から、いつでも自身のアカウントおよび関連データの削除を要求できます。削除は即時実行され、取り消すことはできません。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">7. お問い合わせ</h2>
+    <p class="sketch-body-text">
+      本ポリシーに関するお問い合わせは、以下のメールアドレスまでご連絡ください。
+    </p>
+    <p class="sketch-body-text" style="margin-top: 8px;">
+      <%= mail_to "weightdaily3@gmail.com", "weightdaily3@gmail.com", style: "color: var(--ink); text-decoration: underline;" %>
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">8. 改訂</h2>
+    <p class="sketch-body-text">
+      本ポリシーの内容を変更する場合があります。重要な変更を行う場合は、本ページの更新に加え、登録メールアドレス宛の通知またはアプリ内通知でお知らせします。
+    </p>
+  </div>
+
+  <p class="sketch-small" style="color: var(--muted); margin-top: 8px;">
+    改訂履歴: 2026-05-05 初版公開
+  </p>
+
+</div>

--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "プライバシーポリシー — weight daily." %>
 
-<div class="sketch-page-narrow" style="max-width: 40rem;">
+<div class="sketch-page-narrow" style="max-width: 40rem; padding-left: 16px; padding-right: 16px;">
 
   <h1 class="sketch-hh" style="margin-bottom: 4px;">プライバシーポリシー</h1>
   <p class="sketch-small" style="margin-bottom: 16px;">最終更新: 2026年5月5日</p>

--- a/app/views/legal/terms.html.erb
+++ b/app/views/legal/terms.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "利用規約 — weight daily." %>
 
-<div class="sketch-page-narrow" style="max-width: 40rem;">
+<div class="sketch-page-narrow" style="max-width: 40rem; padding-left: 16px; padding-right: 16px;">
 
   <h1 class="sketch-hh" style="margin-bottom: 4px;">利用規約</h1>
   <p class="sketch-small" style="margin-bottom: 16px;">最終更新: 2026年5月5日</p>

--- a/app/views/legal/terms.html.erb
+++ b/app/views/legal/terms.html.erb
@@ -1,0 +1,75 @@
+<% content_for :title, "利用規約 — weight daily." %>
+
+<div class="sketch-page-narrow" style="max-width: 40rem;">
+
+  <h1 class="sketch-hh" style="margin-bottom: 4px;">利用規約</h1>
+  <p class="sketch-small" style="margin-bottom: 16px;">最終更新: 2026年5月5日</p>
+
+  <p class="sketch-body-text" style="margin-bottom: 24px;">
+    本利用規約 (以下「本規約」) は、weight daily (以下「本サービス」) の利用条件を定めるものです。本サービスを利用する場合、本規約に同意したものとみなします。
+  </p>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">1. サービス概要</h2>
+    <p class="sketch-body-text">
+      本サービスは、ユーザーが日常生活で行う身体活動 (歩く、階段を選ぶなど) を可視化し、行動継続を支援する個人開発の Web アプリケーションです。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">2. 禁止事項</h2>
+    <p class="sketch-body-text" style="margin-bottom: 8px;">ユーザーは、本サービスの利用にあたり、以下の行為を行ってはなりません。</p>
+    <ul class="sketch-body-text" style="padding-left: 1.5em;">
+      <li>他人のアカウントへの不正アクセスまたはなりすまし</li>
+      <li>歩数等のデータを偽装する目的での不正な API リクエスト</li>
+      <li>法令または公序良俗に反する行為</li>
+      <li>本サービスの運営を妨害する行為</li>
+    </ul>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">3. 免責事項</h2>
+    <p class="sketch-body-text" style="margin-bottom: 8px;">
+      本サービスは、健康増進および行動の可視化を目的とした参考情報を提供するものであり、医療的助言、診断、治療を提供するものではありません。健康に関する判断は、必ず医療従事者にご相談ください。
+    </p>
+    <p class="sketch-body-text">
+      本サービスの利用によって生じたいかなる損害についても、運営者は責任を負いません。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">4. サービス変更・終了</h2>
+    <p class="sketch-body-text">
+      本サービスは個人によって運営されており、予告なく機能の変更、停止、または終了を行う場合があります。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">5. 規約の変更</h2>
+    <p class="sketch-body-text">
+      本規約の内容を変更する場合があります。変更後の規約は、本ページに掲載した時点から効力を生じます。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">6. 準拠法</h2>
+    <p class="sketch-body-text">
+      本規約の解釈および適用は、日本法に準拠します。
+    </p>
+  </div>
+
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">7. お問い合わせ</h2>
+    <p class="sketch-body-text">
+      本規約に関するお問い合わせは、以下のメールアドレスまでご連絡ください。
+    </p>
+    <p class="sketch-body-text" style="margin-top: 8px;">
+      <%= mail_to "weightdaily3@gmail.com", "weightdaily3@gmail.com", style: "color: var(--ink); text-decoration: underline;" %>
+    </p>
+  </div>
+
+  <p class="sketch-small" style="color: var(--muted); margin-top: 8px;">
+    改訂履歴: 2026-05-05 初版公開
+  </p>
+
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -85,6 +85,16 @@
     </p>
   <% end %>
 
+  <%# ポリシーリンク %>
+  <div class="sketch-box" style="margin-bottom: 24px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">ポリシー</h2>
+    <p class="sketch-body-text">
+      <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--ink); text-decoration: underline;" %>
+      /
+      <%= link_to "利用規約", terms_path, style: "color: var(--ink); text-decoration: underline;" %>
+    </p>
+  </div>
+
   <%# 危険ゾーン: トークン再生成 %>
   <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5;">
     <p class="sketch-h" style="margin-bottom: 8px;">トークンの再生成</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
 
   get "/about", to: "about#show", as: :about
 
+  get "/privacy", to: "legal#privacy", as: :privacy
+  get "/terms",   to: "legal#terms",   as: :terms
+
   get "/auth/:provider/callback", to: "sessions#create", as: :auth_callback
   get "/auth/failure", to: "sessions#failure", as: :auth_failure
   delete "/logout", to: "sessions#destroy", as: :logout

--- a/spec/requests/legal_spec.rb
+++ b/spec/requests/legal_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe "Legal", type: :request do
+  def login(user)
+    mock_google_oauth2(uid: user.uid, email: user.email, name: user.name)
+    get auth_callback_path(provider: "google_oauth2")
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /privacy
+  # ---------------------------------------------------------------------------
+  describe "GET /privacy" do
+    context "未ログイン時" do
+      before { get privacy_path }
+
+      it "200 OK を返す" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "「プライバシーポリシー」を含む" do
+        expect(response.body).to include("プライバシーポリシー")
+      end
+
+      it "お問い合わせメールアドレスを含む" do
+        expect(response.body).to include("weightdaily3@gmail.com")
+      end
+
+      it "「Anthropic」を含む" do
+        expect(response.body).to include("Anthropic")
+      end
+
+      it "「Render」を含む" do
+        expect(response.body).to include("Render")
+      end
+
+      it "「Google」を含む" do
+        expect(response.body).to include("Google")
+      end
+    end
+
+    context "ログイン済み時" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+        get privacy_path
+      end
+
+      it "200 OK を返す" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "「プライバシーポリシー」を含む" do
+        expect(response.body).to include("プライバシーポリシー")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /terms
+  # ---------------------------------------------------------------------------
+  describe "GET /terms" do
+    context "未ログイン時" do
+      before { get terms_path }
+
+      it "200 OK を返す" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "「利用規約」を含む" do
+        expect(response.body).to include("利用規約")
+      end
+
+      it "「禁止事項」を含む" do
+        expect(response.body).to include("禁止事項")
+      end
+
+      it "免責事項の文言を含む" do
+        expect(response.body).to include("医療的助言、診断、治療を提供するものではありません")
+      end
+
+      it "お問い合わせメールアドレスを含む" do
+        expect(response.body).to include("weightdaily3@gmail.com")
+      end
+    end
+
+    context "ログイン済み時" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+        get terms_path
+      end
+
+      it "200 OK を返す" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "「利用規約」を含む" do
+        expect(response.body).to include("利用規約")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Close #38

## Summary
- `/privacy` プライバシーポリシーページ + `/terms` 利用規約ページを新規実装
- ヘルスデータを扱うアプリとして必須の「医療的助言ではない」免責、第三者提供 (Render / Anthropic / Google OAuth) の明示、退会機能 (#84) との連携を文書化
- 認証不要 (= 未ログインでも閲覧可、スクール公開フォーム提出時の URL 公開対応)
- 連絡先: weightdaily3@gmail.com (= ユーザー本人取得)
- 改訂履歴セクション + 最終更新日でメンテナンス性確保

## レビュー反映 (= 3 者並列、2 ラウンド)

### 1 ラウンド目 → 修正コミット (`687703a`)
- 🔴 design-reviewer Blocker: privacy/terms 左右パディング不足 (4px → 16px) → ✅
- 🔴 design + strategic Blocker: ログイン前ポリシー導線なし → home/index 末尾にフッター追加 → ✅

### 2 ラウンド目 (= 修正後)
- 🟢 code-reviewer マージ可 (= 状態分岐破壊なし、XSS リスクゼロ、認可仕様通り)
- 🟢 strategic-reviewer マージ可 (= 論点 3 解消、スコープ妥当、教材性 OK)
- 🟢 design-reviewer マージ可 (= モバイル 375px で密着解消、全 state でフッター表示確認)

## 別 Issue 化したフォローアップ
- Issue #88: プライバシーポリシーに「事業者の表示」(運営者表記) 追加 (= 個情法ガイドライン対応)
- Issue #89: 利用規約「免責事項」に消費者契約法 8 条対応の但し書き追記
- Issue #90: Settings のポリシーリンクをページ最下部に移動
- Issue #91: 改訂履歴セクションの構造化 (テーブル化)

## Test plan
- [x] `bundle exec rspec` (380 examples / 0 failures)
- [x] `bundle exec rubocop` (no offenses)
- [x] 3 者並列レビュー 2 ラウンド (= code/strategic/design 全員マージ可)

## 教材性ポイント
- **個人開発のプライバシーポリシー雛形**: ヘルスデータ扱う場合の必須項目 (= 第三者提供 / 学習不使用 / 医療免責 / 退会と削除権) のテンプレ
- **footer 配置の慣習**: 法務系リンクはログイン状態に依存しないトップページ末尾、スクロール最下部 1 タップで到達できる
- **inline padding で sketch-page-narrow 上書き**: 共通スタイルを残しつつ inline で個別調整するパターン (= 共通定義を変えると全ページに波及するため)
- **mail_to ヘルパー**: `link_to "mailto:..."` でなく Rails ヘルパーを使うことで意図明確化

🤖 Generated with [Claude Code](https://claude.com/claude-code)