### PR TITLE
feat: 手動同期ボタン + Webhook POST フロー (MVP) (#123)

### DIFF
--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -3,7 +3,8 @@ import { Controller } from "@hotwired/stimulus"
 const HEALTH_READ_TYPES = ["steps", "distance", "floorsClimbed"]
 
 export default class extends Controller {
-  static targets = ["status", "requestButton"]
+  static targets = ["status", "requestButton", "syncButton"]
+  static values = { webhookToken: String }
 
   connect() {
     if (!this.isCapacitorNative()) {
@@ -43,10 +44,12 @@ export default class extends Controller {
       const result = await Health.checkAuthorization({ read: HEALTH_READ_TYPES })
       if (result?.granted) {
         this.requestButtonTarget.style.display = "none"
+        this.syncButtonTarget.style.display = ""
         await this.refreshData()
       } else {
         this.showStatus("⏳ Health Connect の権限が必要です")
         this.requestButtonTarget.style.display = ""
+        this.syncButtonTarget.style.display = "none"
       }
     } catch (error) {
       this.showStatus(`❌ 確認エラー: ${this.errorMessage(error)}`)
@@ -61,6 +64,7 @@ export default class extends Controller {
       const result = await Health.requestAuthorization({ read: HEALTH_READ_TYPES })
       if (result?.granted) {
         this.requestButtonTarget.style.display = "none"
+        this.syncButtonTarget.style.display = ""
         await this.refreshData()
       } else {
         this.showStatus("⚠️ 権限が拒否されました。設定 → アプリ → Health Connect から許可できます")
@@ -168,5 +172,67 @@ export default class extends Controller {
     // queryAggregated の floorsClimbed 集計対応は README 明記なし、0 なら未対応を示唆 (= バグではないと伝える)
     const floorsPart = floors > 0 ? ` / ${floors} 階` : " / 階段(未対応)"
     return `✅ 今日のデータを取得しました — ${steps} 歩 / ${km} km${floorsPart}`
+  }
+
+  // -------------------------------------------------------------------------
+  // Webhook POST フロー (子 Issue #123 / 子 5a = MVP)
+  // -------------------------------------------------------------------------
+
+  async sync() {
+    if (!this.lastFetchedData) {
+      this.showStatus("⚠️ データ未取得です。再読込してください")
+      return
+    }
+    if (!this.webhookTokenValue) {
+      this.showStatus("⚠️ webhook token 未設定 (= ログインし直してください)")
+      return
+    }
+
+    this.showStatus("📡 送信中...")
+    this.syncButtonTarget.disabled = true
+
+    try {
+      const data = this.lastFetchedData
+      // Webhook サーバー側のフィールド名は flights_climbed (= JS 側 floors_climbed から変換)、
+      // distance_meters は整数想定なので Math.round で揃える。
+      const payload = {
+        records: [{
+          recorded_on: data.measured_on,
+          steps: data.step_count,
+          distance_meters: Math.round(data.distance_meters || 0),
+          flights_climbed: data.floors_climbed
+        }]
+      }
+
+      const response = await fetch("/webhooks/health_data", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${this.webhookTokenValue}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      })
+
+      if (!response.ok) {
+        const errorBody = await response.text()
+        this.showStatus(`❌ 送信失敗 (HTTP ${response.status}): ${errorBody.slice(0, 80)}`)
+        return
+      }
+
+      const result = await response.json()
+      this.showStatus(`✅ 送信完了 — ${result.accepted ?? 0} 件保存。ホームを更新します...`)
+      // Turbo で home 画面を再描画して、保存されたデータを反映
+      setTimeout(() => {
+        if (typeof Turbo !== "undefined") {
+          Turbo.visit("/")
+        } else {
+          window.location.assign("/")
+        }
+      }, 1500)
+    } catch (error) {
+      this.showStatus(`❌ 送信エラー: ${this.errorMessage(error)}`)
+    } finally {
+      this.syncButtonTarget.disabled = false
+    }
   }
 }

--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -74,8 +74,20 @@ export default class extends Controller {
     }
   }
 
+  // status 表示は先頭絵文字でトーンを自動分岐 (= success / error / info)。
+  // 発表会デモで成功 / 失敗の瞬間を視認しやすくするため、太字 + 色強調を適用する。
   showStatus(message) {
     this.statusTarget.textContent = message
+    if (message.startsWith("✅")) {
+      this.statusTarget.style.fontWeight = "700"
+      this.statusTarget.style.color = "var(--ink)"
+    } else if (message.startsWith("❌") || message.startsWith("⚠️")) {
+      this.statusTarget.style.fontWeight = "700"
+      this.statusTarget.style.color = "var(--danger)"
+    } else {
+      this.statusTarget.style.fontWeight = ""
+      this.statusTarget.style.color = ""
+    }
   }
 
   errorMessage(error) {
@@ -178,6 +190,9 @@ export default class extends Controller {
   // Webhook POST フロー (子 Issue #123 / 子 5a = MVP)
   // -------------------------------------------------------------------------
 
+  // sync は「子 4 で取得したデータをそのまま POST」する設計。
+  // 連打しても同日 recorded_on は冪等 (= サーバー側 find_or_initialize_by で同じレコードを上書き) のため副作用なし。
+  // 子 5b (WorkManager 自動化) でこのロジックを Worker 化する場合も「取得 → POST」の 1 トランザクション前提を継承する。
   async sync() {
     if (!this.lastFetchedData) {
       this.showStatus("⚠️ データ未取得です。再読込してください")
@@ -215,7 +230,11 @@ export default class extends Controller {
 
       if (!response.ok) {
         const errorBody = await response.text()
-        this.showStatus(`❌ 送信失敗 (HTTP ${response.status}): ${errorBody.slice(0, 80)}`)
+        // サーバーは {error: "..."} JSON で 4xx を返す設計、JSON parse 成功時は error を抜粋。
+        // パース失敗時は生 body の先頭 80 字でフォールバック。
+        let message = errorBody.slice(0, 80)
+        try { message = JSON.parse(errorBody).error ?? message } catch (_) {}
+        this.showStatus(`❌ 送信失敗 (HTTP ${response.status}): ${message}`)
         return
       }
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -97,11 +97,12 @@
 
   <%# Health Connect 連携 (Android のみ、Capacitor 検知で動的表示。Web 版では非表示のまま) %>
   <div data-controller="native-health"
+       data-native-health-webhook-token-value="<%= current_user.webhook_token %>"
        class="sketch-box"
        style="display: none; margin-bottom: 24px;">
     <h2 class="sketch-h" style="margin-bottom: 8px;">📱 Android Health Connect 連携</h2>
     <p class="sketch-small" style="margin-bottom: 12px;">
-      Android アプリ版で Health Connect から歩数 / 距離 / 階段を取得します。
+      Android アプリ版で Health Connect から歩数 / 距離 / 階段を取得 → サーバーへ自動同期します。
     </p>
     <p data-native-health-target="status" class="sketch-body-text" style="margin-bottom: 16px;">
       確認中...
@@ -109,8 +110,14 @@
     <button data-action="click->native-health#requestPermission"
             data-native-health-target="requestButton"
             class="sketch-btn"
-            style="display: none;">
+            style="display: none; margin-right: 8px;">
       権限を許可する
+    </button>
+    <button data-action="click->native-health#sync"
+            data-native-health-target="syncButton"
+            class="sketch-btn"
+            style="display: none;">
+      📡 同期する
     </button>
   </div>
 

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -114,6 +114,16 @@ RSpec.describe "Settings", type: :request do
         # native-health controller を持つ要素の inline style に display: none が含まれる
         expect(response.body).to match(/data-controller="native-health"[^>]*style="[^"]*display: none/)
       end
+
+      # 子 5a (#123): 同期ボタン + Webhook POST フロー
+      it "同期ボタン (= click->native-health#sync action) を含む" do
+        expect(response.body).to include('data-action="click->native-health#sync"')
+      end
+
+      it "webhook_token を Stimulus values 経由で埋め込む (= Capacitor 検知時のみ JS 参照)" do
+        expect(response.body).to include('data-native-health-webhook-token-value="')
+        expect(response.body).to include(user.webhook_token)
+      end
     end
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue #40 子 Issue 5a (#123)。子 4 で取得した Health Connect データを既存 Webhook (\`/webhooks/health_data\`) へ POST する **MVP フロー**。これで「Android で歩く → アプリで同期 → ホーム画面に反映」のループが成立。**Issue #40 B スコープの中核機能達成**。

## 変更内容 (3 files / 86 insertions / 3 deletions)

### \`native_health_controller.js\` 拡張

| 追加要素 | 役割 |
|---|---|
| \`static targets\` に \`syncButton\` 追加 | permission OK 時に表示する同期ボタン |
| \`static values = { webhookToken: String }\` | view から Bearer token を受け取る |
| \`sync()\` メソッド新設 | lastFetchedData → 形式変換 → POST → Turbo home 更新 |

### sync() の処理フロー

\`\`\`
lastFetchedData (子 4 で保存)
  ↓
形式変換 ({records: [{recorded_on, steps, distance_meters, flights_climbed}]})
  ↓
fetch POST /webhooks/health_data + Authorization: Bearer ${token}
  ↓
成功 → status 表示 + Turbo.visit(\"/\") で home 再描画
失敗 → HTTP status + body 抜粋を status target に表示
\`\`\`

**重要なフィールド名変換**: JS 側 \`floors_climbed\` → サーバー側 \`flights_climbed\` (= Apple Health vs Health Connect 歴史的差異、サーバー側に整合)。distance_meters は \`Math.round\` で整数化 (= サーバー側 \`parse_numeric\` が Float reject するため)。

### \`settings/show.html.erb\`

- 「📡 同期する」ボタン追加 (= permission OK 時のみ表示)
- \`data-native-health-webhook-token-value=\"<%= current_user.webhook_token %>\"\` で Bearer token を渡す
- セクション説明文を「取得 → サーバーへ自動同期」に更新

### \`settings_spec\`

- 同期ボタン spec 1 件 (= action 紐付け確認)
- webhook_token 埋め込み spec 1 件 (= Stimulus values 値確認)
- 全 46 spec pass (= 既存 44 + 新規 2)

## Webhook サーバー側の整合 (= 既存 \`webhooks_controller.rb\` 由来、ゼロ修正)

\`\`\`
POST /webhooks/health_data
Authorization: Bearer <webhook_token>
Content-Type: application/json

{
  \"records\": [{
    \"recorded_on\": \"yyyy-MM-dd\",
    \"steps\": 5432,
    \"distance_meters\": 4200,
    \"flights_climbed\": 8
  }]
}

→ 200 OK + {\"accepted\": 1}
\`\`\`

Apple Shortcuts と完全互換、サーバー側ゼロ修正で動作。

## 教材性ポイント (= 後輩教材)

1. **Capacitor アプリは server.url で本番 Web を WebView 表示** → fetch の URL は同一オリジン相対パスで OK (CORS 不要)
2. **Cookie 認証は不要**、Webhook 専用 Bearer token を Stimulus values 経由で渡す (= URL 依存しない)
3. **フィールド名変換** (\`floors → flights\`) は Apple Health / Health Connect の歴史的差異、後輩が両方扱う時の落とし穴

## Web 版影響

- \`isCapacitorNative()\` ガードで Web 版では一切実行されない
- 既存 spec 全 46 件 pass

## Test plan

- [ ] CI green
- [ ] (= 子 6 E2E で) 実機で同期ボタンタップ → 200 OK → home 画面に歩数反映
- [ ] (= 子 6 E2E で) ネットワークエラー時のフォールバック動作

## 関連
- 親 Issue #40
- 前段: PR #127, #130, #133, #136
- 後続: 子 5b (= WorkManager 自動化、v1.1 送り推奨) / 子 6 (= E2E)
- Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)