### PR TITLE
polish: トークン再生成タイトルを sketch-h-danger 統一 + 規約追記 (#105 #106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@
 - **コンポーネント**: `app/assets/stylesheets/sketchy.css` の `sketch-*` クラスを正とする
 - **Tailwind utility**: `flex` / `grid` / `mt-4` / `container` 等のレイアウト用ユーティリティは引き続き使用 OK
 - **daisyUI コンポーネント** (`btn` / `card` / `navbar` / `alert` 等): **新規利用禁止**。既存箇所も触ったタイミングで `sketch-*` に置換
+- **危険度クラス**: `sketch-box-danger` / `sketch-h-danger` / `sketch-btn-danger` のように **独立クラス** (`sketch-*-danger`) で命名する (= modifier class `.sketch-box.filled` パターンとは別の体系。`-soft` 等の派生を組み合わせやすくするため)
 
 ---
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -97,7 +97,7 @@
 
   <%# 危険ゾーン: トークン再生成 %>
   <div class="sketch-box sketch-box-danger-soft" style="margin-bottom: 24px;">
-    <p class="sketch-h" style="margin-bottom: 8px;">トークンの再生成</p>
+    <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;">トークンの再生成</p>
     <p class="sketch-body-text" style="margin-bottom: 16px;">
       ⚠️ <strong>トークンを再生成すると、現在 Apple Shortcuts に設定済みのトークンは無効になります。</strong>
       再生成後は Shortcut 側の設定も更新する必要があります。


### PR DESCRIPTION
## Summary

PR #105 (= Issue #86 sketchy \`--danger\` トークン整備) のレビューで design-reviewer から出た指摘 2 件をまとめて対応。

- **#105**: トークン再生成ボックスのタイトルに \`sketch-h-danger\` を付与し、アカウント削除と「赤背景 + 赤タイトル」で統一
- **#106**: CLAUDE.md スタイル規約に「危険度クラスは独立クラス (\`sketch-*-danger\`) 命名」を 1 行追記し、後輩教材として明文化

## 変更内容

### \`app/views/settings/show.html.erb\` (line 100)

\`\`\`diff
- <p class="sketch-h" style="margin-bottom: 8px;">トークンの再生成</p>
+ <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;">トークンの再生成</p>
\`\`\`

赤背景 (\`sketch-box-danger-soft\`) なのにタイトル色が黒のままで「注意レベル」シグナルが弱まっていた問題を解消。アカウント削除セクションと同じ体系 (\`sketch-h\` + \`sketch-h-danger\`) に統一。

### \`CLAUDE.md\` (🎨 スタイル使い分けルールセクション)

危険度クラスの命名方針を 1 行追記:

> - **危険度クラス**: \`sketch-box-danger\` / \`sketch-h-danger\` / \`sketch-btn-danger\` のように **独立クラス** (\`sketch-*-danger\`) で命名する (= modifier class \`.sketch-box.filled\` パターンとは別の体系。\`-soft\` 等の派生を組み合わせやすくするため)

今後 \`-info\` / \`-warning\` 派生を足す際の命名揺れを防止。

## Test plan

- [ ] CI green
- [ ] 本番デプロイ後、Settings ページのトークン再生成ボックスでタイトルが赤色になっていることを確認
- [ ] アカウント削除セクションとの統一感確認 (= 両者「赤背景 + 赤タイトル + 赤ボタン」の体系揃い)

## 関連

- 元 PR: #105 (= Issue #86 sketchy --danger トークン整備)
- Closes #105 #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)