### PR TITLE
fix: /privacy に Android Health Connect 経由の取得情報を明記 (#131、発表会前必須)

### DIFF
--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -3,7 +3,7 @@
 <div class="sketch-page-narrow" style="max-width: 40rem; padding-left: 16px; padding-right: 16px;">
 
   <h1 class="sketch-hh" style="margin-bottom: 4px;">プライバシーポリシー</h1>
-  <p class="sketch-small" style="margin-bottom: 16px;">最終更新: 2026年5月5日</p>
+  <p class="sketch-small" style="margin-bottom: 16px;">最終更新: 2026年5月6日</p>
 
   <p class="sketch-body-text" style="margin-bottom: 24px;">
     weight daily（以下「本サービス」）は、ユーザーから取得する個人情報および利用情報を以下のとおり取り扱います。
@@ -15,8 +15,9 @@
     <ul class="sketch-body-text" style="padding-left: 1.5em; margin-bottom: 8px;">
       <li>Google アカウントから取得する情報: 氏名、メールアドレス、プロフィール画像</li>
       <li>ユーザーが Apple Shortcuts 経由で送信する情報: 歩数、距離 (m)、上った階数、記録日</li>
+      <li>Android アプリ版で Android Health Connect 経由で読み取る情報: 歩数、移動距離、上った階数、記録日</li>
     </ul>
-    <p class="sketch-body-text">ヘルスケアデータの生データ (GPS、心拍、生体情報など) は取得しません。</p>
+    <p class="sketch-body-text">いずれの経路でも取得するのは数値情報のみで、ヘルスケアデータの生データ (GPS、心拍、血圧、生体情報など) は取得しません。</p>
   </div>
 
   <div class="sketch-box" style="margin-bottom: 20px;">
@@ -98,7 +99,7 @@
   </div>
 
   <p class="sketch-small" style="color: var(--muted); margin-top: 8px;">
-    改訂履歴: 2026-05-05 初版公開 / 2026-05-05 事業者表示追加・消費者契約法対応
+    改訂履歴: 2026-05-05 初版公開 / 2026-05-05 事業者表示追加・消費者契約法対応 / 2026-05-06 Android Health Connect 経由の取得情報を明記
   </p>
 
 </div>

--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -15,9 +15,9 @@
     <ul class="sketch-body-text" style="padding-left: 1.5em; margin-bottom: 8px;">
       <li>Google アカウントから取得する情報: 氏名、メールアドレス、プロフィール画像</li>
       <li>ユーザーが Apple Shortcuts 経由で送信する情報: 歩数、距離 (m)、上った階数、記録日</li>
-      <li>Android アプリ版で Android Health Connect 経由で読み取る情報: 歩数、移動距離、上った階数、記録日</li>
+      <li>Android アプリ版で Android Health Connect 経由で読み取る情報: 歩数、距離 (m)、上った階数、記録日</li>
     </ul>
-    <p class="sketch-body-text">いずれの経路でも取得するのは数値情報のみで、ヘルスケアデータの生データ (GPS、心拍、血圧、生体情報など) は取得しません。</p>
+    <p class="sketch-body-text">いずれの経路でも、取得するのは歩数・距離・階数の 1 日合計値のみです。GPS の位置情報、心拍数の時系列記録、血圧などのセンサーデータは読み取りません。</p>
   </div>
 
   <div class="sketch-box" style="margin-bottom: 20px;">

--- a/spec/requests/legal_spec.rb
+++ b/spec/requests/legal_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe "Legal", type: :request do
         expect(response.body).to include("Google")
       end
 
+      it "「Apple Shortcuts」経由の取得情報を明記している" do
+        expect(response.body).to include("Apple Shortcuts")
+      end
+
+      it "「Android Health Connect」経由の取得情報を明記している (= Issue #131、Google 規約対応)" do
+        expect(response.body).to include("Android Health Connect")
+      end
+
       it "「運営者」セクションを含む" do
         expect(response.body).to include("運営者")
       end


### PR DESCRIPTION
## Summary

Issue #131 (= 発表会前必須マーク) 対応。Google の Health Connect Privacy Policy 要件「アプリが Health Connect を通じて読み取るデータ型と利用目的を明記」を満たす。

## 修正

- 取得情報リストに「Android Health Connect 経由で読み取る情報」1 行追加 (= 案 A 推奨)
- 「生データは取得しません」注記を Apple / Android 両経路共通に再整理
- 最終更新日を 2026-05-06 に更新
- 改訂履歴に「2026-05-06 Android Health Connect 経由の取得情報を明記」追加
- legal_spec.rb に明記確認 spec 2 件追加 (= Apple Shortcuts / Android Health Connect 各 1 件)

## 経緯

PR #92 (= 2026-05-05 /privacy 初版) 時点では Apple Shortcuts のみ想定。Day 7 夜セッションで Issue #40 (Capacitor + Health Connect) を発表会前スコープ化したため、/privacy 側追従が必要に。design-reviewer (PR #130 review) で「発表会前必須」優先度として指摘あり。

## Test plan

- [x] \`bundle exec rspec spec/requests/legal_spec.rb\`: 19 examples, 0 failures
- [x] \`bundle exec rubocop\`: clean
- [ ] マージ → Render auto-deploy
- [ ] 本番 \`https://weight-dialy.onrender.com/privacy\` で「Android Health Connect 経由で読み取る情報」が表示されることを確認

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)