### PR TITLE
refactor: webhook_deliveries / step_records の FK に on_delete: :cascade を追加 (#85)

### DIFF
--- a/db/migrate/20260505041407_add_cascade_delete_to_user_foreign_keys.rb
+++ b/db/migrate/20260505041407_add_cascade_delete_to_user_foreign_keys.rb
@@ -1,0 +1,9 @@
+class AddCascadeDeleteToUserForeignKeys < ActiveRecord::Migration[8.1]
+  def change
+    remove_foreign_key :step_records, :users
+    add_foreign_key :step_records, :users, on_delete: :cascade
+
+    remove_foreign_key :webhook_deliveries, :users
+    add_foreign_key :webhook_deliveries, :users, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_063009) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_041407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,6 +50,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_063009) do
     t.index ["user_id"], name: "index_webhook_deliveries_on_user_id"
   end
 
-  add_foreign_key "step_records", "users"
-  add_foreign_key "webhook_deliveries", "users"
+  add_foreign_key "step_records", "users", on_delete: :cascade
+  add_foreign_key "webhook_deliveries", "users", on_delete: :cascade
 end


### PR DESCRIPTION
Close #85

## Summary
退会機能 (PR #87) で実装した `dependent: :destroy` を DB レイヤーでも整合化。`step_records` / `webhook_deliveries` の FK に `on_delete: :cascade` を追加し、Rails 層と DB 層の **二重防衛** を確立。

## 背景
- PR #87 で `User` モデルに `has_many :step_records, dependent: :destroy` / `has_many :webhook_deliveries, dependent: :destroy` を設定済み
- DB 側 FK は `on_delete:` 指定なし (= RESTRICT 相当) のままで、Rails 経由の削除では問題ないが、コンソール直接削除 (= `User.delete_all` 等) で FK 違反になる潜在リスク
- 本 PR で DB 側にも cascade を明示

## 変更内容
```ruby
class AddCascadeDeleteToUserForeignKeys < ActiveRecord::Migration[8.1]
  def change
    remove_foreign_key :step_records, :users
    add_foreign_key :step_records, :users, on_delete: :cascade

    remove_foreign_key :webhook_deliveries, :users
    add_foreign_key :webhook_deliveries, :users, on_delete: :cascade
  end
end
```

`webhook_deliveries.user_id` は **nullable** (= unauthorized 時 user_id = nil) だが、`on_delete: :cascade` は user_id が NOT NULL の行のみ削除するため、unauthorized レコード (= user_id = nil) への影響なし。

## レビュー結果 (= 3 者並列)
- 🟢 code-reviewer マージ可 (= migration 冪等性 / schema.rb 反映 / 二重防御整合 すべて OK)
- 🟢 strategic-reviewer マージ可 (= 「アプリ層と DB 層は別レイヤー、退会/GDPR 系は必ずペア設計」教材性 ◎)
- 🟢 design-reviewer マージ可 (= UI 影響なし)

## 教材性ポイント
- **Rails `dependent: :destroy` と DB `on_delete: :cascade` の二重防衛**: アプリ層の宣言と DB 層の制約は別レイヤー、片方では孤児レコード対策にならない
- **migration の冪等性**: `remove_foreign_key` → `add_foreign_key` パターンで rollback も自動対応
- **二重防衛の意義**: 退会機能と組み合わせて、SQL 直叩き / 別アプリ経由削除でも孤児レコードが残らない設計

## Test plan
- [x] `bundle exec rspec` (= 431 examples / 0 failures、既存挙動維持)
- [x] `bundle exec rubocop` (= no offenses)
- [x] migration 適用済み (= db/schema.rb 反映確認)
- [x] 3 者並列レビュー全員マージ可

🤖 Generated with [Claude Code](https://claude.com/claude-code)