### PR TITLE
chore: postCreateCommand で mise trust を自動化 (#45)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,5 +30,5 @@
 
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "bin/setup --skip-server"
+  "postCreateCommand": "mise trust mise.toml && bin/setup --skip-server"
 }


### PR DESCRIPTION
Close #45

## Summary
container recreate 時に `mise` の trust 状態が消えて `bin/setup` が失敗する問題を、`postCreateCommand` で `mise trust mise.toml` を自動実行することで解消。

## 背景
Day 4 (= 2026-05-03 前半、ngrok 整備セッション) で発覚:

> **`mise` の trust は container 単位で消える**: container を recreate すると `~/.local/share/mise/trusted-configs/` 相当が消えて Ruby/bundle/rails 全部ブロックされる。手動復旧は `mise trust /workspaces/weight_dialy/mise.toml`。

→ Backlog Issue #45 として起票、Day 7 polish フェーズで消化。

## 変更内容
```diff
- "postCreateCommand": "bin/setup --skip-server"
+ "postCreateCommand": "mise trust mise.toml && bin/setup --skip-server"
```

## 設計判断

- **`mise trust` を `bin/setup` の前**: `bin/setup` は内部で `bundle install` (= mise 経由 Ruby) を呼ぶため、trust が事前必要
- **`&&` 連結**: 失敗時 fail-fast (= `mise trust` 失敗で `bin/setup` を実行しない)
- **相対パス `mise.toml`**: `postCreateCommand` は `workspaceFolder = /workspaces/weight_dialy` をカレントとして実行
- **冪等性**: `mise trust` は既 trust 済みでも no-op (= 副作用ゼロ、再実行安全)

## レビュー結果 (= 3 者並列)
- 🟢 code-reviewer マージ可 (= JSON valid / 順序正しい / 相対パス OK / `&&` 妥当)
- 🟢 strategic-reviewer マージ可 (= 1 行変更、Day 4 実害ベース、YAGNI 適合、教材性 ◎)
- 🟢 design-reviewer マージ可 (= UI 影響なし)

## Test plan
- [x] JSON valid (= `jq` 通過)
- [x] CI green
- [x] 既存 spec 維持 (= devcontainer 設定のみ)
- [ ] **次回 container recreate 時に動作確認** (= 本 PR ではテスト不可、不可逆性は冪等性で許容)

## 教材性ポイント
- **`postCreateCommand` の `&&` 連結**: 「環境信頼 → セットアップ」の順序を強制する典型パターン
- **container ライフサイクルで消える設定**: `~/.local/share/` 配下は recreate で初期化、`postCreateCommand` でブートストラップする
- **冪等性のあるコマンドのみ `&&` 連結**: `mise trust` は no-op 安全なので OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)