### PR TITLE
perf: home_controller の step_records 取得を SQL 集計に切り替え (#72)

### DIFF
--- a/app/services/build_home_dashboard_service.rb
+++ b/app/services/build_home_dashboard_service.rb
@@ -8,7 +8,7 @@
 #
 # nil ガード設計:
 #   - user が nil (= 未ログイン) の場合、state: :guest を先に確定する。
-#   - fetch_records / fetch_calorie_records は state で分岐するため、
+#   - fetch_records / calorie_savings 分岐は state で決定するため、
 #     user が nil のまま step_records を呼び出す経路は存在しない。
 class BuildHomeDashboardService
   Result = Data.define(
@@ -21,10 +21,15 @@ class BuildHomeDashboardService
     # @param request [ActionDispatch::Request] UA 判定のためのリクエストオブジェクト
     # @return [Result]
     def call(user:, request:)
-      state           = determine_state(user, request)
-      records         = fetch_records(user, state)
-      calorie_records = fetch_calorie_records(user, state)
-      today_record    = records.find { |r| r.recorded_on == Date.current } || records.last
+      state        = determine_state(user, request)
+      records      = fetch_records(user, state)
+      today_record = records.find { |r| r.recorded_on == Date.current } || records.last
+
+      calorie_savings = if state == :iphone_with_data
+                          CalorieSavingsService.call_for_user(user)
+      else
+                          CalorieSavingsService.call(records)
+      end
 
       Result.new(
         state:           state,
@@ -33,7 +38,7 @@ class BuildHomeDashboardService
         today_record:    today_record,
         streak:          StreakCalculatorService.call(records),
         advice:          CalorieAdviceService.call(today_record&.estimated_kcal.to_i),
-        calorie_savings: CalorieSavingsService.call(calorie_records),
+        calorie_savings: calorie_savings,
         food_equivalent: CalorieEquivalentService.call(today_record&.estimated_kcal.to_i)
       )
     end
@@ -58,16 +63,6 @@ class BuildHomeDashboardService
             .where(recorded_on: 30.days.ago.to_date..Date.current)
             .order(:recorded_on)
             .to_a
-      else
-        DemoDataService.call
-      end
-    end
-
-    # 貯カロリー算出用に全期間レコードを返す (累計 total を正確に計算するため)。
-    # demo state では DemoDataService の 30 日分で代替。
-    def fetch_calorie_records(user, state)
-      if state == :iphone_with_data
-        user.step_records.order(:recorded_on).to_a
       else
         DemoDataService.call
       end

--- a/app/services/build_home_dashboard_service.rb
+++ b/app/services/build_home_dashboard_service.rb
@@ -25,11 +25,12 @@ class BuildHomeDashboardService
       records      = fetch_records(user, state)
       today_record = records.find { |r| r.recorded_on == Date.current } || records.last
 
-      calorie_savings = if state == :iphone_with_data
-                          CalorieSavingsService.call_for_user(user)
-      else
-                          CalorieSavingsService.call(records)
-      end
+      calorie_savings =
+        if state == :iphone_with_data
+          CalorieSavingsService.call_for_user(user)
+        else
+          CalorieSavingsService.call(records)
+        end
 
       Result.new(
         state:           state,

--- a/app/services/calorie_savings_service.rb
+++ b/app/services/calorie_savings_service.rb
@@ -35,6 +35,26 @@ class CalorieSavingsService
       }
     end
 
+    # @param user [User] ログイン済みユーザー (AR ベースの SQL 集計、本番ユーザー用)
+    # @return [Hash{Symbol=>Integer}] { this_month:, last_month:, total: } 各 kcal を整数で返す
+    #
+    # call(records) との違い:
+    #   - 配列を全件メモリに載せず、DB 側で SUM 集計する (= N+1 / メモリ効率)。
+    #   - scope が user.step_records に限定されるため、他ユーザーのレコードが混入しない。
+    #   - recorded_on は date 型のため time zone の影響を受けない。
+    def call_for_user(user)
+      today = Date.current
+      this_month_range = today.beginning_of_month..today.end_of_month
+      last_month_date  = today - 1.month
+      last_month_range = last_month_date.beginning_of_month..last_month_date.end_of_month
+
+      {
+        this_month: kcal_in_range_sql(user, this_month_range),
+        last_month: kcal_in_range_sql(user, last_month_range),
+        total:      kcal_total_sql(user)
+      }
+    end
+
     private
 
     def zero_result
@@ -48,6 +68,14 @@ class CalorieSavingsService
 
     def kcal_total(records)
       (records.sum(&:steps) * CALORIES_PER_STEP).round
+    end
+
+    def kcal_in_range_sql(user, range)
+      (user.step_records.where(recorded_on: range).sum(:steps) * CALORIES_PER_STEP).round
+    end
+
+    def kcal_total_sql(user)
+      (user.step_records.sum(:steps) * CALORIES_PER_STEP).round
     end
   end
 end

--- a/app/services/calorie_savings_service.rb
+++ b/app/services/calorie_savings_service.rb
@@ -35,14 +35,19 @@ class CalorieSavingsService
       }
     end
 
-    # @param user [User] ログイン済みユーザー (AR ベースの SQL 集計、本番ユーザー用)
+    # @param user [User, nil] ログイン済みユーザー (AR ベースの SQL 集計、本番ユーザー用)
     # @return [Hash{Symbol=>Integer}] { this_month:, last_month:, total: } 各 kcal を整数で返す
     #
     # call(records) との違い:
     #   - 配列を全件メモリに載せず、DB 側で SUM 集計する (= N+1 / メモリ効率)。
     #   - scope が user.step_records に限定されるため、他ユーザーのレコードが混入しない。
     #   - recorded_on は date 型のため time zone の影響を受けない。
+    #
+    # 構造上 nil 来ない (= 呼び出し側 BuildHomeDashboardService で state ガード済み) が、
+    # メソッド単体での安全性のため call(records) の records.blank? ガードと対称に nil ガード。
     def call_for_user(user)
+      return zero_result if user.nil?
+
       today = Date.current
       this_month_range = today.beginning_of_month..today.end_of_month
       last_month_date  = today - 1.month

--- a/spec/services/calorie_savings_service_spec.rb
+++ b/spec/services/calorie_savings_service_spec.rb
@@ -106,4 +106,102 @@ RSpec.describe CalorieSavingsService do
       end
     end
   end
+
+  describe ".call_for_user" do
+    let(:user) { create(:user) }
+
+    context "レコード 0 件" do
+      it "全 0 のハッシュを返す" do
+        expect(CalorieSavingsService.call_for_user(user)).to eq(this_month: 0, last_month: 0, total: 0)
+      end
+    end
+
+    context "当月のみ 1 件 (1000 歩)" do
+      before { create(:step_record, user: user, recorded_on: this_month_15, steps: 1000) }
+
+      it "this_month = 40 kcal (= 1000 * 0.04)" do
+        expect(CalorieSavingsService.call_for_user(user)[:this_month]).to eq(40)
+      end
+
+      it "last_month = 0 kcal" do
+        expect(CalorieSavingsService.call_for_user(user)[:last_month]).to eq(0)
+      end
+
+      it "total = 40 kcal (= this_month と一致)" do
+        expect(CalorieSavingsService.call_for_user(user)[:total]).to eq(40)
+      end
+    end
+
+    context "前月のみ 1 件 (5000 歩)" do
+      before { create(:step_record, user: user, recorded_on: last_month_15, steps: 5000) }
+
+      it "this_month = 0 kcal" do
+        expect(CalorieSavingsService.call_for_user(user)[:this_month]).to eq(0)
+      end
+
+      it "last_month = 200 kcal (= 5000 * 0.04)" do
+        expect(CalorieSavingsService.call_for_user(user)[:last_month]).to eq(200)
+      end
+
+      it "total = 200 kcal" do
+        expect(CalorieSavingsService.call_for_user(user)[:total]).to eq(200)
+      end
+    end
+
+    context "当月 + 前月 + 2 ヶ月前 の混在" do
+      before do
+        create(:step_record, user: user, recorded_on: two_months_ago_day, steps: 10000) # 400 kcal
+        create(:step_record, user: user, recorded_on: last_month_15,      steps: 5000)  # 200 kcal
+        create(:step_record, user: user, recorded_on: this_month_15,      steps: 2500)  # 100 kcal
+      end
+
+      it "this_month は今月分のみ (100 kcal)" do
+        expect(CalorieSavingsService.call_for_user(user)[:this_month]).to eq(100)
+      end
+
+      it "last_month は前月分のみ (200 kcal)" do
+        expect(CalorieSavingsService.call_for_user(user)[:last_month]).to eq(200)
+      end
+
+      it "total は全期間 (700 kcal)" do
+        expect(CalorieSavingsService.call_for_user(user)[:total]).to eq(700)
+      end
+    end
+
+    context "他ユーザーのレコードは混入しない (= scope が user.step_records)" do
+      let(:other_user) { create(:user) }
+
+      before do
+        create(:step_record, user: user,       recorded_on: this_month_15, steps: 1000)
+        create(:step_record, user: other_user, recorded_on: this_month_15, steps: 99999)
+      end
+
+      it "user のレコードのみが集計される" do
+        expect(CalorieSavingsService.call_for_user(user)[:this_month]).to eq(40)
+      end
+    end
+
+    context "月境界: 今月の月初 (= today.beginning_of_month)" do
+      it "月初 1 日のレコードも this_month に含む" do
+        create(:step_record, user: user, recorded_on: today.beginning_of_month, steps: 1000)
+        expect(CalorieSavingsService.call_for_user(user)[:this_month]).to eq(40)
+      end
+    end
+
+    context "月境界: 前月の月末 (= 1 ヶ月前の月末)" do
+      it "前月末日のレコードを last_month に含む" do
+        last_month_end = (today - 1.month).end_of_month
+        create(:step_record, user: user, recorded_on: last_month_end, steps: 1000)
+        expect(CalorieSavingsService.call_for_user(user)[:last_month]).to eq(40)
+      end
+    end
+
+    context "call(records) と call_for_user(user) の換算結果一致 (= 9000 歩 → 360 kcal)" do
+      before { create(:step_record, user: user, recorded_on: this_month_15, steps: 9000) }
+
+      it "this_month が 360 kcal" do
+        expect(CalorieSavingsService.call_for_user(user)[:this_month]).to eq(360)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Close #72

## Summary
直前 PR #110 で `BuildHomeDashboardService` に集約したロジックの **SQL 集計化本体**。`CalorieSavingsService` に `call_for_user(user)` パスを追加し、本番ユーザー (= `:iphone_with_data` state) は全期間 records を Ruby 配列に load せず、DB 側で `SUM` 集計する。

## 背景
- 元現状: `home_controller#index` で `current_user.step_records.order(:recorded_on).to_a` (= 全期間 records 配列 load)
- 長期運用 (= 1 ユーザー 1000+ 件) で Ruby メモリ + N+1 派生のリスク
- PR #110 で集約は完了、本 PR で SQL 集計化を別 PR として分離 (= 3 者事前レビューで「PR 分割」推奨)

## 変更内容

### 1. `CalorieSavingsService` に `call_for_user(user)` 追加
- 既存 `call(records)` は変更なし (= demo 用、後方互換)
- 新規 `call_for_user(user)` で `user.step_records.where(...).sum(:steps)` の SQL 集計
- `recorded_on` は date 型 (= time zone 影響なし)
- 構造上 nil 来ないが、`call(records)` の `records.blank?` ガードと対称に **`return zero_result if user.nil?`** を追加

### 2. `BuildHomeDashboardService` の state 分岐
- `fetch_calorie_records` 削除 (= 不要、demo 時は records を再利用)
- `:iphone_with_data` → `CalorieSavingsService.call_for_user(user)` (= SQL)
- それ以外 → `CalorieSavingsService.call(records)` (= 配列、demo 互換)

## レビュー反映 (= 3 者並列、2 ラウンド)

### 1 ラウンド目
- 🟡 code-reviewer Should fix: `if/else` else アライメント崩れ → ✅ 修正 (= 代入を改行分離 + Layout/EndAlignment 違反解消)
- 💡 code-reviewer Nit: `call_for_user` の nil ガード非対称 → ✅ 修正 (= 対称性向上)
- 🟢 strategic-reviewer マージ可 (= 数値整合担保 OK、教材性 ◎)
- 🟢 design-reviewer マージ可 (= UI / 型契約維持)

## Test plan
- [x] `bundle exec rspec` (= 479 examples / 0 failures、+14 新規)
- [x] `bundle exec rubocop` (= no offenses)
- [x] 既存 `home_spec.rb` 統合テスト 39 examples 維持 (= 9000 歩 → 360 kcal SQL パスでも整合)
- [x] 新規 spec カバー: 0 件 / 当月 / 前月 / 月境界 / ユーザー分離 / 9000 歩整合
- [x] 3 者並列レビュー 2 ラウンド (= 全員マージ可)

## 教材性ポイント
- **`call(records)` / `call_for_user(user)` のメソッド分離パターン**: 引数型と集計経路の責務明確
- **AR scope での SQL 集計**: `user.step_records.where(...).sum(:steps)` で N+1 ゼロ
- **fetch_calorie_records 削除**: 中間配列を排除、demo 時は records を再利用
- **対称性のための nil ガード**: 構造上 nil 来ないが、メソッド単体での安全性 + ドキュメント性として有意義

## 将来 (= 本 PR スコープ外)
- 3 SQL → `GROUP BY DATE_TRUNC('month', recorded_on)` で 1 SQL 化 (= 教材性とのバランスで現状妥当)
- `step_records.recorded_on` / `user_id` の複合 index (= 1000+ 件運用時に検討)

🤖 Generated with [Claude Code](https://claude.com/claude-code)