### PR TITLE
fix: Capacitor 同期済 Android user にデモデータが永久表示される設計バグ修正 (#158, #159)

### DIFF
--- a/app/services/build_home_dashboard_service.rb
+++ b/app/services/build_home_dashboard_service.rb
@@ -46,12 +46,21 @@ class BuildHomeDashboardService
 
     private
 
+    # state 判定の優先順位 (= 2026-05-06 Day 8 で見直し):
+    # 1. 未ログイン → :guest
+    # 2. 実データあり → :iphone_with_data (= platform に関わらず実データ表示、誤称だが互換性のため名前は据え置き)
+    # 3. Android UA + データなし → :android (= Capacitor 連携誘導バナー)
+    # 4. それ以外 + データなし → :empty (= iOS Shortcut 誘導バナー)
+    #
+    # 旧版は 2 と 3 が逆順で「Android Capacitor user は同期成功してもデモデータが永久表示」される設計バグだった
+    # (= Issue #158, #159 で発覚)。Capacitor アプリの overrideUserAgent に "Android" が含まれるため、
+    # データの有無を見ずに :android 状態を強制するとデモデータが返る。
     def determine_state(user, request)
       return :guest unless user
+      return :iphone_with_data if user.step_records.exists?
 
       platform = PlatformDetectorService.from_request(request)
       return :android if platform == :android
-      return :iphone_with_data if user.step_records.exists?
 
       :empty
     end

--- a/spec/services/build_home_dashboard_service_spec.rb
+++ b/spec/services/build_home_dashboard_service_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe BuildHomeDashboardService do
     end
 
     # ─────────────────────────────────────────────────
-    # 状態 :android — ログイン済み + Android UA
+    # 状態 :android — ログイン済み + Android UA + step_records なし (= Capacitor 連携誘導)
     # ─────────────────────────────────────────────────
-    context "state: :android (user あり + Android UA)" do
+    context "state: :android (user あり + Android UA + step_records なし)" do
       let(:user) { create(:user) }
       subject(:result) { described_class.call(user: user, request: build_request(ua: android_ua)) }
 
@@ -94,6 +94,32 @@ RSpec.describe BuildHomeDashboardService do
       it "calorie_savings が Hash で 3 キーを持つ" do
         expect(result.calorie_savings).to be_a(Hash)
           .and include(:this_month, :last_month, :total)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 回帰防止: ログイン済み + Android UA + step_records あり (= Capacitor 同期済 user)
+    # 旧版は :android 状態でデモデータを返していた (Issue #158, #159)
+    # ─────────────────────────────────────────────────
+    context "state: :iphone_with_data (user あり + Android UA + step_records あり = Capacitor 同期済)" do
+      let(:user) { create(:user) }
+      let!(:step_record) { create(:step_record, user: user, recorded_on: Date.current, steps: 9000) }
+      subject(:result) { described_class.call(user: user, request: build_request(ua: android_ua)) }
+
+      it "state が :iphone_with_data (= Android user でも実データあれば実データ状態を返す)" do
+        expect(result.state).to eq(:iphone_with_data)
+      end
+
+      it "records に DB の StepRecord が含まれる (= デモデータではない)" do
+        expect(result.records).to include(step_record)
+      end
+
+      it "today_record が今日の StepRecord (= デモではなく自分のデータ)" do
+        expect(result.today_record).to eq(step_record)
+      end
+
+      it "calorie_savings の this_month が実データ計算 (= 9000 歩 * 0.04 = 360 kcal)" do
+        expect(result.calorie_savings[:this_month]).to eq(360)
       end
     end
 


### PR DESCRIPTION
## Summary

\`BuildHomeDashboardService#determine_state\` で **Android UA 判定を step_records 判定より先行** させていたため、Capacitor アプリで Health Connect 同期成功してもデモデータが永久表示される設計バグを修正。Issue #158 (= デモ表記のまま) + Issue #159 (= 設定画面導線残る) を 1 PR で同時 close。

## 検証経緯と原因確定

実機スクショの「+294 kcal」が **DemoDataService の今日値と完全一致**:

\`\`\`ruby
# DemoDataService RECENT_7_PATTERN[0] (= 今日)
{ steps: 7_200, distance_meters: 5_400, flights_climbed: 12 }
# estimated_kcal = 7200 * 0.04 + 12 * 0.5 = 294
\`\`\`

→ 「実データが反映されていない」ではなく **「Capacitor アプリではデモデータが強制表示される設計バグ」** と判明。

旧 \`determine_state\`:
\`\`\`ruby
return :guest unless user
platform = PlatformDetectorService.from_request(request)
return :android if platform == :android  # ← データあっても無視
return :iphone_with_data if user.step_records.exists?
:empty
\`\`\`

Capacitor アプリは overrideUserAgent に Android を含むため、**データの有無を見ずに :android 状態が確定** → DemoData 表示。

## 修正

\`app/services/build_home_dashboard_service.rb\`: 1 行順序変更

\`\`\`ruby
return :guest unless user
return :iphone_with_data if user.step_records.exists?  # ← platform 判定より前に
platform = PlatformDetectorService.from_request(request)
return :android if platform == :android
:empty
\`\`\`

## 修正後の優先順位

| ユーザー状態 | state | 表示 |
|---|---|---|
| 未ログイン | \`:guest\` | guest バナー + デモデータ |
| ログイン + step_records あり (= 全 platform 共通) | \`:iphone_with_data\` | バナーなし、**実データ** |
| ログイン + step_records なし + Android UA | \`:android\` | Capacitor 連携誘導バナー + デモ |
| ログイン + step_records なし + iOS/Web UA | \`:empty\` | iOS Shortcut 誘導バナー + デモ |

## v1.1 候補

state 名 \`:iphone_with_data\` は誤称 (= Android user も到達)。リネーム別 PR (= \`:user_with_data\` 等) で対応予定。

## Test plan

- [x] \`bundle exec rspec\`: 519 examples, 0 failures (= 新規 spec 4 件追加)
- [x] \`bundle exec rubocop\`: clean
- [x] 新規回帰防止 spec:
  - 「Android UA + step_records あり → :iphone_with_data」
  - 「records に DB StepRecord 含む (= デモではない)」
  - 「today_record が自分のデータ」
  - 「calorie_savings.this_month が実データ計算 (= 360 kcal)」
- [ ] マージ → Render auto-deploy
- [ ] 実機 (Torque G6) で再ログイン後ホーム画面確認:
  - 「サンプルデータです」表記が消える
  - 「Android アプリ版で連携できます」+「設定を見る」バナーが消える
  - 実データの歩数 / 消費カロリー / グラフが反映

Closes #158
Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)