### PR TITLE
fix: Health Connect 階段データ型を flightsClimbed に修正 = 実機検証で typo 発覚

### DIFF
--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -1,6 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
-const HEALTH_READ_TYPES = ["steps", "distance", "floorsClimbed"]
+// @capgo/capacitor-health (v8.4.9) の HealthDataType 定義に合わせる。
+// Health Connect 内部レコードは FloorsClimbedRecord だが、plugin の JS 公開 API は米国流の "flightsClimbed" (= 階段の段数)。
+// 旧コードでは "floorsClimbed" と書かれており permission チェックで "Unsupported data type" エラーになっていた (2026-05-06 実機検証で発覚)。
+const HEALTH_READ_TYPES = ["steps", "distance", "flightsClimbed"]
 
 export default class extends Controller {
   static targets = ["status", "requestButton", "syncButton"]
@@ -116,11 +119,10 @@ export default class extends Controller {
 
     try {
       // 個別フォールバック方式: 1 dataType 失敗しても他が取れれば全体は成立
-      // README 注記より steps / distance は queryAggregated 対応、floorsClimbed は明記なし
       const [steps, distance, floors] = await Promise.all([
         this.queryAggregatedSafe(Health, "steps", startDate, endDate),
         this.queryAggregatedSafe(Health, "distance", startDate, endDate),
-        this.queryAggregatedSafe(Health, "floorsClimbed", startDate, endDate)
+        this.queryAggregatedSafe(Health, "flightsClimbed", startDate, endDate)
       ])
       return {
         step_count: this.sumSamples(steps),
@@ -181,8 +183,9 @@ export default class extends Controller {
     const steps = (data.step_count || 0).toLocaleString()
     const km = ((data.distance_meters || 0) / 1000).toFixed(1) // ホーム画面と同じ 1 桁表示
     const floors = data.floors_climbed
-    // queryAggregated の floorsClimbed 集計対応は README 明記なし、0 なら未対応を示唆 (= バグではないと伝える)
-    const floorsPart = floors > 0 ? ` / ${floors} 階` : " / 階段(未対応)"
+    // 階段データ (= flightsClimbed) は Health Connect に記録があれば取得できる。
+    // 0 の場合は「今日まだ階段昇降がない」or「ソース device が未対応」のいずれかなので「階段なし」と表示する。
+    const floorsPart = floors > 0 ? ` / ${floors} 階` : " / 階段なし"
     return `✅ 今日のデータを取得しました — ${steps} 歩 / ${km} km${floorsPart}`
   }
 


### PR DESCRIPTION
## Summary

子 6 完走後の実機検証で Android Health Connect 連携カードに **「❌ 確認エラー: Unsupported data type: FloorsClimbed」** と表示される障害を発見、修正。

## 原因

\`@capgo/capacitor-health\` (v8.4.9) の \`HealthDataType\` 定義は米国流の **\`flightsClimbed\`** (= 階段の段数) だが、Day 7 実装時に **\`floorsClimbed\`** (= フロア数) と typo。plugin 側で permission チェック段階で「Unsupported data type」として弾かれていた → 結果として子 6 で OAuth 完走しても「歩数 / 距離 / 階段」3 種類の取得自体が permission レベルで失敗。

定義 (\`node_modules/@capgo/capacitor-health/dist/esm/definitions.d.ts\`):
\`\`\`ts
export type HealthDataType = '...' | 'flightsClimbed' | '...';
\`\`\`

plugin 内部 native レイヤでは Health Connect の \`FloorsClimbedRecord\` (= フロア記録) を使うが、JS API 名は \`flightsClimbed\` という不整合。命名のミスマッチ問題。

## 修正

\`app/javascript/controllers/native_health_controller.js\`:
- \`HEALTH_READ_TYPES\` の \`"floorsClimbed"\` → \`"flightsClimbed"\` (= permission チェック + 取得 API 全て)
- \`queryAggregatedSafe\` 呼び出しの \`"floorsClimbed"\` → \`"flightsClimbed"\`
- \`formatSummary\` の「階段(未対応)」表示を「階段なし」に変更 (= 修正後は 0 = 「今日まだ階段昇降なし」or「ソース device 未対応」のどちらかで、bug 由来の未対応ではないため)

内部変数 (\`data.floors_climbed\` 等) と Webhook payload の \`flights_climbed\` field 名は変更不要 (= サーバ側 `webhook_deliveries.flights_climbed` カラムとも整合済)。

## Test plan

- [x] \`bundle exec rspec\`: 515 examples, 0 failures
- [x] \`bundle exec rubocop\`: clean
- [x] \`grep -r "floorsClimbed" app/ config/ db/ docs/ spec/\` → 1 件のみ (= 歴史コメントとして残置、コードでは未参照)
- [ ] マージ → Render auto-deploy
- [ ] 実機 (Torque G6) で再ログイン後、Android Health Connect 連携カードの エラー文言が消え permission 確認 → 取得まで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)