### PR TITLE
feat: 下段 4 カード「消費カード」の食品換算を動的化 (#71)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -128,6 +128,8 @@ body {
 /* font-size 14px 統一 (モバイル + プロジェクタ可読性、design-reviewer 指摘) */
 .sketch-label { font-family: 'Kalam', cursive; font-size: 14px; color: var(--muted); }
 .sketch-small { font-family: 'Kalam', cursive; font-size: 14px; color: var(--ink-2); }
+/* 食品換算テキスト: モバイル 375px で長い文字列が折り返さないよう ellipsis を当てる専用クラス */
+.sketch-food-equivalent { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .sketch-body-text { font-family: 'Kalam', cursive; font-size: 15px; line-height: 1.55; color: var(--ink-2); }
 
 /* highlight (黄/緑のマーカー風) */

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,8 @@ class HomeController < ApplicationController
     @advice          = CalorieAdviceService.call(@today_record&.estimated_kcal.to_i)
     # 貯カロリー (= 月リセット + 累計の二段構造) はチャート用 30 日 records とは別に
     # 全期間 records を渡して算出する (= 累計 total は全期間でないと意味が出ないため)。
-    @calorie_savings = CalorieSavingsService.call(fetch_calorie_records(@dashboard_state))
+    @calorie_savings  = CalorieSavingsService.call(fetch_calorie_records(@dashboard_state))
+    @food_equivalent  = CalorieEquivalentService.call(@today_record&.estimated_kcal.to_i)
   end
 
   private

--- a/app/services/calorie_equivalent_service.rb
+++ b/app/services/calorie_equivalent_service.rb
@@ -1,0 +1,52 @@
+# 今日の消費 kcal を身近な食品に換算して表示するためのサービス。
+#
+# 設計思想:
+#   - 「消費 kcal = 抽象的な数字」を「アイス N 個ぶん」に変換して直感的に伝える。
+#   - アプリの 3 ステップ思想ステップ ① 「罪悪感を減らす」の補助: 消費を食品で可視化することで
+#     「今日は動いた」という小さな達成感を具体的に実感させる。
+#
+# ランダム性の設計:
+#   - 毎日異なる食品が表示される「日替わり」方式。
+#   - seed に Date.current.to_s.bytes.sum を使うことで 1 日固定 (= 同日はリロードしても同じ)。
+#   - Date.to_s.hash を使わない理由: Ruby 1.9+ でハッシュ値のランダム化が導入されており
+#     実行ごとに異なる値になる可能性があるため。bytes.sum は実装依存なく安全。
+#   - seed: キーワード引数でテスト時に固定値を注入可能 (= テスト容易性)。
+#
+# nil 返却の条件:
+#   - today_kcal < 90 (= 最小食品 kcal 未満): 意味のある換算にならないため非表示。
+#   - count < 1: 選ばれた食品の kcal が today_kcal より大きい場合も非表示。
+class CalorieEquivalentService
+  Item = Struct.new(:emoji, :name, :unit, :kcal, keyword_init: true)
+
+  # 食品定数。外部からの参照を防ぐため private_constant で保護。
+  FOODS = [
+    Item.new(emoji: "🍦", name: "アイス",            unit: "個", kcal: 200),
+    Item.new(emoji: "🍺", name: "缶ビール",          unit: "本", kcal: 140),
+    Item.new(emoji: "🍙", name: "おにぎり",          unit: "個", kcal: 180),
+    Item.new(emoji: "🍌", name: "バナナ",            unit: "本", kcal:  90),
+    Item.new(emoji: "🍫", name: "板チョコ半分",      unit: "枚", kcal: 130),
+    Item.new(emoji: "🍡", name: "大福",              unit: "個", kcal: 170),
+    Item.new(emoji: "🍗", name: "唐揚げ 3 個",       unit: "皿", kcal: 250),
+    Item.new(emoji: "🥮", name: "どら焼き",          unit: "個", kcal: 200),
+    Item.new(emoji: "🥛", name: "カップヨーグルト",  unit: "個", kcal:  90),
+    Item.new(emoji: "☕", name: "カフェラテ",        unit: "杯", kcal: 150)
+  ].freeze
+  private_constant :FOODS
+
+  # @param today_kcal [Integer] 今日の消費 kcal
+  # @param seed [Integer] ランダムシード (テスト時に固定値を注入して確定的な挙動にする)
+  # @return [Hash{Symbol=>Object}, nil] { emoji:, name:, unit:, count: } or nil (表示しない)
+  def self.call(today_kcal, seed: Date.current.to_s.bytes.sum)
+    # 90 kcal (最小食品) 未満は意味のある換算にならないため非表示
+    return nil if today_kcal < FOODS.map(&:kcal).min
+
+    rng  = Random.new(seed)
+    food = FOODS.sample(random: rng)
+    count = today_kcal / food.kcal  # Integer 除算で切り捨て
+
+    # 選ばれた食品の kcal が today_kcal より大きい場合は 0 になるため skip
+    return nil if count < 1
+
+    { emoji: food.emoji, name: food.name, unit: food.unit, count: count }
+  end
+end

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -289,7 +289,9 @@
     <div class="sketch-label">🔥 消費</div>
     <div class="sketch-hh">+<%= today_kcal %> <span class="sketch-small">kcal</span></div>
     <% if food_equivalent %>
-      <div class="sketch-small">≒ <%= food_equivalent[:emoji] %> <%= food_equivalent[:name] %> <%= food_equivalent[:count] %> <%= food_equivalent[:unit] %>ぶん</div>
+      <div class="sketch-small sketch-food-equivalent">≒ <%= food_equivalent[:emoji] %> <%= food_equivalent[:name] %> <%= food_equivalent[:count] %> <%= food_equivalent[:unit] %>ぶん</div>
+    <% else %>
+      <div class="sketch-small">今日のプラスα</div>
     <% end %>
   </div>
 

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -1,8 +1,9 @@
 <%#
   Dashboard partial — Wireframe v3 の sketchy 再現版。
-  ローカル変数: display_name, records, today_record, streak, advice, calorie_savings
+  ローカル変数: display_name, records, today_record, streak, advice, calorie_savings, food_equivalent
   duck typing: records の各要素は recorded_on / steps / distance_meters / flights_climbed / estimated_kcal を持つ。
   calorie_savings: { this_month:, last_month:, total: } 各 kcal を整数で保持 (CalorieSavingsService 由来)。
+  food_equivalent: { emoji:, name:, unit:, count: } または nil (CalorieEquivalentService 由来)。
 %>
 
 <%# ---- SVG チャート計算 ---- %>
@@ -287,7 +288,9 @@
   <div class="sketch-box filled">
     <div class="sketch-label">🔥 消費</div>
     <div class="sketch-hh">+<%= today_kcal %> <span class="sketch-small">kcal</span></div>
-    <div class="sketch-small">≒ アイス 1 個ぶん</div>
+    <% if food_equivalent %>
+      <div class="sketch-small">≒ <%= food_equivalent[:emoji] %> <%= food_equivalent[:name] %> <%= food_equivalent[:count] %> <%= food_equivalent[:unit] %>ぶん</div>
+    <% end %>
   </div>
 
   <div class="sketch-box accent">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -28,7 +28,8 @@
         today_record:    @today_record,
         streak:          @streak,
         advice:          @advice,
-        calorie_savings: @calorie_savings %>
+        calorie_savings: @calorie_savings,
+        food_equivalent: @food_equivalent %>
 </div>
 
 <%# ポリシーフッター (= 未ログインでも到達できる経路) %>

--- a/spec/services/calorie_equivalent_service_spec.rb
+++ b/spec/services/calorie_equivalent_service_spec.rb
@@ -1,0 +1,267 @@
+require "rails_helper"
+
+RSpec.describe CalorieEquivalentService do
+  # 全テストで seed: を明示注入して確定的な挙動にする。
+  # グローバル乱数状態 (Kernel#srand) とは独立した Random.new を使うため
+  # srand リセットは不要。
+
+  # 食品 kcal の確認 (seed 別の選択結果):
+  #   seed=0,1 → 大福    170 kcal
+  #   seed=2,3 → カップヨーグルト  90 kcal
+  #   seed=4   → どら焼き 200 kcal
+  #   seed=5   → バナナ    90 kcal
+  #   seed=6   → カフェラテ 150 kcal
+  #   seed=7   → 板チョコ半分 130 kcal
+  #   seed=42  → 唐揚げ 3 個 250 kcal
+  #   seed=100 → カップヨーグルト  90 kcal
+  #   seed=123 → おにぎり 180 kcal
+  #   seed=999 → アイス   200 kcal
+
+  describe ".call" do
+    # ─────────────────────────────────────────────────
+    # nil 返却: today_kcal < 90 (最小食品 kcal 未満)
+    # ─────────────────────────────────────────────────
+    context "today_kcal = 0 のとき" do
+      it "nil を返す" do
+        expect(described_class.call(0, seed: 0)).to be_nil
+      end
+    end
+
+    context "today_kcal = 50 のとき" do
+      it "nil を返す" do
+        expect(described_class.call(50, seed: 0)).to be_nil
+      end
+    end
+
+    context "today_kcal = 89 のとき (最小食品 kcal の 1 未満)" do
+      it "nil を返す" do
+        expect(described_class.call(89, seed: 0)).to be_nil
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 境界値: today_kcal = 90 (最小食品 kcal と同値)
+    # ─────────────────────────────────────────────────
+    context "today_kcal = 90 かつ seed=2 (カップヨーグルト 90 kcal が選ばれる) のとき" do
+      subject(:result) { described_class.call(90, seed: 2) }
+
+      it "nil ではない" do
+        expect(result).not_to be_nil
+      end
+
+      it "count が 1 である (90 / 90 = 1)" do
+        expect(result[:count]).to eq(1)
+      end
+
+      it "name が「カップヨーグルト」である" do
+        expect(result[:name]).to eq("カップヨーグルト")
+      end
+    end
+
+    context "today_kcal = 90 かつ seed=42 (唐揚げ 3 個 250 kcal が選ばれる) のとき" do
+      it "nil を返す (count = 90 / 250 = 0 のため)" do
+        expect(described_class.call(90, seed: 42)).to be_nil
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 返却値の構造検証
+    # ─────────────────────────────────────────────────
+    context "today_kcal = 200 かつ seed=0 (大福 170 kcal が選ばれる) のとき" do
+      subject(:result) { described_class.call(200, seed: 0) }
+
+      it "nil ではない" do
+        expect(result).not_to be_nil
+      end
+
+      it ":emoji キーを持つ" do
+        expect(result).to have_key(:emoji)
+      end
+
+      it ":name キーを持つ" do
+        expect(result).to have_key(:name)
+      end
+
+      it ":unit キーを持つ" do
+        expect(result).to have_key(:unit)
+      end
+
+      it ":count キーを持つ" do
+        expect(result).to have_key(:count)
+      end
+
+      it "count が Integer である" do
+        expect(result[:count]).to be_a(Integer)
+      end
+
+      it "count が 1 以上である" do
+        expect(result[:count]).to be >= 1
+      end
+
+      it "count が 1 である (200 / 170 = 1)" do
+        expect(result[:count]).to eq(1)
+      end
+
+      it "name が「大福」である" do
+        expect(result[:name]).to eq("大福")
+      end
+
+      it "emoji が「🍡」である" do
+        expect(result[:emoji]).to eq("🍡")
+      end
+
+      it "unit が「個」である" do
+        expect(result[:unit]).to eq("個")
+      end
+    end
+
+    context "today_kcal = 200 かつ seed=5 (バナナ 90 kcal が選ばれる) のとき" do
+      subject(:result) { described_class.call(200, seed: 5) }
+
+      it "count が 2 である (200 / 90 = 2)" do
+        expect(result[:count]).to eq(2)
+      end
+
+      it "unit が「本」である" do
+        expect(result[:unit]).to eq("本")
+      end
+    end
+
+    context "today_kcal = 200 かつ seed=6 (カフェラテ 150 kcal が選ばれる) のとき" do
+      subject(:result) { described_class.call(200, seed: 6) }
+
+      it "count が 1 である (200 / 150 = 1)" do
+        expect(result[:count]).to eq(1)
+      end
+
+      it "unit が「杯」である" do
+        expect(result[:unit]).to eq("杯")
+      end
+    end
+
+    context "today_kcal = 200 かつ seed=7 (板チョコ半分 130 kcal が選ばれる) のとき" do
+      subject(:result) { described_class.call(200, seed: 7) }
+
+      it "count が 1 である (200 / 130 = 1)" do
+        expect(result[:count]).to eq(1)
+      end
+
+      it "unit が「枚」である" do
+        expect(result[:unit]).to eq("枚")
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # today_kcal = 1000 (大きい count)
+    # ─────────────────────────────────────────────────
+    context "today_kcal = 1000 かつ seed=42 (唐揚げ 3 個 250 kcal) のとき" do
+      subject(:result) { described_class.call(1000, seed: 42) }
+
+      it "count が 4 である (1000 / 250 = 4)" do
+        expect(result[:count]).to eq(4)
+      end
+
+      it "unit が「皿」である" do
+        expect(result[:unit]).to eq("皿")
+      end
+    end
+
+    context "today_kcal = 1000 かつ seed=123 (おにぎり 180 kcal) のとき" do
+      subject(:result) { described_class.call(1000, seed: 123) }
+
+      it "count が 5 である (1000 / 180 = 5)" do
+        expect(result[:count]).to eq(5)
+      end
+    end
+
+    context "today_kcal = 1000 かつ seed=5 (バナナ 90 kcal) のとき" do
+      subject(:result) { described_class.call(1000, seed: 5) }
+
+      it "count が 11 である (1000 / 90 = 11)" do
+        expect(result[:count]).to eq(11)
+      end
+    end
+
+    context "today_kcal = 1000 かつ seed=999 (アイス 200 kcal) のとき" do
+      subject(:result) { described_class.call(1000, seed: 999) }
+
+      it "count が 5 である (1000 / 200 = 5)" do
+        expect(result[:count]).to eq(5)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # シード固定の確定性 (同一 seed → 毎回同じ結果)
+    # ─────────────────────────────────────────────────
+    context "確定性: 同一 seed で複数回呼んでも同じ結果を返す" do
+      it "seed=42, kcal=1000 で 2 回呼んでも同じ Hash を返す" do
+        first  = described_class.call(1000, seed: 42)
+        second = described_class.call(1000, seed: 42)
+        expect(first).to eq(second)
+      end
+
+      it "seed=0, kcal=500 で 2 回呼んでも同じ Hash を返す" do
+        first  = described_class.call(500, seed: 0)
+        second = described_class.call(500, seed: 0)
+        expect(first).to eq(second)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # シード別に異なる食品が選ばれること
+    # ─────────────────────────────────────────────────
+    context "seed の違いで異なる食品が選ばれる" do
+      it "seed=0 (大福) と seed=42 (唐揚げ 3 個) では name が異なる" do
+        result_0  = described_class.call(1000, seed: 0)
+        result_42 = described_class.call(1000, seed: 42)
+        expect(result_0[:name]).not_to eq(result_42[:name])
+      end
+
+      it "seed=100 (カップヨーグルト) と seed=123 (おにぎり) では name が異なる" do
+        result_100 = described_class.call(1000, seed: 100)
+        result_123 = described_class.call(1000, seed: 123)
+        expect(result_100[:name]).not_to eq(result_123[:name])
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # unit の取り得る値 (実装の Item 定義参照)
+    # ─────────────────────────────────────────────────
+    context "unit の値" do
+      valid_units = %w[個 本 枚 杯 皿]
+
+      # seed=0,1(大福→個), 2(カップヨーグルト→個), 4(どら焼き→個), 5(バナナ→本),
+      # 6(カフェラテ→杯), 7(板チョコ半分→枚), 42(唐揚げ→皿)
+      {
+        0   => "個",  # 大福
+        5   => "本",  # バナナ
+        6   => "杯",  # カフェラテ
+        7   => "枚",  # 板チョコ半分
+        42  => "皿"  # 唐揚げ 3 個
+      }.each do |seed, expected_unit|
+        it "seed=#{seed} のとき unit が「#{expected_unit}」である" do
+          result = described_class.call(1000, seed: seed)
+          expect(result[:unit]).to eq(expected_unit)
+        end
+      end
+
+      it "seed=100 のとき unit が valid_units のいずれかである" do
+        result = described_class.call(500, seed: 100)
+        expect(valid_units).to include(result[:unit])
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # グローバル乱数状態への副作用なし
+    # ─────────────────────────────────────────────────
+    context "グローバル乱数状態への副作用" do
+      it "呼び出し後も Kernel#rand の系列が変わらない (Random.new 使用のため)" do
+        srand(12_345)
+        expected_next = rand
+        srand(12_345)
+        described_class.call(500, seed: 99)
+        expect(rand).to eq(expected_next)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Close #71

## Summary
- 下段 4 カード「🔥 消費」内の `≒ アイス 1 個ぶん` ハードコードを **動的計算 + 日替わりランダム + 絵文字付き** に動的化
- 軽食カテゴリ 10 種類 (= 🍦 アイス / 🍺 缶ビール / 🍙 おにぎり / 🍌 バナナ / 🍫 板チョコ半分 / 🍡 大福 / 🍗 唐揚げ 3 個 / 🥮 どら焼き / 🥛 カップヨーグルト / ☕ カフェラテ) からランダム抽出
- 1 日固定シード (= `Date.current.to_s.bytes.sum`) で日替わり、1 日内は安定
- `today_kcal < 90` (= 最小食品 kcal 未満) は表示しない、`<% else %>` で「今日のプラスα」フォールバック

## スコープ変更経緯
元 Issue「貯カロリーに食品換算」だったが、画面構成上の重複懸念から再設計:
- 下段 4 カード = 軽食ランダム動的化 (= 本 PR)
- AI 提案カードを累計ベース化 → **Issue #93** で別途
- 「next」案 = **Issue #94** で別途

## レビュー反映 (= 3 者並列、事前 + 実装後 2 ラウンド)

### 事前 (= 設計レビュー、実装前)
- 「next」案見送り (= 強要原則 / モバイル幅 / 英語浮き)
- 食品リスト平易化 (= 缶ビール 1 本 / カップヨーグルト 1 個 / 板チョコ半分 等)
- 絵文字付加 (= デモ効果)
- 技術仕様明確化 (= 90 kcal 未満 nil / `bytes.sum` シード / `seed:` 注入)

### 実装後 1 ラウンド目 → 修正コミット (`8a4241c`)
- 🔴 design Blocker: モバイル 375px 折り返しリスク → `.sketch-food-equivalent` 専用クラス追加 (= ellipsis) ✅
- 🔴 design Blocker: nil 時カード高さ不均一 → `<% else %>` フォールバック「今日のプラスα」追加 ✅

### 実装後 2 ラウンド目 (= 修正後)
- 🟢 code-reviewer マージ可 (= 既存パターン整合、回帰なし)
- 🟢 strategic-reviewer マージ可 (= スコープ最小、教材性微増)
- 🟢 design-reviewer マージ可 (= ellipsis 親制約成立、フォールバック整合)

## 別 Issue 化したフォローアップ (= 発表会後対応)
- Issue #93: AI 提案カードを累計ベース化
- Issue #94: 「next」案 (= 同スケール内次の食品ゲーミフィケーション)
- Issue #95: count 上限キャップ (= 「バナナ 11 本ぶん」回避)
- Issue #96: `MIN_KCAL` 定数化 + `Item` の `private_constant`

## Test plan
- [x] `bundle exec rspec` (420 examples / 0 failures、新規 spec 40 examples)
- [x] `bundle exec rubocop` (no offenses)
- [x] 3 者並列レビュー 計 3 ラウンド (= 事前 + 実装後 2 ラウンド) 全員マージ可

## 教材性ポイント
- **`Random.new(seed)` の局所化**: グローバル `srand` 副作用なしを spec で検証
- **`Date.to_s.bytes.sum` シード**: `.hash` は Ruby 1.9+ 実装依存なので回避、コメントで理由明記
- **`seed:` キーワード引数**: テスト容易性、外部依存切り離し
- **`Item = Struct` + `FOODS = [...].freeze` + `private_constant`**: Service object パターン、定数の保護
- **専用 CSS クラス分離 (`sketch-food-equivalent`)**: ユーティリティクラスに副作用出る修正は専用クラス切るパターン
- **nil フォールバックでカード高さ揃え**: グリッド UI のセル整合の典型対処

🤖 Generated with [Claude Code](https://claude.com/claude-code)