### PR TITLE
refactor: CalorieEquivalentService の MIN_KCAL 定数化 + Item の private_constant 追加 (#96)

### DIFF
--- a/app/services/calorie_equivalent_service.rb
+++ b/app/services/calorie_equivalent_service.rb
@@ -17,6 +17,7 @@
 #   - count < 1: 選ばれた食品の kcal が today_kcal より大きい場合も非表示。
 class CalorieEquivalentService
   Item = Struct.new(:emoji, :name, :unit, :kcal, keyword_init: true)
+  private_constant :Item
 
   # 食品定数。外部からの参照を防ぐため private_constant で保護。
   FOODS = [
@@ -33,12 +34,16 @@ class CalorieEquivalentService
   ].freeze
   private_constant :FOODS
 
+  # 最小食品 kcal を定数化。call のたびに FOODS を走査せず一度だけ評価する。
+  MIN_KCAL = FOODS.map(&:kcal).min
+  private_constant :MIN_KCAL
+
   # @param today_kcal [Integer] 今日の消費 kcal
   # @param seed [Integer] ランダムシード (テスト時に固定値を注入して確定的な挙動にする)
   # @return [Hash{Symbol=>Object}, nil] { emoji:, name:, unit:, count: } or nil (表示しない)
   def self.call(today_kcal, seed: Date.current.to_s.bytes.sum)
-    # 90 kcal (最小食品) 未満は意味のある換算にならないため非表示
-    return nil if today_kcal < FOODS.map(&:kcal).min
+    # MIN_KCAL (最小食品 kcal) 未満は意味のある換算にならないため非表示
+    return nil if today_kcal < MIN_KCAL
 
     rng  = Random.new(seed)
     food = FOODS.sample(random: rng)


### PR DESCRIPTION
Close #96

## Summary
- `MIN_KCAL = FOODS.map(&:kcal).min` を class-level 定数化 + `private_constant` (= `call` のたびの再評価を防ぐ)
- `Item` Struct に `private_constant :Item` 追加 (= 外部からの参照を防ぐ、`FOODS` と統一)
- 純粋リファクタ、動作変更なし

## レビュー結果 (= 3 者並列)
- 🟢 code-reviewer: マージ可 (Nit 1 件: コメント表記整合性、軽微で見送り)
- 🟢 strategic-reviewer: マージ可 (= スコープ理想形、教材性 ◎、残時間影響なし)
- 🟢 design-reviewer: マージ可 (= UI 影響なし)

## Test plan
- [x] `bundle exec rspec` (420 examples / 0 failures、動作変更なし維持)
- [x] `bundle exec rubocop` (no offenses)
- [x] 3 者並列レビュー全員 マージ可

## 教材性ポイント
- **`private_constant`**: Service 内部実装 (= `Struct` / 設定配列 / 派生定数) を外部参照不可にする Rails Way の API 境界宣言
- **マジックナンバー排除**: `FOODS.map(&:kcal).min` の遅延評価をクラスロード時に 1 回だけ評価して定数化、意図 (= 「最小食品 kcal 未満は非表示」) を名前で表現

🤖 Generated with [Claude Code](https://claude.com/claude-code)