### PR TITLE
feat: Health Connect から歩数 / 距離 / 階段データを取得 (#122)

### DIFF
--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -135,20 +135,38 @@ export default class extends Controller {
     return result.samples.reduce((acc, s) => acc + (s?.value || 0), 0)
   }
 
+  // ローカル時刻 (= 日本ユーザー想定なので JST) の 0:00 を ISO 8601 形式で返す。
+  // toISOString() は UTC 化するため、setHours(0,0,0,0) と併用すると前日 15:00 UTC になり日付ズレ発生。
+  // タイムゾーンオフセット付きで返すことで Health Connect の集計バケットを意図通りに切る。
   startOfTodayISO() {
     const d = new Date()
     d.setHours(0, 0, 0, 0)
-    return d.toISOString()
+    return this.toLocalISOString(d)
   }
 
+  // ローカル日付の YYYY-MM-DD。toISOString().slice(0,10) は UTC 基準のため、JST 0-8 時台で前日扱いになる。
+  // measured_on (= サーバー側 recorded_on) として送るため必ずローカル日付。
   todayISODate() {
-    return new Date().toISOString().slice(0, 10)
+    const d = new Date()
+    const pad = (n) => String(n).padStart(2, "0")
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+  }
+
+  toLocalISOString(d) {
+    const pad = (n) => String(n).padStart(2, "0")
+    const offsetMin = -d.getTimezoneOffset()
+    const sign = offsetMin >= 0 ? "+" : "-"
+    const offH = pad(Math.floor(Math.abs(offsetMin) / 60))
+    const offM = pad(Math.abs(offsetMin) % 60)
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}${sign}${offH}:${offM}`
   }
 
   formatSummary(data) {
     const steps = (data.step_count || 0).toLocaleString()
-    const km = ((data.distance_meters || 0) / 1000).toFixed(2)
-    const floors = data.floors_climbed || 0
-    return `✅ 取得成功: ${steps} 歩 / ${km} km / ${floors} 階`
+    const km = ((data.distance_meters || 0) / 1000).toFixed(1) // ホーム画面と同じ 1 桁表示
+    const floors = data.floors_climbed
+    // queryAggregated の floorsClimbed 集計対応は README 明記なし、0 なら未対応を示唆 (= バグではないと伝える)
+    const floorsPart = floors > 0 ? ` / ${floors} 階` : " / 階段(未対応)"
+    return `✅ 今日のデータを取得しました — ${steps} 歩 / ${km} km${floorsPart}`
   }
 }

--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -42,8 +42,8 @@ export default class extends Controller {
 
       const result = await Health.checkAuthorization({ read: HEALTH_READ_TYPES })
       if (result?.granted) {
-        this.showStatus("✅ Health Connect 連携済み (歩数 / 距離 / 階段)")
         this.requestButtonTarget.style.display = "none"
+        await this.refreshData()
       } else {
         this.showStatus("⏳ Health Connect の権限が必要です")
         this.requestButtonTarget.style.display = ""
@@ -60,8 +60,8 @@ export default class extends Controller {
     try {
       const result = await Health.requestAuthorization({ read: HEALTH_READ_TYPES })
       if (result?.granted) {
-        this.showStatus("✅ 権限を取得しました")
         this.requestButtonTarget.style.display = "none"
+        await this.refreshData()
       } else {
         this.showStatus("⚠️ 権限が拒否されました。設定 → アプリ → Health Connect から許可できます")
       }
@@ -77,5 +77,78 @@ export default class extends Controller {
   errorMessage(error) {
     if (!error) return "原因不明"
     return error.message || error.errorMessage || String(error)
+  }
+
+  // -------------------------------------------------------------------------
+  // データ取得 (子 Issue #122 / 子 4)
+  // -------------------------------------------------------------------------
+
+  async refreshData() {
+    this.showStatus("⏳ データ取得中...")
+    const data = await this.fetchTodayData()
+    if (!data) return
+    this.lastFetchedData = data
+    this.showStatus(this.formatSummary(data))
+  }
+
+  async fetchTodayData() {
+    const Health = this.healthPlugin()
+    if (!Health) return null
+
+    const startDate = this.startOfTodayISO()
+    const endDate = new Date().toISOString()
+
+    try {
+      // 個別フォールバック方式: 1 dataType 失敗しても他が取れれば全体は成立
+      // README 注記より steps / distance は queryAggregated 対応、floorsClimbed は明記なし
+      const [steps, distance, floors] = await Promise.all([
+        this.queryAggregatedSafe(Health, "steps", startDate, endDate),
+        this.queryAggregatedSafe(Health, "distance", startDate, endDate),
+        this.queryAggregatedSafe(Health, "floorsClimbed", startDate, endDate)
+      ])
+      return {
+        step_count: this.sumSamples(steps),
+        distance_meters: this.sumSamples(distance),
+        floors_climbed: this.sumSamples(floors),
+        measured_on: this.todayISODate()
+      }
+    } catch (error) {
+      this.showStatus(`❌ 取得エラー: ${this.errorMessage(error)}`)
+      return null
+    }
+  }
+
+  async queryAggregatedSafe(Health, dataType, startDate, endDate) {
+    try {
+      return await Health.queryAggregated({
+        dataType, startDate, endDate,
+        bucket: "day", aggregation: "sum"
+      })
+    } catch (error) {
+      console.warn(`queryAggregated failed for ${dataType}:`, error)
+      return { samples: [] }
+    }
+  }
+
+  sumSamples(result) {
+    if (!result?.samples?.length) return 0
+    return result.samples.reduce((acc, s) => acc + (s?.value || 0), 0)
+  }
+
+  startOfTodayISO() {
+    const d = new Date()
+    d.setHours(0, 0, 0, 0)
+    return d.toISOString()
+  }
+
+  todayISODate() {
+    return new Date().toISOString().slice(0, 10)
+  }
+
+  formatSummary(data) {
+    const steps = (data.step_count || 0).toLocaleString()
+    const km = ((data.distance_meters || 0) / 1000).toFixed(2)
+    const floors = data.floors_climbed || 0
+    return `✅ 取得成功: ${steps} 歩 / ${km} km / ${floors} 階`
   }
 }


### PR DESCRIPTION
## Summary

Issue #40 子 Issue 4 (#122)。\`@capgo/capacitor-health\` の \`queryAggregated\` API で当日分の **歩数 / 距離 / 階段** を集計取得し、UI にサマリー表示。子 3 の permission flow を発展させ、子 5a (= 同期ボタン + Webhook POST) の前段。

## 変更内容

### \`native_health_controller.js\` 拡張 (= 別 controller 化せず YAGNI)

| メソッド | 役割 |
|---|---|
| \`refreshData()\` | permission OK 後の状態管理エントリ、子 5a でも再利用予定 |
| \`fetchTodayData()\` | 3 種類データを Promise.all で並列取得 |
| \`queryAggregatedSafe(...)\` | 個別 dataType ごとに try/catch + 0 フォールバック |
| \`sumSamples(...)\` | { samples: [...] } 戻り値を合計 |
| ヘルパー | \`startOfTodayISO\` / \`todayISODate\` / \`formatSummary\` |

### 仕様判明事項 (= 教材性)

- README 注記: queryAggregated 集計対応リスト = steps / distance / calories / heart rate / weight / resting heart rate
- **\`floorsClimbed\` は集計対応リスト明記なし** → 動かない可能性、queryAggregatedSafe で 0 フォールバック保険
- 実機確認は子 6 (E2E) で、ダメなら readSamples 個別取得 + JS 合計に切替検討

## Web 版影響

- isCapacitorNative() ガードで Web 版では一切実行されない
- 既存 settings_spec 全 44 spec pass 維持

## Test plan

- [ ] CI green
- [ ] (= 子 6 E2E で) 実機で 3 種類データ表示
- [ ] (= 子 6 E2E で) floorsClimbed が動くか確認

## 関連
- 親 Issue #40
- 前段: PR #127, #130, #133
- 後続: 子 5a (#123 = MVP 同期)
- Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)