### PR TITLE
fix: AssetLinks intent-filter 削除 = Phase 3 実機検証で OAuth callback 横取り障害発覚

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
                  Custom Tabs 内で Rails が com.weightdialy.app://oauth_callback?token=XXX に redirect
                  → Android が scheme を認識して Custom Tabs 自動 close、Capacitor アプリ前面復帰
                  → appUrlOpen listener で token 受信 → /auto_login?token=XXX 経由で WebView に session 確立
-                 (= Auth0 公式 quickstart 由来の業界標準パターン、AssetLinks deep link は Custom Tabs 内 callback 不対象のため不可) -->
+                 (= Auth0 公式 quickstart 由来の業界標準パターン) -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -34,16 +34,11 @@
                 <data android:scheme="@string/custom_url_scheme" />
             </intent-filter>
 
-            <!-- Deep link (= Phase 2b): https AssetLinks intent-filter は Phase 3 動作確認後に別 PR で削除予定
-                 (= Custom Tabs 内 callback では発動しないと確定済み、学び 20 参照) -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https"
-                      android:host="weight-dialy.onrender.com"
-                      android:pathPrefix="/auth/" />
-            </intent-filter>
+            <!-- ⚠ Phase 2b の AssetLinks (https autoVerify) intent-filter は意図的に削除済み (2026-05-06)。
+                 理由: 実機 (Torque G6) で Day 7 の前提と異なり Custom Tabs 内 OAuth callback も AssetLinks で
+                 横取りされてしまい、Rails の sessions#create 処理 (= Phase 3 ブリッジの中核) が走らず WebView 側で
+                 state 不整合 → 「ログインキャンセル」になる障害が発生したため。Phase 3 は custom scheme 一本で完結する設計。
+                 削除に伴い public/.well-known/assetlinks.json も実質不要 (= ファイルは残るが効果なし)、別 PR で削除予定。 -->
 
         </activity>
 

--- a/app/javascript/native/capacitor_init.js
+++ b/app/javascript/native/capacitor_init.js
@@ -39,10 +39,14 @@ if (typeof window.Capacitor !== "undefined" && window.Capacitor.isNativePlatform
             try { await Browser.close() } catch (_) { /* close 失敗は致命的でない */ }
           }
           window.location.href = `/auto_login?token=${encodeURIComponent(token)}`
-        } else if (url.includes("/auth/")) {
-          // Phase 2a 互換経路 (= AssetLinks intent-filter 経由のフォールバック、Phase 3 動作確認後に削除予定)
-          const parsed = new URL(url)
-          window.location.href = parsed.pathname + parsed.search
+        } else {
+          // Phase 2a 互換経路 (= /auth/ を含む https URL を WebView に転送) は意図的に削除。
+          // 理由: AssetLinks intent-filter で OAuth callback URL を appUrlOpen 経由で受信した場合、
+          // ここで WebView に転送してしまうと WebView 側 session に OAuth state cookie がない状態で
+          // OmniAuth callback 処理が走り、state 不整合で「ログインキャンセル」になる障害が発生した
+          // (2026-05-06、Phase 3 実機検証で発覚)。AndroidManifest 側の AssetLinks intent-filter も
+          // 同時に削除済 = この else 分岐は今後到達想定なし、何もしないのが正解。
+          console.debug("[Capacitor] appUrlOpen received non-custom-scheme URL, ignored:", url)
         }
       } catch (error) {
         console.error("[Capacitor] appUrlOpen handler error:", error)


### PR DESCRIPTION
## Summary

PR #153 (Phase 3) マージ後の実機検証 (Torque G6) で、**AssetLinks intent-filter が Custom Tabs 内 OAuth callback URL を横取りする障害**が発覚。Phase 3 設計の前提が崩れるため AssetLinks 経路を廃止し custom URL scheme 一本に統一。

## 障害再現

実機ログ抜粋 (= 2026-05-06 07:54:43):
\`\`\`
Capacitor/AppPlugin: Notifying listeners for event appUrlOpen
URL: https://weight-dialy.onrender.com/auth/google_oauth2/callback?state=...&code=...
\`\`\`

期待: \`com.weightdialy.app://oauth_callback?token=XXX\` を appUrlOpen で受信
実際: OAuth callback URL そのものを受信 → Phase 2a 互換 path で WebView 転送 → OmniAuth state 不整合 → 「Google ログインがキャンセルされました」 alert

## 原因

Day 7 学び 20 では「AssetLinks は Custom Tabs 内 callback では発動しない」と確定したが、実機検証で **発動するケースがある** と判明。AssetLinks intent-filter (\`autoVerify=true\` + \`https\` scheme + \`weight-dialy.onrender.com/auth/*\` path) が Custom Tabs の callback navigation を OS レベルで横取りし、Rails の \`sessions#create\` (= Phase 3 ブリッジ核心) に到達する前に Capacitor アプリへ deep link する。

→ Custom Tabs の OAuth state cookie が活用されず、WebView 側 fresh session で callback を処理しようとして state 不整合で失敗。

端末 / Android バージョン / AssetLinks verify 完了タイミング等の差で「動いたり動かなかったり」する模様。

## 修正

- \`android/app/src/main/AndroidManifest.xml\`: AssetLinks (\`autoVerify=true\` + https) intent-filter 削除
- \`app/javascript/native/capacitor_init.js\`: Phase 2a 互換 path (= \`/auth/\` を含む URL を WebView 転送) 削除、custom scheme 以外の appUrlOpen は debug log のみで無視

修正後の挙動:
1. Custom Tabs OAuth 完了 → Google 302 → \`/auth/google_oauth2/callback\`
2. Custom Tabs が callback を **素通しで処理** (= AssetLinks 横取りなし)
3. Rails \`sessions#create\`: capacitor_oauth フラグ検出 → OneTimeLoginToken 発行 → \`com.weightdialy.app://oauth_callback?token=XXX\` redirect
4. Custom URL scheme intent-filter (= 残置) 発火 → Capacitor アプリへ deep link
5. \`appUrlOpen\` で custom scheme URL 受信 → \`/auto_login?token=XXX\` → session 確立

## v1.1 / 別 PR

- \`public/.well-known/assetlinks.json\` ファイル自体も不要 (= 実質効果なし、残しても害なし)、別 PR で削除

## Test plan

- [x] \`bundle exec rspec\` (515 examples, 0 failures)
- [x] \`bundle exec rubocop\` (clean)
- [ ] マージ → Render auto-deploy 完了
- [ ] Windows 側 AndroidManifest 同期 + APK 再ビルド + 実機再インストール
- [ ] OAuth 完走 → custom scheme deep link → \`/auto_login\` → ログイン状態反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)