### PR TITLE
polish: sketch-box-danger-soft のボーダーを半透明赤にして三一致させる (#116)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -21,6 +21,7 @@
   /* danger (危険ゾーン / 破壊的操作) */
   --danger: #cc0000;
   --danger-bg: #ffe5e5;
+  --danger-soft-border: rgba(204, 0, 0, 0.35); /* sketch-box-danger-soft 用、削除より弱い警告強度 */
 }
 
 /* body 全体を紙質背景に。layout から bg-base-200 は外す前提。 */
@@ -98,11 +99,12 @@ body {
 .sketch-box.accent .sketch-label,
 .sketch-box.accent .sketch-small { color: var(--ink-2); }
 /* danger: 破壊的操作 (退会 / トークン再生成) の警告エリア。
-   sketch-box-danger  → 背景 + ボーダー両方を danger 色に (アカウント削除ボックス等)。
-   sketch-box-danger-soft → 背景のみ (ボーダーは既定の --ink 黒のまま = トークン再生成ボックス)。
+   sketch-box-danger      → 背景 + ボーダー両方を不透明 danger 色に (= 削除ボックス、最強の警告)。
+   sketch-box-danger-soft → 背景 + ボーダーを半透明赤 (35%) に (= トークン再生成ボックス、弱い警告)。
+                             背景・タイトル・ボーダーで赤系 3 色を一致させ、強度差は不透明度で表現。
    --danger (#cc0000) は黒文字 (5.91:1) で WCAG AA 合格。 */
 .sketch-box-danger      { background: var(--danger-bg); border-color: var(--danger); }
-.sketch-box-danger-soft { background: var(--danger-bg); }
+.sketch-box-danger-soft { background: var(--danger-bg); border-color: var(--danger-soft-border); }
 /* danger テキスト (見出し・ラベル) */
 .sketch-h-danger { color: var(--danger); }
 /* danger ボタン: .sketch-btn と組み合わせて使う。ボーダー + 文字を danger 色に。 */

--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -21,7 +21,7 @@
   /* danger (危険ゾーン / 破壊的操作) */
   --danger: #cc0000;
   --danger-bg: #ffe5e5;
-  --danger-soft-border: rgba(204, 0, 0, 0.35); /* sketch-box-danger-soft 用、削除より弱い警告強度 */
+  --danger-soft-border: rgba(204,0,0,0.35); /* sketch-box-danger-soft 用、削除より弱い警告強度 */
 }
 
 /* body 全体を紙質背景に。layout から bg-base-200 は外す前提。 */


### PR DESCRIPTION
## Summary

PR #115 (= Issue #105 #106 sketchy danger フォローアップ) の design-reviewer 任意提案 (Issue #116) を反映する polish。

\`sketch-box-danger-soft\` のボーダーが黒のままで「赤背景 + 赤タイトル + 黒ボーダー」と色が揃っておらず、初見ユーザーに「デザインの間違い」と読まれるリスクがあった。半透明赤に変更して **背景・タイトル・ボーダーの 3 要素を赤系で一致** させる。

## 変更内容

### CSS 変数 (\`:root\`)

\`\`\`diff
   --danger: #cc0000;
   --danger-bg: #ffe5e5;
+  --danger-soft-border: rgba(204, 0, 0, 0.35); /* sketch-box-danger-soft 用、削除より弱い警告強度 */
\`\`\`

### \`.sketch-box-danger-soft\` ルール

\`\`\`diff
-.sketch-box-danger-soft { background: var(--danger-bg); }
+.sketch-box-danger-soft { background: var(--danger-bg); border-color: var(--danger-soft-border); }
\`\`\`

### コメント (= 教材性向上)

強度差の根拠と CSS 変数の用途を明文化:

\`\`\`
sketch-box-danger      → 背景 + ボーダー両方を不透明 danger 色に (= 削除ボックス、最強の警告)。
sketch-box-danger-soft → 背景 + ボーダーを半透明赤 (35%) に (= トークン再生成ボックス、弱い警告)。
                         背景・タイトル・ボーダーで赤系 3 色を一致させ、強度差は不透明度で表現。
\`\`\`

## デザイン方針

| 要素 | sketch-box-danger (削除) | sketch-box-danger-soft (再生成) |
|---|---|---|
| 背景 | 薄赤 \`#ffe5e5\` | 同 |
| タイトル | 赤 \`#cc0000\` | 同 (PR #115) |
| ボーダー | 不透明赤 \`#cc0000\` | **半透明赤 \`rgba(204,0,0,0.35)\`** |
| 警告強度 | **最強** | **弱** (不透明度で差別化) |

## Test plan

- [ ] CI green
- [ ] 本番デプロイ後、Settings ページのトークン再生成ボックスが「赤背景 + 赤タイトル + 半透明赤ボーダー」になっていることを目視確認
- [ ] アカウント削除ボックスとの強度差 (= 不透明度差) が依然として明確か確認
- [ ] grep で他に \`sketch-box-danger-soft\` を使う箇所がないか念のため確認 (= Settings 1 箇所のみのはず)

## 関連
- 元 PR: #115 (= sketchy danger フォローアップ)
- Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)