### PR TITLE
polish: Capacitor splash 背景色を sketchy theme paper 色 (#fbf8f1) に置き換え (#128)

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- weight_dialy ブランドカラー (= sketchy theme との一貫性、Web 版 CSS 変数 --paper と完全に同色)。
+         splash screen 背景に使用、Capacitor デフォルトの「Android ロボット + 水色背景」を置き換える (= Issue #128)。 -->
+    <color name="colorSplashBackground">#fbf8f1</color>
+</resources>

--- a/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#FFFFFF</color>
+    <!-- Issue #128: app icon (= ic_launcher) の背景色を sketchy theme paper (#fbf8f1) に揃える。
+         AndroidX SplashScreen API (= Android 12+) は windowSplashScreenAnimatedIcon に未指定の場合、
+         この ic_launcher を splash 中央に重ねるため、白背景のままだと paper 色 splash の上に「白い矩形」が浮く視覚問題が発生する (= design-reviewer 指摘)。
+         paper 色に揃えると splash 背景とアイコン背景が連続して見える。 -->
+    <color name="ic_launcher_background">#fbf8f1</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -16,7 +16,11 @@
     </style>
 
 
+    <!-- Issue #128: Capacitor デフォルトの「Android ロボット + 水色背景」を sketchy theme の paper 色 (#fbf8f1) に置き換え、
+         Web 版とブランドカラー一貫性を保つ。
+         windowSplashScreenBackground は AndroidX SplashScreen API 標準属性、android:background は古い API のフォールバック (= 二重保険)。 -->
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-        <item name="android:background">@drawable/splash</item>
+        <item name="windowSplashScreenBackground">@color/colorSplashBackground</item>
+        <item name="android:background">@color/colorSplashBackground</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -18,7 +18,8 @@
 
     <!-- Issue #128: Capacitor デフォルトの「Android ロボット + 水色背景」を sketchy theme の paper 色 (#fbf8f1) に置き換え、
          Web 版とブランドカラー一貫性を保つ。
-         windowSplashScreenBackground は AndroidX SplashScreen API 標準属性、android:background は古い API のフォールバック (= 二重保険)。 -->
+         windowSplashScreenBackground は Android 12+ (API 31+) の AndroidX SplashScreen API 標準属性、
+         android:background は API 30 以下のフォールバック。両方書くことで全 Android version で paper 色を保証する。 -->
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/colorSplashBackground</item>
         <item name="android:background">@color/colorSplashBackground</item>


### PR DESCRIPTION
## Summary

Issue #128 (= 発表会前 polish) 対応。Capacitor デフォルトの「Android ロボット + 水色背景」splash 画面が sketchy theme (= \`--paper\` #fbf8f1 + 手書き文字) の世界観と乖離していた問題を **案 A 「最小コスト = 背景色のみ単色化」** で対応。

## 修正

- \`android/app/src/main/res/values/colors.xml\` 新設 (= \`colorSplashBackground\` = `#fbf8f1`)
- \`styles.xml\` の \`AppTheme.NoActionBarLaunch\` を新カラーで上書き:
  - \`windowSplashScreenBackground\` (= AndroidX SplashScreen API 標準)
  - \`android:background\` (= 古い API のフォールバック、二重保険)
- \`splash.png\` 画像はそのまま (= placeholder のままだが背景が paper 色になることで Web 版とのブランド連続性確保)

## v1.1 候補

- 案 B (= splash.png を sketchy 化)
- 案 C (= テキスト描画 splash で「weight daily.」文字)

## Test plan

- [x] \`bundle exec rubocop\`: clean (= Ruby 側変更なし、Android XML のみ)
- [ ] マージ → Windows 側 styles.xml + colors.xml を sync (= APK 再ビルド必要)
- [ ] 実機 (Torque G6) で APK 再ビルド + 起動 → splash 背景色が paper 色 (= cream/ベージュ系) になることを目視確認

## ⚠️ 同期必要 (= Windows ↔ WSL)

\`\`\`powershell
Copy-Item "\\\\wsl.localhost\\Ubuntu\\home\\bohemian1506\\workspace\\weight_dialy\\android\\app\\src\\main\\res\\values\\colors.xml" "C:\\dev\\weight_dialy_android\\app\\src\\main\\res\\values\\colors.xml" -Force
Copy-Item "\\\\wsl.localhost\\Ubuntu\\home\\bohemian1506\\workspace\\weight_dialy\\android\\app\\src\\main\\res\\values\\styles.xml" "C:\\dev\\weight_dialy_android\\app\\src\\main\\res\\values\\styles.xml" -Force
\`\`\`

その後 Android Studio で Sync + Rebuild + Run。

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)