### PR TITLE
fix: /auth/ パスを allow_browser から bypass (OAuth Custom Tabs 対応、子 6 OAuth ブロッカー)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,10 @@ class ApplicationController < ActionController::Base
   #         副作用: SNS 内蔵ブラウザ (LINE / Twitter 等) も "; wv)" 含むため通る、OAuth 詰まり問題は Issue #143 で対応予定 (v1.1)
   allow_browser versions: :modern,
                 if: -> {
+                  # OAuth コールバックパスは Chrome Custom Tabs で開かれる (= Google の "In-App Browsers Are Not Allowed" 2021 ポリシー)
+                  # Custom Tabs は Capacitor の overrideUserAgent の影響を受けないため UA に WeightDialyCapacitor が含まれず、modern check で弾かれる。
+                  # /auth/ 配下は認証フロー専用で UA 判定すべきパスではないため、modern check 自体をスキップする。
+                  return false if request.path.start_with?("/auth/")
                   ua = request.user_agent.to_s
                   !ua.include?("WeightDialyCapacitor") && !ua.include?("; wv)")
                 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
                   # OAuth コールバックパスは Chrome Custom Tabs で開かれる (= Google の "In-App Browsers Are Not Allowed" 2021 ポリシー)
                   # Custom Tabs は Capacitor の overrideUserAgent の影響を受けないため UA に WeightDialyCapacitor が含まれず、modern check で弾かれる。
                   # /auth/ 配下は認証フロー専用で UA 判定すべきパスではないため、modern check 自体をスキップする。
-                  return false if request.path.start_with?("/auth/")
+                  next false if request.path.start_with?("/auth/")
                   ua = request.user_agent.to_s
                   !ua.include?("WeightDialyCapacitor") && !ua.include?("; wv)")
                 }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
     auth = request.env["omniauth.auth"]
     if auth.nil?
       Rails.logger.error("OAuth login failed: omniauth.auth is nil")
-      return redirect_to root_path, alert: "ログインに失敗しました"
+      return redirect_to root_path, alert: "ログインに失敗しました。もう一度お試しください"
     end
 
     user = User.from_omniauth(auth)
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     redirect_to root_path, notice: "ログインしました"
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error("OAuth login failed: #{e.message}")
-    redirect_to root_path, alert: "ログインに失敗しました"
+    redirect_to root_path, alert: "ログインに失敗しました。もう一度お試しください"
   end
 
   def destroy
@@ -21,6 +21,7 @@ class SessionsController < ApplicationController
   end
 
   def failure
-    redirect_to root_path, alert: "ログインに失敗しました"
+    # OAuth フロー中断 (= ユーザーがキャンセル / Custom Tabs から戻った等) の専用文言
+    redirect_to root_path, alert: "Google ログインがキャンセルされました。再度お試しください"
   end
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -320,8 +320,9 @@ RSpec.describe "Home", type: :request do
             headers: { "User-Agent" => "Mozilla/4.0 (compatible; MSIE 6.0)" }
       end
 
-      it "406 Not Acceptable ではない (= /auth/ 配下は modern check スキップ)" do
+      it "406 Not Acceptable ではなく、認証成功で 302 redirect を返す (= /auth/ 配下は modern check スキップ + OAuth callback 動作)" do
         expect(response).not_to have_http_status(:not_acceptable)
+        expect(response).to have_http_status(:redirect)
       end
     end
   end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -309,5 +309,20 @@ RSpec.describe "Home", type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    # OAuth Custom Tabs パス bypass (= Google "In-App Browsers Are Not Allowed" 2021 ポリシー対応)
+    context "/auth/ パスへの古い UA でのアクセス (= Chrome Custom Tabs から OAuth callback)" do
+      let(:user) { create(:user) }
+      before do
+        # 古い UA で OAuth callback にアクセス、Custom Tabs 経由を模倣
+        mock_google_oauth2(uid: user.uid, email: user.email, name: user.name)
+        get auth_callback_path(provider: "google_oauth2"),
+            headers: { "User-Agent" => "Mozilla/4.0 (compatible; MSIE 6.0)" }
+      end
+
+      it "406 Not Acceptable ではない (= /auth/ 配下は modern check スキップ)" do
+        expect(response).not_to have_http_status(:not_acceptable)
+      end
+    end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe "Sessions", type: :request do
       expect(response).to redirect_to(root_path)
     end
 
-    it "sets an alert flash" do
+    it "sets an alert flash with cancellation guidance" do
+      # PR #146 design レビューで OAuth 中断専用文言に変更 (= 通常失敗とは別、Custom Tabs 復帰時の UX 改善)
       get auth_failure_path
-      expect(flash[:alert]).to eq("ログインに失敗しました")
+      expect(flash[:alert]).to eq("Google ログインがキャンセルされました。再度お試しください")
     end
   end
 end


### PR DESCRIPTION
## Summary

子 6 (#125) E2E 動作確認の **3 ラウンド目 fix**。OAuth フロー後の 406 を解消。

## 何が起きていたか

```
Capacitor アプリで「Google でログイン」タップ
  ↓
Google "In-App Browsers Are Not Allowed" (2021) ポリシーで Capacitor WebView での OAuth が block
  ↓
Android が Chrome Custom Tabs で accounts.google.com を開く (= 別 WebView、UA に WeightDialyCapacitor 含まれない)
  ↓
2FA 完了 → callback (/auth/google_oauth2/callback?code=...) が Custom Tabs で Rails にリクエスト
  ↓
Custom Tabs UA で modern check 発動 → 406 ← ここで詰まる
```

## 修正内容 (2 files / 19 insertions)

### \`application_controller.rb\` の \`if:\` 条件に \`/auth/\` 早期リターン追加

\`\`\`diff
   allow_browser versions: :modern,
                 if: -> {
+                  # OAuth コールバックパスは Chrome Custom Tabs で開かれる (= Google "In-App Browsers Are Not Allowed" 2021 ポリシー)
+                  return false if request.path.start_with?(\"/auth/\")
                   ua = request.user_agent.to_s
                   !ua.include?(\"WeightDialyCapacitor\") && !ua.include?(\"; wv)\")
                 }
\`\`\`

### \`home_spec.rb\` に bypass spec 追加

- \`mock_google_oauth2\` + 古い UA で \`/auth/google_oauth2/callback\` アクセス → 406 でないことを確認
- 全 43 spec pass

## 完成形のフロー

\`\`\`
Capacitor アプリ起動 (overrideUserAgent: WeightDialyCapacitor、bypass 通る)
  ↓
「Google でログイン」タップ → Custom Tabs で accounts.google.com 開く
  ↓
2FA → callback (/auth/google_oauth2/callback) → Rails で /auth/ bypass → 200 OK → OmniAuth セッション確立
  ↓
リダイレクト先 (= ホーム /) を Capacitor WebView で開く → overrideUserAgent + WeightDialyCapacitor → bypass 通る → ホーム表示
\`\`\`

## 教材性ポイント

1. **Google OAuth 2021 ポリシー**: WebView 不可、Custom Tabs / Safari View Controller のみ
2. **Capacitor + OAuth の落とし穴**: callback の UA が変わる前提で設計が必要
3. **`/auth/` パスは UA 判定と独立すべき**: 認証フローは UA に依存しない、modern check 適用すると詰まる

## Test plan

- [ ] CI green
- [ ] 全 43 spec pass
- [ ] マージ後 Render デプロイ完了
- [ ] AVD で再 Run → ログインボタン → Custom Tabs で OAuth → 2FA → callback → ホーム表示 (= 406 なし)
- [ ] ホーム画面で「おはようございます〇〇さん」表示
- [ ] Settings → Health Connect セクション動作

## 関連
- 親 Issue #40
- 前段: PR #140 (= Capacitor bypass + minSdk), #142 (= overrideUserAgent + wv 二重防衛)
- 子 6 (#125): 進行中、本 PR で OAuth ブロッカー解消後にエミュレータ再テストで完走予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)