### PR TITLE
refactor: sketchy theme に --danger カラートークン + 専用クラスを整備 (#86)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -18,6 +18,9 @@
   --accent-2: #ffd23f;
   --accent-3: #4ea8de;
   --accent-4: #7ac74f;
+  /* danger (危険ゾーン / 破壊的操作) */
+  --danger: #cc0000;
+  --danger-bg: #ffe5e5;
 }
 
 /* body 全体を紙質背景に。layout から bg-base-200 は外す前提。 */
@@ -94,6 +97,16 @@ body {
 .sketch-box.accent { background: var(--accent); color: var(--ink); }
 .sketch-box.accent .sketch-label,
 .sketch-box.accent .sketch-small { color: var(--ink-2); }
+/* danger: 破壊的操作 (退会 / トークン再生成) の警告エリア。
+   sketch-box-danger  → 背景 + ボーダー両方を danger 色に (アカウント削除ボックス等)。
+   sketch-box-danger-soft → 背景のみ (ボーダーは既定の --ink 黒のまま = トークン再生成ボックス)。
+   --danger (#cc0000) は黒文字 (5.91:1) で WCAG AA 合格。 */
+.sketch-box-danger      { background: var(--danger-bg); border-color: var(--danger); }
+.sketch-box-danger-soft { background: var(--danger-bg); }
+/* danger テキスト (見出し・ラベル) */
+.sketch-h-danger { color: var(--danger); }
+/* danger ボタン: .sketch-btn と組み合わせて使う。ボーダー + 文字を danger 色に。 */
+.sketch-btn-danger { border-color: var(--danger); color: var(--danger); }
 
 /* ---------- webhook delivery history (Settings 画面) ---------- */
 /* 受信履歴の各行を縦並びリストで表示。time / status / count / error_message を flex で配置。

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -96,7 +96,7 @@
   </div>
 
   <%# 危険ゾーン: トークン再生成 %>
-  <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5;">
+  <div class="sketch-box sketch-box-danger-soft" style="margin-bottom: 24px;">
     <p class="sketch-h" style="margin-bottom: 8px;">トークンの再生成</p>
     <p class="sketch-body-text" style="margin-bottom: 16px;">
       ⚠️ <strong>トークンを再生成すると、現在 Apple Shortcuts に設定済みのトークンは無効になります。</strong>
@@ -113,15 +113,14 @@
   <div data-controller="confirm-deletion"
        data-confirm-deletion-expected-name-value="<%= current_user.name %>">
 
-    <div class="sketch-box" style="margin-bottom: 24px; background: #ffe5e5; border-color: #cc0000;">
-      <p class="sketch-h" style="margin-bottom: 8px; color: #cc0000;">⚠️ アカウントの削除</p>
+    <div class="sketch-box sketch-box-danger" style="margin-bottom: 24px;">
+      <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;">⚠️ アカウントの削除</p>
       <p class="sketch-body-text" style="margin-bottom: 16px;">
         アカウントを削除すると、歩数記録・連携設定を含む<strong>すべてのデータが即時に削除</strong>されます。
         この操作は取り消せません。
       </p>
       <button type="button"
-              class="sketch-btn"
-              style="border-color: #cc0000; color: #cc0000;"
+              class="sketch-btn sketch-btn-danger"
               data-action="click->confirm-deletion#openModal">
         アカウントを削除する
       </button>
@@ -137,7 +136,7 @@
          data-action="click->confirm-deletion#backdropClose">
       <div class="sketch-box"
            style="width: min(90vw, 24rem); background: var(--paper); position: relative;">
-        <p id="deletion-modal-title" class="sketch-h" style="margin-bottom: 12px; color: #cc0000;">
+        <p id="deletion-modal-title" class="sketch-h sketch-h-danger" style="margin-bottom: 12px;">
           ⚠️ 本当に退会しますか？
         </p>
         <p class="sketch-body-text" style="margin-bottom: 16px;">
@@ -165,8 +164,7 @@
               キャンセル
             </button>
             <button type="submit"
-                    class="sketch-btn"
-                    style="border-color: #cc0000; color: #cc0000;"
+                    class="sketch-btn sketch-btn-danger"
                     disabled
                     data-confirm-deletion-target="submitButton">
               退会する


### PR DESCRIPTION
Close #86

## Summary
PR #87 (退会機能) で `app/views/settings/show.html.erb` にハードコードしていた `#cc0000` / `#ffe5e5` を、sketchy theme の **CSS variable + 専用クラス** に整備。

## 変更内容

### 1. CSS variable 追加 (`:root`)
| トークン | 値 | 用途 |
|---|---|---|
| `--danger` | `#cc0000` | 文字・ボーダー色 |
| `--danger-bg` | `#ffe5e5` | 背景色 |

### 2. 専用クラス追加 (sketchy.css)
| クラス | 内容 | 使用箇所 |
|---|---|---|
| `.sketch-box-danger` | 背景 + 赤ボーダー | アカウント削除ボックス (= 強い警告) |
| `.sketch-box-danger-soft` | 背景のみ (ボーダーは黒) | トークン再生成ボックス (= 弱い注意) |
| `.sketch-h-danger` | 文字色 only | 削除見出し / モーダルタイトル |
| `.sketch-btn-danger` | sketch-btn と組み合わせ、ボーダー + 文字色 | 削除ボタン |

### 3. view ハードコード排除
`#cc0000` / `#ffe5e5` の grep ヒット **0 件** 確認。

## 設計判断: `-soft` suffix で 2 段階 intensity

- **強い警告** = `sketch-box-danger` (背景 + ボーダー赤)
- **弱い注意** = `sketch-box-danger-soft` (背景のみ、ボーダー黒)

→ アカウント削除と token 再生成の警告レベル差を視覚的に表現。

## レビュー結果 (= 3 者並列)
- 🟢 code-reviewer マージ可 (= Nit: 既存命名混在は許容)
- 🟢 strategic-reviewer マージ可 (= スコープ妥当、教材性 ◎、`--danger` 整備が `--accent` `--success` 拡張の雛形に)
- 🟢 design-reviewer マージ可 (= WCAG AA 5.91:1 通過、視覚差自然、純粋 refactor)

## 別 Issue 化したフォローアップ
- Issue #105: トークン再生成ボックスのタイトル色統一 (= `sketch-h-danger` 付与)
- Issue #106: CLAUDE.md に危険度クラス命名方針を追記 (= 後輩教材性向上)

## Test plan
- [x] `bundle exec rspec` (= 431 examples / 0 failures)
- [x] `bundle exec rubocop` (= no offenses)
- [x] view から `#cc0000` `#ffe5e5` ハードコード排除 (= grep 0 件)
- [x] 3 者並列レビュー全員マージ可

## 教材性ポイント
- **「色のハードコード → CSS variable → 専用クラス」の 3 段階整備**: 後輩が CSS 設計を学ぶ最小教材
- **2 段階 intensity (`-soft`)**: 警告レベルを命名で表現、daisyUI の `btn-error` / `btn-error-soft` パターンと整合
- **将来拡張パス**: `--accent` `--success` 等を整備する時の雛形

🤖 Generated with [Claude Code](https://claude.com/claude-code)