### PR TITLE
feat: CalorieEquivalentService に count 上限キャップ + 再抽選を追加 (#95)

### DIFF
--- a/app/services/calorie_equivalent_service.rb
+++ b/app/services/calorie_equivalent_service.rb
@@ -52,6 +52,8 @@ class CalorieEquivalentService
     return nil if today_kcal < MIN_KCAL
 
     rng = Random.new(seed)
+    # 同 seed でも候補順をばらけさせ、上限 max_count 超え食品を弾く再抽選を可能にする。
+    # (旧実装の FOODS.sample では 1 食品決め打ちで上限超えを skip できなかった)
     shuffled = FOODS.shuffle(random: rng)
 
     # 1 <= count <= max_count を満たす最初の食品を採用 (再抽選ロジック)
@@ -60,8 +62,11 @@ class CalorieEquivalentService
       return { emoji: food.emoji, name: food.name, unit: food.unit, count: count } if count >= 1 && count <= max_count
     end
 
-    # フォールバック: 全食品で count > max_count の場合は最大 kcal 食品でキャップ
-    # (例: today_kcal = 5000 では全食品 count > 5 になる)
+    # フォールバック: 全食品で 1 <= count <= max_count を満たさない場合 (= today_kcal が
+    # 非常に高い)、最大 kcal 食品で [count, max_count].min にキャップして返す。
+    # count == 0 (today_kcal < food.kcal) の経路も理論上ここに到達するが、現状の FOODS は
+    # MIN_KCAL = 90 のため today_kcal >= 90 なら必ず 1 食品以上 count >= 1 になり、count == 0
+    # 経路は発生しない。
     largest = FOODS.max_by(&:kcal)
     count = today_kcal / largest.kcal
     return nil if count < 1

--- a/app/services/calorie_equivalent_service.rb
+++ b/app/services/calorie_equivalent_service.rb
@@ -14,7 +14,12 @@
 #
 # nil 返却の条件:
 #   - today_kcal < 90 (= 最小食品 kcal 未満): 意味のある換算にならないため非表示。
-#   - count < 1: 選ばれた食品の kcal が today_kcal より大きい場合も非表示。
+#   - フォールバック時に count < 1: 最大 kcal 食品でも today_kcal が 1 個ぶんに満たない場合。
+#
+# count 上限キャップの設計:
+#   - max_count (デフォルト 5) を超える count は UI 上で冗長になる (例: バナナ 11 本ぶん)。
+#   - FOODS.shuffle で順序を確定し、count が 1..max_count に収まる最初の食品を採用する。
+#   - 全食品で上限を超える場合は最大 kcal 食品で [count, max_count].min にキャップ。
 class CalorieEquivalentService
   Item = Struct.new(:emoji, :name, :unit, :kcal, keyword_init: true)
   private_constant :Item
@@ -40,18 +45,27 @@ class CalorieEquivalentService
 
   # @param today_kcal [Integer] 今日の消費 kcal
   # @param seed [Integer] ランダムシード (テスト時に固定値を注入して確定的な挙動にする)
+  # @param max_count [Integer] count の上限 (デフォルト 5)。これを超える count は再抽選 or キャップ
   # @return [Hash{Symbol=>Object}, nil] { emoji:, name:, unit:, count: } or nil (表示しない)
-  def self.call(today_kcal, seed: Date.current.to_s.bytes.sum)
+  def self.call(today_kcal, seed: Date.current.to_s.bytes.sum, max_count: 5)
     # MIN_KCAL (最小食品 kcal) 未満は意味のある換算にならないため非表示
     return nil if today_kcal < MIN_KCAL
 
-    rng  = Random.new(seed)
-    food = FOODS.sample(random: rng)
-    count = today_kcal / food.kcal  # Integer 除算で切り捨て
+    rng = Random.new(seed)
+    shuffled = FOODS.shuffle(random: rng)
 
-    # 選ばれた食品の kcal が today_kcal より大きい場合は 0 になるため skip
+    # 1 <= count <= max_count を満たす最初の食品を採用 (再抽選ロジック)
+    shuffled.each do |food|
+      count = today_kcal / food.kcal  # Integer 除算で切り捨て
+      return { emoji: food.emoji, name: food.name, unit: food.unit, count: count } if count >= 1 && count <= max_count
+    end
+
+    # フォールバック: 全食品で count > max_count の場合は最大 kcal 食品でキャップ
+    # (例: today_kcal = 5000 では全食品 count > 5 になる)
+    largest = FOODS.max_by(&:kcal)
+    count = today_kcal / largest.kcal
     return nil if count < 1
 
-    { emoji: food.emoji, name: food.name, unit: food.unit, count: count }
+    { emoji: largest.emoji, name: largest.name, unit: largest.unit, count: [ count, max_count ].min }
   end
 end

--- a/spec/services/calorie_equivalent_service_spec.rb
+++ b/spec/services/calorie_equivalent_service_spec.rb
@@ -5,17 +5,18 @@ RSpec.describe CalorieEquivalentService do
   # グローバル乱数状態 (Kernel#srand) とは独立した Random.new を使うため
   # srand リセットは不要。
 
-  # 食品 kcal の確認 (seed 別の選択結果):
-  #   seed=0,1 → 大福    170 kcal
-  #   seed=2,3 → カップヨーグルト  90 kcal
-  #   seed=4   → どら焼き 200 kcal
-  #   seed=5   → バナナ    90 kcal
-  #   seed=6   → カフェラテ 150 kcal
-  #   seed=7   → 板チョコ半分 130 kcal
-  #   seed=42  → 唐揚げ 3 個 250 kcal
-  #   seed=100 → カップヨーグルト  90 kcal
-  #   seed=123 → おにぎり 180 kcal
-  #   seed=999 → アイス   200 kcal
+  # 新アルゴリズム (shuffle + 再抽選) での seed 別採用食品:
+  #   - FOODS.shuffle(random: rng) で並び順を確定し、1 <= count <= max_count(5) を
+  #     満たす最初の食品を採用する。以下は today_kcal=1000, max_count=5 での結果。
+  #   seed=0   → おにぎり   180 kcal (count=5)
+  #   seed=1   → おにぎり   180 kcal (count=5)
+  #   seed=2   → 大福       170 kcal (count=5)
+  #   seed=5   → 大福       170 kcal (count=5)
+  #   seed=6   → どら焼き   200 kcal (count=5)
+  #   seed=42  → 大福       170 kcal (count=5)
+  #   seed=100 → どら焼き   200 kcal (count=5)
+  #   seed=123 → アイス     200 kcal (count=5)
+  #   seed=999 → 唐揚げ 3 個 250 kcal (count=4)
 
   describe ".call" do
     # ─────────────────────────────────────────────────
@@ -42,10 +43,26 @@ RSpec.describe CalorieEquivalentService do
     # ─────────────────────────────────────────────────
     # 境界値: today_kcal = 90 (最小食品 kcal と同値)
     # ─────────────────────────────────────────────────
-    context "today_kcal = 90 かつ seed=2 (カップヨーグルト 90 kcal が選ばれる) のとき" do
+    context "today_kcal = 90 かつ seed=2 (shuffle後の最初の 90 kcal 食品: バナナ) のとき" do
       subject(:result) { described_class.call(90, seed: 2) }
 
       it "nil ではない" do
+        expect(result).not_to be_nil
+      end
+
+      it "count が 1 である (90 / 90 = 1)" do
+        expect(result[:count]).to eq(1)
+      end
+
+      it "name が「バナナ」である" do
+        expect(result[:name]).to eq("バナナ")
+      end
+    end
+
+    context "today_kcal = 90 かつ seed=42 (shuffle後の最初の 90 kcal 食品: カップヨーグルト) のとき" do
+      subject(:result) { described_class.call(90, seed: 42) }
+
+      it "nil ではない (再抽選でカップヨーグルトが見つかる)" do
         expect(result).not_to be_nil
       end
 
@@ -58,16 +75,10 @@ RSpec.describe CalorieEquivalentService do
       end
     end
 
-    context "today_kcal = 90 かつ seed=42 (唐揚げ 3 個 250 kcal が選ばれる) のとき" do
-      it "nil を返す (count = 90 / 250 = 0 のため)" do
-        expect(described_class.call(90, seed: 42)).to be_nil
-      end
-    end
-
     # ─────────────────────────────────────────────────
     # 返却値の構造検証
     # ─────────────────────────────────────────────────
-    context "today_kcal = 200 かつ seed=0 (大福 170 kcal が選ばれる) のとき" do
+    context "today_kcal = 200 かつ seed=0 (shuffle後の最初の適合食品: おにぎり 180 kcal) のとき" do
       subject(:result) { described_class.call(200, seed: 0) }
 
       it "nil ではない" do
@@ -98,16 +109,16 @@ RSpec.describe CalorieEquivalentService do
         expect(result[:count]).to be >= 1
       end
 
-      it "count が 1 である (200 / 170 = 1)" do
+      it "count が 1 である (200 / 180 = 1)" do
         expect(result[:count]).to eq(1)
       end
 
-      it "name が「大福」である" do
-        expect(result[:name]).to eq("大福")
+      it "name が「おにぎり」である" do
+        expect(result[:name]).to eq("おにぎり")
       end
 
-      it "emoji が「🍡」である" do
-        expect(result[:emoji]).to eq("🍡")
+      it "emoji が「🍙」である" do
+        expect(result[:emoji]).to eq("🍙")
       end
 
       it "unit が「個」である" do
@@ -115,20 +126,8 @@ RSpec.describe CalorieEquivalentService do
       end
     end
 
-    context "today_kcal = 200 かつ seed=5 (バナナ 90 kcal が選ばれる) のとき" do
+    context "today_kcal = 200 かつ seed=5 (カフェラテ 150 kcal が選ばれる) のとき" do
       subject(:result) { described_class.call(200, seed: 5) }
-
-      it "count が 2 である (200 / 90 = 2)" do
-        expect(result[:count]).to eq(2)
-      end
-
-      it "unit が「本」である" do
-        expect(result[:unit]).to eq("本")
-      end
-    end
-
-    context "today_kcal = 200 かつ seed=6 (カフェラテ 150 kcal が選ばれる) のとき" do
-      subject(:result) { described_class.call(200, seed: 6) }
 
       it "count が 1 である (200 / 150 = 1)" do
         expect(result[:count]).to eq(1)
@@ -139,23 +138,67 @@ RSpec.describe CalorieEquivalentService do
       end
     end
 
-    context "today_kcal = 200 かつ seed=7 (板チョコ半分 130 kcal が選ばれる) のとき" do
-      subject(:result) { described_class.call(200, seed: 7) }
+    context "today_kcal = 200 かつ seed=6 (カップヨーグルト 90 kcal が選ばれる) のとき" do
+      subject(:result) { described_class.call(200, seed: 6) }
 
-      it "count が 1 である (200 / 130 = 1)" do
-        expect(result[:count]).to eq(1)
+      it "count が 2 である (200 / 90 = 2)" do
+        expect(result[:count]).to eq(2)
       end
 
-      it "unit が「枚」である" do
-        expect(result[:unit]).to eq("枚")
+      it "unit が「個」である" do
+        expect(result[:unit]).to eq("個")
+      end
+    end
+
+    context "today_kcal = 200 かつ seed=7 (カップヨーグルト 90 kcal が選ばれる) のとき" do
+      subject(:result) { described_class.call(200, seed: 7) }
+
+      it "count が 2 である (200 / 90 = 2)" do
+        expect(result[:count]).to eq(2)
+      end
+
+      it "unit が「個」である" do
+        expect(result[:unit]).to eq("個")
       end
     end
 
     # ─────────────────────────────────────────────────
-    # today_kcal = 1000 (大きい count)
+    # today_kcal = 1000 (count 上限キャップの動作確認)
     # ─────────────────────────────────────────────────
-    context "today_kcal = 1000 かつ seed=42 (唐揚げ 3 個 250 kcal) のとき" do
+    context "today_kcal = 1000 かつ seed=42 (大福 170 kcal, count=5) のとき" do
       subject(:result) { described_class.call(1000, seed: 42) }
+
+      it "count が 5 である (1000 / 170 = 5, max_count=5 以内)" do
+        expect(result[:count]).to eq(5)
+      end
+
+      it "unit が「個」である" do
+        expect(result[:unit]).to eq("個")
+      end
+    end
+
+    context "today_kcal = 1000 かつ seed=123 (アイス 200 kcal, count=5) のとき" do
+      subject(:result) { described_class.call(1000, seed: 123) }
+
+      it "count が 5 である (1000 / 200 = 5)" do
+        expect(result[:count]).to eq(5)
+      end
+    end
+
+    context "today_kcal = 1000 かつ seed=5 (大福 170 kcal, count=5: 旧バナナ count=11 は上限超え) のとき" do
+      subject(:result) { described_class.call(1000, seed: 5) }
+
+      it "count が max_count (5) 以下である" do
+        expect(result[:count]).to be <= 5
+      end
+
+      it "count が 5 である (大福 170 kcal で 1000 / 170 = 5)" do
+        expect(result[:count]).to eq(5)
+      end
+    end
+
+    context "today_kcal = 1000 かつ seed=999 (唐揚げ 3 個 250 kcal, count=4) のとき" do
+      subject(:result) { described_class.call(1000, seed: 999) }
 
       it "count が 4 である (1000 / 250 = 4)" do
         expect(result[:count]).to eq(4)
@@ -166,27 +209,43 @@ RSpec.describe CalorieEquivalentService do
       end
     end
 
-    context "today_kcal = 1000 かつ seed=123 (おにぎり 180 kcal) のとき" do
-      subject(:result) { described_class.call(1000, seed: 123) }
+    # ─────────────────────────────────────────────────
+    # count 上限キャップ: max_count を超えないこと
+    # ─────────────────────────────────────────────────
+    context "today_kcal = 5000 (全食品で count > 5 になる) のとき" do
+      subject(:result) { described_class.call(5000, seed: 0) }
 
-      it "count が 5 である (1000 / 180 = 5)" do
+      it "nil ではない (フォールバックで最大 kcal 食品が返る)" do
+        expect(result).not_to be_nil
+      end
+
+      it "count が max_count (5) 以下である" do
+        expect(result[:count]).to be <= 5
+      end
+
+      it "フォールバックで唐揚げ 3 個 (最大 kcal 250) が返る" do
+        expect(result[:name]).to eq("唐揚げ 3 個")
+      end
+
+      it "count が 5 にキャップされている (5000 / 250 = 20 → cap)" do
         expect(result[:count]).to eq(5)
       end
     end
 
-    context "today_kcal = 1000 かつ seed=5 (バナナ 90 kcal) のとき" do
-      subject(:result) { described_class.call(1000, seed: 5) }
+    context "max_count: 3 を指定したとき (today_kcal = 1000, seed=0)" do
+      # seed=0 では全食品で count > 3 → フォールバックで唐揚げ 3 個 (250 kcal) + cap
+      subject(:result) { described_class.call(1000, seed: 0, max_count: 3) }
 
-      it "count が 11 である (1000 / 90 = 11)" do
-        expect(result[:count]).to eq(11)
+      it "count が 3 以下である" do
+        expect(result[:count]).to be <= 3
       end
-    end
 
-    context "today_kcal = 1000 かつ seed=999 (アイス 200 kcal) のとき" do
-      subject(:result) { described_class.call(1000, seed: 999) }
+      it "count が 3 にキャップされている (1000 / 250 = 4 → cap 3)" do
+        expect(result[:count]).to eq(3)
+      end
 
-      it "count が 5 である (1000 / 200 = 5)" do
-        expect(result[:count]).to eq(5)
+      it "フォールバックで唐揚げ 3 個が返る" do
+        expect(result[:name]).to eq("唐揚げ 3 個")
       end
     end
 
@@ -211,16 +270,16 @@ RSpec.describe CalorieEquivalentService do
     # シード別に異なる食品が選ばれること
     # ─────────────────────────────────────────────────
     context "seed の違いで異なる食品が選ばれる" do
-      it "seed=0 (大福) と seed=42 (唐揚げ 3 個) では name が異なる" do
+      it "seed=0 (おにぎり) と seed=42 (大福) では name が異なる" do
         result_0  = described_class.call(1000, seed: 0)
         result_42 = described_class.call(1000, seed: 42)
         expect(result_0[:name]).not_to eq(result_42[:name])
       end
 
-      it "seed=100 (カップヨーグルト) と seed=123 (おにぎり) では name が異なる" do
+      it "seed=100 (どら焼き) と seed=999 (唐揚げ 3 個) では name が異なる" do
         result_100 = described_class.call(1000, seed: 100)
-        result_123 = described_class.call(1000, seed: 123)
-        expect(result_100[:name]).not_to eq(result_123[:name])
+        result_999 = described_class.call(1000, seed: 999)
+        expect(result_100[:name]).not_to eq(result_999[:name])
       end
     end
 
@@ -230,14 +289,14 @@ RSpec.describe CalorieEquivalentService do
     context "unit の値" do
       valid_units = %w[個 本 枚 杯 皿]
 
-      # seed=0,1(大福→個), 2(カップヨーグルト→個), 4(どら焼き→個), 5(バナナ→本),
-      # 6(カフェラテ→杯), 7(板チョコ半分→枚), 42(唐揚げ→皿)
+      # seed=0(おにぎり→個), seed=5(大福→個), seed=6(どら焼き→個), seed=7(大福→個),
+      # seed=42(大福→個), seed=999(唐揚げ→皿)
       {
-        0   => "個",  # 大福
-        5   => "本",  # バナナ
-        6   => "杯",  # カフェラテ
-        7   => "枚",  # 板チョコ半分
-        42  => "皿"  # 唐揚げ 3 個
+        0   => "個",  # おにぎり
+        5   => "個",  # 大福
+        6   => "個",  # どら焼き
+        7   => "個",  # 大福
+        999 => "皿"  # 唐揚げ 3 個
       }.each do |seed, expected_unit|
         it "seed=#{seed} のとき unit が「#{expected_unit}」である" do
           result = described_class.call(1000, seed: seed)


### PR DESCRIPTION
Close #95

## Summary
- `max_count` キーワード引数 (= デフォルト `5`) を追加して count 上限キャップを導入
- アルゴリズム変更: `FOODS.sample(random: rng)` → `FOODS.shuffle(random: rng)` で順序確定 → `1 <= count <= max_count` を満たす最初の食品を採用 (= 再抽選)
- フォールバック: 全食品マッチしない場合は最大 kcal 食品で `[count, max_count].min` キャップ
- 「バナナ 11 本ぶん」のような大きい count を回避し、「アイス 5 個ぶん」程度に抑える

## レビュー反映 (= 3 者並列、2 ラウンド)

### 1 ラウンド目 → コメント修正 commit (`c9b0904`)
- 🟡 code-reviewer Should fix: フォールバックコメント不正確 → 修正済 (= count == 0 経路の言及含む)
- 🟡 strategic-reviewer 推奨: shuffle 採用理由コメント追加 → 修正済 (= 教材性向上)

### 2 ラウンド目 (= 修正後)
- 🟢 code-reviewer マージ可 (= コメント正確、動作変更なし)
- 🟢 strategic-reviewer マージ可 (= 最小差分で教材性底上げ)
- 🟢 design-reviewer マージ可 (= UI 影響なし)

## 別 Issue 化したフォローアップ
- Issue #99: 食品換算フォールバック文言の読みづらさ解消 (= 食品 name 構造改善、発表会後対応)

## Test plan
- [x] `bundle exec rspec` (431 examples / 0 failures、新規 16 examples)
- [x] `bundle exec rubocop` (no offenses)
- [x] 3 者並列レビュー 2 ラウンド (= 全員マージ可)

## 教材性ポイント
- **再抽選 + フォールバック + キャップの 3 段階ロジック**: Service object の応用パターン
- **`shuffle(random: rng)` の選択**: 旧 `sample` と比較してなぜ shuffle かをコメントで明示
- **コメントで「現在の制約 + 将来の含意」を残す**: フォールバック path の count == 0 経路は現状 FOODS では発生しないが、将来 FOODS 変更時の混乱回避のため明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)