### PR TITLE
refactor: home_controller のロジックを BuildHomeDashboardService に集約

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,48 +1,13 @@
 class HomeController < ApplicationController
   def index
-    @dashboard_state = determine_state
-    @display_name    = current_user&.name || "ユウキ"
-    @records         = fetch_records(@dashboard_state)
-    @today_record    = @records.find { |r| r.recorded_on == Date.current } || @records.last
-    @streak          = StreakCalculatorService.call(@records)
-    @advice          = CalorieAdviceService.call(@today_record&.estimated_kcal.to_i)
-    # 貯カロリー (= 月リセット + 累計の二段構造) はチャート用 30 日 records とは別に
-    # 全期間 records を渡して算出する (= 累計 total は全期間でないと意味が出ないため)。
-    @calorie_savings  = CalorieSavingsService.call(fetch_calorie_records(@dashboard_state))
-    @food_equivalent  = CalorieEquivalentService.call(@today_record&.estimated_kcal.to_i)
-  end
-
-  private
-
-  def determine_state
-    return :guest unless logged_in?
-
-    platform = PlatformDetectorService.from_request(request)
-    return :android if platform == :android
-    return :iphone_with_data if current_user.step_records.exists?
-
-    :empty
-  end
-
-  # 状態を引数で明示的に受け取って暗黙の呼び出し順依存を排除する。
-  def fetch_records(state)
-    if state == :iphone_with_data
-      current_user.step_records
-                  .where(recorded_on: 30.days.ago.to_date..Date.current)
-                  .order(:recorded_on)
-                  .to_a
-    else
-      DemoDataService.call
-    end
-  end
-
-  # 貯カロリー算出用の records は 全期間 を返す (= 累計 total を正確に計算するため)。
-  # demo state では demo の 30 日分 (= fetch_records と同一) で代替。
-  def fetch_calorie_records(state)
-    if state == :iphone_with_data
-      current_user.step_records.order(:recorded_on).to_a
-    else
-      DemoDataService.call
-    end
+    data = BuildHomeDashboardService.call(user: current_user, request: request)
+    @dashboard_state = data.state
+    @display_name    = data.display_name
+    @records         = data.records
+    @today_record    = data.today_record
+    @streak          = data.streak
+    @advice          = data.advice
+    @calorie_savings = data.calorie_savings
+    @food_equivalent = data.food_equivalent
   end
 end

--- a/app/services/build_home_dashboard_service.rb
+++ b/app/services/build_home_dashboard_service.rb
@@ -1,0 +1,76 @@
+# ホームダッシュボード表示に必要な全データを一括で組み立てる。
+#
+# 設計思想:
+#   - HomeController#index の private メソッド群をここに集約し、Controller を薄くする。
+#   - 各サービスへの依存は明示的な呼び出しで表現し、暗黙の順序依存を排除する。
+#   - Data.define (Ruby 3.2+) で immutable な Result 型を定義。
+#     Struct の上位互換で等値性・パターンマッチングに対応し、テスト検証が容易。
+#
+# nil ガード設計:
+#   - user が nil (= 未ログイン) の場合、state: :guest を先に確定する。
+#   - fetch_records / fetch_calorie_records は state で分岐するため、
+#     user が nil のまま step_records を呼び出す経路は存在しない。
+class BuildHomeDashboardService
+  Result = Data.define(
+    :state, :display_name, :records, :today_record,
+    :streak, :advice, :calorie_savings, :food_equivalent
+  )
+
+  class << self
+    # @param user  [User, nil]    current_user (未ログイン時は nil)
+    # @param request [ActionDispatch::Request] UA 判定のためのリクエストオブジェクト
+    # @return [Result]
+    def call(user:, request:)
+      state           = determine_state(user, request)
+      records         = fetch_records(user, state)
+      calorie_records = fetch_calorie_records(user, state)
+      today_record    = records.find { |r| r.recorded_on == Date.current } || records.last
+
+      Result.new(
+        state:           state,
+        display_name:    user&.name || "ユウキ",
+        records:         records,
+        today_record:    today_record,
+        streak:          StreakCalculatorService.call(records),
+        advice:          CalorieAdviceService.call(today_record&.estimated_kcal.to_i),
+        calorie_savings: CalorieSavingsService.call(calorie_records),
+        food_equivalent: CalorieEquivalentService.call(today_record&.estimated_kcal.to_i)
+      )
+    end
+
+    private
+
+    def determine_state(user, request)
+      return :guest unless user
+
+      platform = PlatformDetectorService.from_request(request)
+      return :android if platform == :android
+      return :iphone_with_data if user.step_records.exists?
+
+      :empty
+    end
+
+    # 直近 30 日のレコードを返す (チャート描画用)。
+    # guest / android / empty は DemoDataService のデモデータで代替。
+    def fetch_records(user, state)
+      if state == :iphone_with_data
+        user.step_records
+            .where(recorded_on: 30.days.ago.to_date..Date.current)
+            .order(:recorded_on)
+            .to_a
+      else
+        DemoDataService.call
+      end
+    end
+
+    # 貯カロリー算出用に全期間レコードを返す (累計 total を正確に計算するため)。
+    # demo state では DemoDataService の 30 日分で代替。
+    def fetch_calorie_records(user, state)
+      if state == :iphone_with_data
+        user.step_records.order(:recorded_on).to_a
+      else
+        DemoDataService.call
+      end
+    end
+  end
+end

--- a/spec/services/build_home_dashboard_service_spec.rb
+++ b/spec/services/build_home_dashboard_service_spec.rb
@@ -1,9 +1,14 @@
 require "rails_helper"
 
 RSpec.describe BuildHomeDashboardService do
-  # UA 定数 (home_spec.rb と同一)
-  IPHONE_UA  = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1"
-  ANDROID_UA = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+  # UA 定数 (home_spec.rb と同等内容)。
+  # トップレベル Object 空間への定数漏れを避けるため `let` に変換 (= 既存 home_spec.rb と整合)。
+  let(:iphone_ua) do
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1"
+  end
+  let(:android_ua) do
+    "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+  end
 
   # 最小限の ActionDispatch::Request double を生成する。
   # PlatformDetectorService は request.user_agent だけ参照するため、
@@ -72,7 +77,7 @@ RSpec.describe BuildHomeDashboardService do
     # ─────────────────────────────────────────────────
     context "state: :android (user あり + Android UA)" do
       let(:user) { create(:user) }
-      subject(:result) { described_class.call(user: user, request: build_request(ua: ANDROID_UA)) }
+      subject(:result) { described_class.call(user: user, request: build_request(ua: android_ua)) }
 
       it "state が :android" do
         expect(result.state).to eq(:android)
@@ -97,7 +102,7 @@ RSpec.describe BuildHomeDashboardService do
     # ─────────────────────────────────────────────────
     context "state: :empty (user あり + iOS UA + step_records なし)" do
       let(:user) { create(:user) }
-      subject(:result) { described_class.call(user: user, request: build_request(ua: IPHONE_UA)) }
+      subject(:result) { described_class.call(user: user, request: build_request(ua: iphone_ua)) }
 
       it "state が :empty" do
         expect(result.state).to eq(:empty)
@@ -118,7 +123,7 @@ RSpec.describe BuildHomeDashboardService do
     context "state: :iphone_with_data (user あり + iOS UA + step_records あり)" do
       let(:user) { create(:user) }
       let!(:step_record) { create(:step_record, user: user, recorded_on: Date.current, steps: 9000) }
-      subject(:result) { described_class.call(user: user, request: build_request(ua: IPHONE_UA)) }
+      subject(:result) { described_class.call(user: user, request: build_request(ua: iphone_ua)) }
 
       it "state が :iphone_with_data" do
         expect(result.state).to eq(:iphone_with_data)

--- a/spec/services/build_home_dashboard_service_spec.rb
+++ b/spec/services/build_home_dashboard_service_spec.rb
@@ -1,0 +1,199 @@
+require "rails_helper"
+
+RSpec.describe BuildHomeDashboardService do
+  # UA 定数 (home_spec.rb と同一)
+  IPHONE_UA  = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1"
+  ANDROID_UA = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+
+  # 最小限の ActionDispatch::Request double を生成する。
+  # PlatformDetectorService は request.user_agent だけ参照するため、
+  # これだけ stub すれば十分 (= 過剰な stub を避ける)。
+  def build_request(ua: "")
+    instance_double(ActionDispatch::Request, user_agent: ua)
+  end
+
+  describe ".call の戻り値型" do
+    it "BuildHomeDashboardService::Result を返す" do
+      request = build_request
+      result  = described_class.call(user: nil, request: request)
+      expect(result).to be_a(BuildHomeDashboardService::Result)
+    end
+
+    it "Result は immutable (frozen)" do
+      request = build_request
+      result  = described_class.call(user: nil, request: request)
+      expect(result).to be_frozen
+    end
+  end
+
+  describe ".call" do
+    # ─────────────────────────────────────────────────
+    # 状態 :guest — user: nil
+    # ─────────────────────────────────────────────────
+    context "state: :guest (user が nil)" do
+      subject(:result) { described_class.call(user: nil, request: build_request) }
+
+      it "state が :guest" do
+        expect(result.state).to eq(:guest)
+      end
+
+      it "display_name がデフォルト「ユウキ」" do
+        expect(result.display_name).to eq("ユウキ")
+      end
+
+      it "records が Array" do
+        expect(result.records).to be_an(Array)
+      end
+
+      it "records が空でない (= デモデータ)" do
+        expect(result.records).not_to be_empty
+      end
+
+      it "today_record が nil でない (= デモデータから取得)" do
+        expect(result.today_record).not_to be_nil
+      end
+
+      it "streak が Integer" do
+        expect(result.streak).to be_an(Integer)
+      end
+
+      it "calorie_savings が Hash で 3 キーを持つ" do
+        expect(result.calorie_savings).to be_a(Hash)
+          .and include(:this_month, :last_month, :total)
+      end
+
+      it "NoMethodError を発生させない (= nil ガード確認)" do
+        expect { described_class.call(user: nil, request: build_request) }.not_to raise_error
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 状態 :android — ログイン済み + Android UA
+    # ─────────────────────────────────────────────────
+    context "state: :android (user あり + Android UA)" do
+      let(:user) { create(:user) }
+      subject(:result) { described_class.call(user: user, request: build_request(ua: ANDROID_UA)) }
+
+      it "state が :android" do
+        expect(result.state).to eq(:android)
+      end
+
+      it "display_name が user.name" do
+        expect(result.display_name).to eq(user.name)
+      end
+
+      it "records がデモデータ (= step_records なし)" do
+        expect(result.records).not_to be_empty
+      end
+
+      it "calorie_savings が Hash で 3 キーを持つ" do
+        expect(result.calorie_savings).to be_a(Hash)
+          .and include(:this_month, :last_month, :total)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 状態 :empty — ログイン済み + iOS + データなし
+    # ─────────────────────────────────────────────────
+    context "state: :empty (user あり + iOS UA + step_records なし)" do
+      let(:user) { create(:user) }
+      subject(:result) { described_class.call(user: user, request: build_request(ua: IPHONE_UA)) }
+
+      it "state が :empty" do
+        expect(result.state).to eq(:empty)
+      end
+
+      it "display_name が user.name" do
+        expect(result.display_name).to eq(user.name)
+      end
+
+      it "records がデモデータ (空でない)" do
+        expect(result.records).not_to be_empty
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 状態 :iphone_with_data — ログイン済み + iOS + データあり
+    # ─────────────────────────────────────────────────
+    context "state: :iphone_with_data (user あり + iOS UA + step_records あり)" do
+      let(:user) { create(:user) }
+      let!(:step_record) { create(:step_record, user: user, recorded_on: Date.current, steps: 9000) }
+      subject(:result) { described_class.call(user: user, request: build_request(ua: IPHONE_UA)) }
+
+      it "state が :iphone_with_data" do
+        expect(result.state).to eq(:iphone_with_data)
+      end
+
+      it "display_name が user.name" do
+        expect(result.display_name).to eq(user.name)
+      end
+
+      it "records に DB の StepRecord が含まれる" do
+        expect(result.records).to include(step_record)
+      end
+
+      it "today_record が今日の StepRecord" do
+        expect(result.today_record).to eq(step_record)
+      end
+
+      it "streak が 1 以上の Integer (= 今日のレコードがある)" do
+        expect(result.streak).to be >= 1
+      end
+
+      it "calorie_savings の this_month が正しい (= 9000 歩 * 0.04 = 360 kcal)" do
+        expect(result.calorie_savings[:this_month]).to eq(360)
+      end
+
+      it "calorie_savings の total が正しい (= 全期間で 9000 歩のみ → 360 kcal)" do
+        expect(result.calorie_savings[:total]).to eq(360)
+      end
+
+      it "advice が CalorieAdviceService::Result (= Struct)" do
+        expect(result.advice).to be_a(CalorieAdviceService::Result)
+      end
+
+      it "food_equivalent が Hash または nil" do
+        expect(result.food_equivalent).to be_a(Hash).or be_nil
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # Result field の互換性確認 (= Controller の @xxx 7 本と対応)
+    # ─────────────────────────────────────────────────
+    describe "Result field の互換性" do
+      subject(:result) { described_class.call(user: nil, request: build_request) }
+
+      it "state field が存在する" do
+        expect(result).to respond_to(:state)
+      end
+
+      it "display_name field が存在する" do
+        expect(result).to respond_to(:display_name)
+      end
+
+      it "records field が存在する" do
+        expect(result).to respond_to(:records)
+      end
+
+      it "today_record field が存在する" do
+        expect(result).to respond_to(:today_record)
+      end
+
+      it "streak field が存在する" do
+        expect(result).to respond_to(:streak)
+      end
+
+      it "advice field が存在する" do
+        expect(result).to respond_to(:advice)
+      end
+
+      it "calorie_savings field が存在する" do
+        expect(result).to respond_to(:calorie_savings)
+      end
+
+      it "food_equivalent field が存在する" do
+        expect(result).to respond_to(:food_equivalent)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
home_controller#index のデータ集約ロジックを `BuildHomeDashboardService` に移譲し、controller を skinny 化。Issue #72 の SQL 集計化に向けた第 1 段階 (= 純粋リファクタ、挙動変更なし)。

## 背景
ユーザー提案: 「コントローラーで計算せず、Service クラスで処理して持ってくる」。
3 者並列事前レビューで「PR 分割 + Data.define + メソッド分離」推奨確定 → 本 PR は **リファクタのみ**、SQL 集計化 (Issue #72 本体) は別 PR で発表会後対応。

## 変更内容

### 1. `BuildHomeDashboardService` 新設
- `app/services/build_home_dashboard_service.rb`
- **`Data.define`** (Ruby 3.2+) で immutable な `Result` 返却 (= Struct の上位互換)
- 8 fields: `state` / `display_name` / `records` / `today_record` / `streak` / `advice` / `calorie_savings` / `food_equivalent`
- 既存ロジック (= state 判定 / records 取得 / streak / advice / savings / equivalent) を移譲
- `class << self` ブロック内 `private` (= 既存 `CalorieSavingsService` と整合)
- nil ガード徹底 (= `return :guest unless user`)

### 2. `home_controller#index` 簡素化
13 行 → 8 行の変数展開のみ。private メソッド全削除。

### 3. `CalorieSavingsService` 変更なし (= SQL 集計化は別 PR)

## レビュー反映 (= 3 者並列、2 ラウンド)

### 事前レビュー (= 設計レビュー)
- 5 種類の代替パターン提示 (= Service+Result / Query Object / ViewModel / Decorator / Interactor) → A+C 採用
- PR 分割推奨 → 本 PR は純粋リファクタのみ
- `Data.define` 採用 (= Ruby 3.2+ モダン)
- 命名 `BuildHomeDashboardService` (= 動詞+名詞ルール)

### 実装後レビュー
- 🟡 code-reviewer 修正必要: spec の定数 → `let` 変換 → ✅ 修正コミット (`6ae13e9`)
- 🟢 strategic-reviewer マージ可 (= 純粋リファクタとして模範的、教材性 ◎)
- 🟢 design-reviewer マージ可 (= UI 影響なし、interface 完全互換)

## Test plan
- [x] `bundle exec rspec` (= 465 examples / 0 failures、+34 新規)
- [x] `bundle exec rubocop` (= no offenses)
- [x] 既存 `home_spec.rb` 統合テスト 39 examples 維持 (= 挙動変更ゼロの証明)
- [x] 4 state 全カバー spec (= guest / android / empty / iphone_with_data)
- [x] 3 者並列レビュー 2 ラウンド (= 事前 + 実装後)

## 教材性ポイント
- **`Data.define` (Ruby 3.2+)**: Struct より immutable、等値性 + pattern matching 対応
- **Service 集約パターン**: controller skinny / Service が「集約役」として責任明確
- **PR 分割の判断**: 「リファクタ + SQL 集計化を 1 PR にしない」運用、回帰時の切り分け容易性
- **5 種類の代替パターン比較**: Service / Query Object / ViewModel / Decorator / Interactor を strategic-reviewer が比較提示、後輩教材として価値高

## 関連
- Issue #72 (= SQL 集計化、本 PR では未対応、別 PR で発表会後対応予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)