### PR TITLE
polish: navbar 高さ 74px → 62px に slim 化 (#49) + flash toast 位置追従

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -36,9 +36,12 @@ body {
 }
 
 /* ---------- navbar ---------- */
+/* Issue #49: padding 14px → 8px に縮小して navbar 高さを 74px → 62px に slim 化。
+   ボタン自体の高さ 46px は維持するため WCAG 2.5.5 (= 44px タップ領域) は引き続き満たす。
+   Issue #47 (= sketch-btn 全体 44px 化) のゴールと両立する設計、design-reviewer 事前相談で確定。 */
 .sketch-navbar {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 14px 20px; gap: 12px;
+  padding: 8px 20px; gap: 12px;
   border-bottom: 2px solid var(--ink);
   background: var(--paper);
 }

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "weight_dialy について" %>
 
-<%# min-h は 100vh から navbar (約 60px) + <main> の mt-4 (1rem) を引いた高さ。
+<%# min-h は 100vh から navbar 62px (= Issue #49 slim 化後) + <main> の mt-4 (16px) ≈ 78px を引いた高さ。
+    5rem (80px) で近似 (= 余裕 2px は min-h なので下方向マージン化、視覚影響なし)。
     layout 側の <main class="... mt-4"> や navbar padding を変更したら本値も合わせて見直す。 %>
 <div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
   <div class="sketch-page-narrow w-full">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,8 +48,8 @@
     </header>
 
     <%# flash はトースト風に画面上部 fixed で重ねる (document flow から外れるため、表示/非表示で下のコンテンツがズレない)。
-        top-20 (80px) は navbar 高さ 62px (= Issue #49 slim 化後) + 余白 18px。
-        Issue #49 で navbar 高さを 74px → 62px に縮めたのに合わせて top-24 → top-20 に追従、トーストが navbar 直下から自然に出る。
+        top-20 (80px) は navbar 高さ 約 64px (= padding 16px + ボタン約 46px + border-bottom 2px、Issue #49 slim 化後) + 余白 約 16px。
+        Issue #49 で navbar 高さを 74px → 約 64px に縮めたのに合わせて top-24 → top-20 に追従、トーストが navbar 直下から自然に出る。
         FOUC 対策: 初期 opacity-0 + Stimulus connect() で fade-in。JS 無効フォールバックは <head> の <noscript><style> 参照。
         見た目は sketchy トーストに差し替え (sketch-toast)、フェード挙動 (flash_controller.js) は変更しない。 %>
     <% if flash[:notice] || flash[:alert] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,11 +48,12 @@
     </header>
 
     <%# flash はトースト風に画面上部 fixed で重ねる (document flow から外れるため、表示/非表示で下のコンテンツがズレない)。
-        top-24 (96px) は navbar 高さ + 余白 + 将来 navbar を sticky 化した時の追加バッファ。
+        top-20 (80px) は navbar 高さ 62px (= Issue #49 slim 化後) + 余白 18px。
+        Issue #49 で navbar 高さを 74px → 62px に縮めたのに合わせて top-24 → top-20 に追従、トーストが navbar 直下から自然に出る。
         FOUC 対策: 初期 opacity-0 + Stimulus connect() で fade-in。JS 無効フォールバックは <head> の <noscript><style> 参照。
         見た目は sketchy トーストに差し替え (sketch-toast)、フェード挙動 (flash_controller.js) は変更しない。 %>
     <% if flash[:notice] || flash[:alert] %>
-      <div class="fixed top-24 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-md space-y-2">
+      <div class="fixed top-20 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-md space-y-2">
         <% if flash[:notice] %>
           <div class="sketch-toast notice opacity-0" role="alert" data-controller="flash">
             <span class="sketch-toast-message"><%= flash[:notice] %></span>


### PR DESCRIPTION
## Summary

PR #47 (= sketch-btn 全体 44px 化) の副作用で navbar 高 **74px** に膨張していた問題 (Issue #49) を、**design-reviewer 事前相談** (= 学び 24 = 「実装前デザイン相談」パターン) で **候補 3 (= padding 縮小、ボタン高は維持)** に方針確定後実装。

## 修正

- \`app/assets/stylesheets/sketchy.css\`: \`.sketch-navbar\` の \`padding\` を \`14px 20px\` → \`8px 20px\`
  - ボタン高 46px はそのまま (= padding-block は触らない)
  - navbar 全体高さ **74px → 62px** (= 12px slim 化)
- \`app/views/layouts/application.html.erb\`: flash toast の \`top-24\` → \`top-20\`
  - navbar slim 化 12px に追従、トーストが navbar 直下から自然に出る

## なぜ両立する設計か

| ゴール | 状態 |
|---|---|
| Issue #47 (= 44px タップ領域確保) | ✅ 維持 (= ボタン padding 10px 不変、ボタン高 46px > 44px WCAG OK) |
| Issue #49 (= 見た目スリム化) | ✅ 達成 (= navbar の外側余白を削るだけで 12px 縮む) |

design-reviewer の判断ポイント:
- 候補 1 (= ボタン padding-block を 6px に) は WCAG 2.5.5 (44px) 未達リスク → **却下**
- 候補 2 (= ハンバーガーメニュー) は 5h で実装するにはスコープ広すぎ → v1.1
- **候補 3 (= navbar padding 縮小) が「タップ領域犠牲なしで見た目改善」の両立解**

## v1.1 候補 (= design-reviewer 提示)

- ハンバーガーメニュー化 (= スマホで設定/ログアウトをメニュー収納、ブランド印象向上)
- ログイン前 navbar の CTA 検討 (= 現状右側空白、「ログイン」ボタン置くと 3 秒テスト改善)

## Test plan

- [x] \`bundle exec rspec\`: 538 examples, 0 failures
- [x] \`bundle exec rubocop\`: clean
- [ ] マージ → Render auto-deploy
- [ ] 実機 / ブラウザで navbar 高さが視覚的に slim 化、flash toast 位置が自然か確認

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)