### PR TITLE
feat: Phase 2b — AssetLinks verify で deep link を seamless 化 (= 子 6 完全完走)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,10 +22,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Deep link (= Phase 2a): OAuth callback を Capacitor アプリで受信
-                 autoVerify="false" のため「アプリで開く?」ダイアログがユーザーに表示される。
-                 autoVerify="true" + AssetLinks 検証は Phase 2b で対応予定 (= seamless 化)。 -->
-            <intent-filter>
+            <!-- Deep link (= Phase 2b): OAuth callback を Capacitor アプリで受信
+                 autoVerify="true" + public/.well-known/assetlinks.json で AssetLinks 検証
+                 → Android OS が SHA-256 fingerprint を検証して seamless にアプリ起動 (= ダイアログなし) -->
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.weightdialy.app",
+      "sha256_cert_fingerprints": [
+        "30:BA:CC:77:A0:21:9B:65:AD:D6:70:99:28:C2:C0:11:E0:19:0C:90:1A:E6:3C:4A:39:41:B7:2D:1D:0A:79:84"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Issue #40 子 6 構造的問題への根本解決 **Phase 2b**。Phase 2a (PR #149) では deep link が機能しないことが AVD 動作確認で判明、**AssetLinks verify が必須**と確認されたため本 PR で完成させる。

## 何が違うか (= Phase 2a vs Phase 2b)

| 項目 | Phase 2a (PR #149) | Phase 2b (本 PR) |
|---|---|---|
| `autoVerify` | `"false"` | **`"true"`** |
| AssetLinks JSON | 配信なし | `public/.well-known/assetlinks.json` |
| 動作 | 機能せず (= ダイアログすら出ない) | seamless deep link |

## 変更内容 (2 files / 16 insertions / 4 deletions)

### 1. \`public/.well-known/assetlinks.json\` (新規)
\`\`\`json
[{
  "relation": ["delegate_permission/common.handle_all_urls"],
  "target": {
    "namespace": "android_app",
    "package_name": "com.weightdialy.app",
    "sha256_cert_fingerprints": [
      "30:BA:CC:77:A0:21:9B:65:AD:D6:70:99:28:C2:C0:11:E0:19:0C:90:1A:E6:3C:4A:39:41:B7:2D:1D:0A:79:84"
    ]
  }
}]
\`\`\`

- SHA-256: debug 署名 (= ~/.android/debug.keystore、Android Studio が自動生成)
- Rails の public/ 配下なので静的配信、weight-dialy.onrender.com/.well-known/assetlinks.json で 200 OK 期待
- 発表会後 v1.1 で release 署名追加予定 (= sha256_cert_fingerprints 配列に追加)

### 2. \`AndroidManifest.xml\` の \`<intent-filter>\` を \`autoVerify="true"\` に変更
\`\`\`diff
-<intent-filter>
+<intent-filter android:autoVerify="true">
   <action android:name="android.intent.action.VIEW" />
   <category android:name="android.intent.category.DEFAULT" />
   <category android:name="android.intent.category.BROWSABLE" />
   <data android:scheme="https"
         android:host="weight-dialy.onrender.com"
         android:pathPrefix="/auth/" />
 </intent-filter>
\`\`\`

## 仕組み (= Phase 2b 完成形のフロー)

\`\`\`
1. Capacitor アプリで「Google でログイン」タップ
2. Custom Tabs で OAuth 完了 → callback URL リクエスト
3. Android OS が AssetLinks 検証済 (= SHA-256 一致) → Capacitor アプリに直接 deep link
4. appUrlOpen ハンドラー (PR #149) で callback 処理 → Rails session 確立
5. ホーム画面表示 → Capacitor アプリ内でログイン状態維持 → Health Connect 連携可能
\`\`\`

## Test plan

- [ ] CI green
- [ ] 全 245 spec pass
- [ ] マージ後 Render デプロイ → \`https://weight-dialy.onrender.com/.well-known/assetlinks.json\` で 200 OK + JSON 配信
- [ ] APK 再ビルド + AVD 再 install
- [ ] AssetLinks verify (= 数十秒、自動)
- [ ] OAuth フロー → 「アプリで開く?」ダイアログなしで Capacitor アプリに seamless 帰還
- [ ] ホーム画面表示 + ログイン状態維持

## 関連
- 親 Issue #40
- 前段: PR #149 (= Phase 2a appUrlOpen handler、本 PR で完成)
- 子 6 (#125): 進行中、本 PR で完全完走見込
- 学び 19 (= dev-log day-7) で予告した Phase 2a/2b 完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)