### PR TITLE
feat: Health Connect 動的パーミッションフロー実装 (#121)

### DIFF
--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -1,0 +1,79 @@
+import { Controller } from "@hotwired/stimulus"
+
+const HEALTH_READ_TYPES = ["steps", "distance", "floorsClimbed"]
+
+export default class extends Controller {
+  static targets = ["container", "status", "requestButton"]
+
+  connect() {
+    if (!this.isCapacitorNative()) {
+      return
+    }
+    this.containerTarget.style.display = ""
+    this.checkPermission()
+  }
+
+  isCapacitorNative() {
+    const cap = window.Capacitor
+    return typeof cap !== "undefined" &&
+      typeof cap.isNativePlatform === "function" &&
+      cap.isNativePlatform()
+  }
+
+  healthPlugin() {
+    return window.Capacitor?.Plugins?.Health
+  }
+
+  async checkPermission() {
+    const Health = this.healthPlugin()
+    if (!Health) {
+      this.showStatus("⚠️ Health プラグインが見つかりません (cap sync 不足の可能性)")
+      return
+    }
+
+    try {
+      const availability = await Health.isAvailable()
+      if (!availability?.available) {
+        this.showStatus(`⚠️ Health Connect 利用不可: ${availability?.reason || "原因不明"}`)
+        return
+      }
+
+      const result = await Health.checkAuthorization({ read: HEALTH_READ_TYPES })
+      if (result?.granted) {
+        this.showStatus("✅ Health Connect 連携済み (歩数 / 距離 / 階段)")
+        this.requestButtonTarget.style.display = "none"
+      } else {
+        this.showStatus("⏳ Health Connect の権限が必要です")
+        this.requestButtonTarget.style.display = ""
+      }
+    } catch (error) {
+      this.showStatus(`❌ 確認エラー: ${this.errorMessage(error)}`)
+    }
+  }
+
+  async requestPermission() {
+    const Health = this.healthPlugin()
+    if (!Health) return
+
+    try {
+      const result = await Health.requestAuthorization({ read: HEALTH_READ_TYPES })
+      if (result?.granted) {
+        this.showStatus("✅ 権限を取得しました")
+        this.requestButtonTarget.style.display = "none"
+      } else {
+        this.showStatus("⚠️ 権限が拒否されました。Android 設定 → アプリ → Health Connect から許可してください")
+      }
+    } catch (error) {
+      this.showStatus(`❌ リクエストエラー: ${this.errorMessage(error)}`)
+    }
+  }
+
+  showStatus(message) {
+    this.statusTarget.textContent = message
+  }
+
+  errorMessage(error) {
+    if (!error) return "原因不明"
+    return error.message || error.errorMessage || String(error)
+  }
+}

--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -3,14 +3,16 @@ import { Controller } from "@hotwired/stimulus"
 const HEALTH_READ_TYPES = ["steps", "distance", "floorsClimbed"]
 
 export default class extends Controller {
-  static targets = ["container", "status", "requestButton"]
+  static targets = ["status", "requestButton"]
 
   connect() {
     if (!this.isCapacitorNative()) {
       return
     }
-    this.containerTarget.style.display = ""
-    this.checkPermission()
+    this.element.style.display = ""
+    this.checkPermission().catch((error) => {
+      this.showStatus(`❌ 初期化エラー: ${this.errorMessage(error)}`)
+    })
   }
 
   isCapacitorNative() {
@@ -61,7 +63,7 @@ export default class extends Controller {
         this.showStatus("✅ 権限を取得しました")
         this.requestButtonTarget.style.display = "none"
       } else {
-        this.showStatus("⚠️ 権限が拒否されました。Android 設定 → アプリ → Health Connect から許可してください")
+        this.showStatus("⚠️ 権限が拒否されました。設定 → アプリ → Health Connect から許可できます")
       }
     } catch (error) {
       this.showStatus(`❌ リクエストエラー: ${this.errorMessage(error)}`)

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -85,9 +85,18 @@
     </p>
   <% end %>
 
+  <%# ポリシーリンク (= Health Connect より上、インフォームドコンセントの順序) %>
+  <div class="sketch-box" style="margin-bottom: 24px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">ポリシー</h2>
+    <p class="sketch-body-text">
+      <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--ink); text-decoration: underline;" %>
+      /
+      <%= link_to "利用規約", terms_path, style: "color: var(--ink); text-decoration: underline;" %>
+    </p>
+  </div>
+
   <%# Health Connect 連携 (Android のみ、Capacitor 検知で動的表示。Web 版では非表示のまま) %>
   <div data-controller="native-health"
-       data-native-health-target="container"
        class="sketch-box"
        style="display: none; margin-bottom: 24px;">
     <h2 class="sketch-h" style="margin-bottom: 8px;">📱 Android Health Connect 連携</h2>
@@ -103,16 +112,6 @@
             style="display: none;">
       権限を許可する
     </button>
-  </div>
-
-  <%# ポリシーリンク %>
-  <div class="sketch-box" style="margin-bottom: 24px;">
-    <h2 class="sketch-h" style="margin-bottom: 8px;">ポリシー</h2>
-    <p class="sketch-body-text">
-      <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--ink); text-decoration: underline;" %>
-      /
-      <%= link_to "利用規約", terms_path, style: "color: var(--ink); text-decoration: underline;" %>
-    </p>
   </div>
 
   <%# 危険ゾーン: トークン再生成 %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -85,6 +85,26 @@
     </p>
   <% end %>
 
+  <%# Health Connect 連携 (Android のみ、Capacitor 検知で動的表示。Web 版では非表示のまま) %>
+  <div data-controller="native-health"
+       data-native-health-target="container"
+       class="sketch-box"
+       style="display: none; margin-bottom: 24px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">📱 Android Health Connect 連携</h2>
+    <p class="sketch-small" style="margin-bottom: 12px;">
+      Android アプリ版で Health Connect から歩数 / 距離 / 階段を取得します。
+    </p>
+    <p data-native-health-target="status" class="sketch-body-text" style="margin-bottom: 16px;">
+      確認中...
+    </p>
+    <button data-action="click->native-health#requestPermission"
+            data-native-health-target="requestButton"
+            class="sketch-btn"
+            style="display: none;">
+      権限を許可する
+    </button>
+  </div>
+
   <%# ポリシーリンク %>
   <div class="sketch-box" style="margin-bottom: 24px;">
     <h2 class="sketch-h" style="margin-bottom: 8px;">ポリシー</h2>

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -94,6 +94,29 @@ RSpec.describe "Settings", type: :request do
     end
 
     # -------------------------------------------------------------------------
+    # Health Connect 連携セクション (Issue #40 子 3 / #121)
+    # Capacitor (Android アプリ) でのみ動的表示、Web 版では display: none 維持
+    # -------------------------------------------------------------------------
+    context "ログイン時 (Health Connect セクション)" do
+      let(:user) { create(:user) }
+
+      before do
+        login(user)
+        get settings_path
+      end
+
+      it "Android Health Connect 連携セクションを含む (= Stimulus controller 経由でレンダリング)" do
+        expect(response.body).to include("Android Health Connect 連携")
+        expect(response.body).to include('data-controller="native-health"')
+      end
+
+      it "Web 版では display: none で初期表示する (= Capacitor 検知時のみ表示に切り替わる)" do
+        # native-health controller を持つ要素の inline style に display: none が含まれる
+        expect(response.body).to match(/data-controller="native-health"[^>]*style="[^"]*display: none/)
+      end
+    end
+
+    # -------------------------------------------------------------------------
     # 受信履歴セクション (Issue #53)
     # -------------------------------------------------------------------------
     context "ログイン時 (受信履歴セクション)" do


### PR DESCRIPTION
## Summary

Issue #40 子 Issue 3 (#121)。Android アプリ版で Health Connect 権限を動的にユーザーリクエストし、拒否時のフォールバック UI を整備。Web 版への影響ゼロ。

## 変更内容

### 1. \`app/javascript/controllers/native_health_controller.js\` (新規)

Stimulus controller。connect 時に Capacitor 検知 → permission チェック → 状態に応じた UI 切替。

- **Capacitor 検知**: \`window.Capacitor?.isNativePlatform?.()\` で native プラットフォーム判定。Web 版では何もせず return
- **Plugin 参照**: \`window.Capacitor.Plugins.Health\` (= 技術判断 B 採用、Importmap 触らない)
- **3 メソッド呼び出し**:
  - \`Health.isAvailable()\`: Health Connect が端末にインストールされているか確認
  - \`Health.checkAuthorization({ read: [...] })\`: 既存の権限状態確認
  - \`Health.requestAuthorization({ read: [...] })\`: 未許可なら新規リクエスト
- **read scope**: \`['steps', 'distance', 'floorsClimbed']\` (= 3 種類すべて、親 Issue #40 論点 2 結果)
- **エラーハンドリング**: プラグイン未読込 / Health Connect 未利用可 / 権限拒否 を UI でフィードバック

### 2. \`app/views/settings/show.html.erb\`

ポリシーリンクの直前に Health Connect セクション追加:

\`\`\`erb
<div data-controller=\"native-health\" data-native-health-target=\"container\"
     class=\"sketch-box\" style=\"display: none; margin-bottom: 24px;\">
  <h2 class=\"sketch-h\">📱 Android Health Connect 連携</h2>
  <p class=\"sketch-small\">Android アプリ版で Health Connect から歩数 / 距離 / 階段を取得します。</p>
  <p data-native-health-target=\"status\" class=\"sketch-body-text\">確認中...</p>
  <button data-action=\"click->native-health#requestPermission\"
          data-native-health-target=\"requestButton\"
          class=\"sketch-btn\" style=\"display: none;\">権限を許可する</button>
</div>
\`\`\`

- 初期 \`style=\"display: none;\"\` で Web 版では非表示
- Capacitor 検知時のみ controller が \`display: \"\"\` に切り替えて表示
- sketchy theme クラスで UI 統一

### 3. \`spec/requests/settings_spec.rb\`

新規 context: 「ログイン時 (Health Connect セクション)」+ spec 2 件:

- spec 1: \`\"Android Health Connect 連携\"\` + \`data-controller=\"native-health\"\` がレンダリング HTML に含まれる
- spec 2: 正規表現で \`data-controller=\"native-health\"\` を持つ要素の inline style に \`display: none\` が含まれる (= Web 版での初期非表示確認)

## 技術判断記録 (= 後輩教材)

**Importmap × Capacitor Plugin 連携の方式選択**

- ❌ A. Importmap で CDN pin: CDN 障害リスク + 依存解決失敗の可能性
- ✅ **B. \`window.Capacitor.Plugins.Health\` グローバル参照** ⭐採用
- ❌ C. esbuild / vite で bundle: Rails 8.1 Importmap 慣習から大きく外れる、教材性低下

→ **B** を選んだ理由: Capacitor は WebView に \`window.Capacitor\` を inject する仕様、プラグインも \`Plugins.<name>\` で global access 可能。Importmap 触らず Web 版に副作用ゼロ。

## 確認できたこと
- [x] \`bundle exec rspec spec/requests/settings_spec.rb\` で全 44 spec pass (= 新規 2 spec 含む)
- [x] Web 版アクセス時に Health Connect セクションが \`display: none\` で初期表示
- [x] Stimulus controller がシンタックスエラーなし、自動 register (= \`eagerLoadControllersFrom\` 経由)
- [x] sketchy theme クラスで Apple Shortcuts / 退会セクションと UI 統一

## 確認していないこと (= 別途、子 6 E2E で実施)
- [ ] 実機 / エミュレータで \`window.Capacitor.Plugins.Health\` が正しく解決される
- [ ] Health Connect の permission ダイアログが起動する
- [ ] 権限拒否 → 設定アプリ案内メッセージの動作

## Test plan

- [ ] CI green
- [ ] 既存 spec への副作用なし (= 全 spec pass、Apple Shortcuts 関連 spec は変更なし)
- [ ] Web 版で /settings にアクセスして Health Connect セクションが見えない (= display: none 維持)
- [ ] (= 子 6 E2E で) Capacitor アプリで Health Connect セクションが表示される

## 関連
- 親 Issue #40
- 前段: PR #127 (= Capacitor 初期化), PR #130 (= プラグイン導入)
- 後続子 Issue: #122 (= データ取得ロジック)
- Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)