### PR TITLE
polish: navbar を sticky 化 (= スクロール時も常時画面上部に残す、デモ向上)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -36,14 +36,20 @@ body {
 }
 
 /* ---------- navbar ---------- */
-/* Issue #49: padding 14px → 8px に縮小して navbar 高さを 74px → 62px に slim 化。
+/* Issue #49: padding 14px → 8px に縮小して navbar 高さを 74px → 約 64px に slim 化。
    ボタン自体の高さ 46px は維持するため WCAG 2.5.5 (= 44px タップ領域) は引き続き満たす。
-   Issue #47 (= sketch-btn 全体 44px 化) のゴールと両立する設計、design-reviewer 事前相談で確定。 */
+   Issue #47 (= sketch-btn 全体 44px 化) のゴールと両立する設計、design-reviewer 事前相談で確定。
+
+   sticky 化 (= position: sticky; top: 0): スクロール時も navbar が常時画面上部に残る。
+   z-index: 30 < flash toast z-50 のため、トーストは navbar より前面に出る (= 階層整合済)。
+   background: var(--paper) は半透明背景 (= scroll で下のコンテンツが透けるのを防ぐ) と
+   sticky 重なり時の視認性確保のためそのまま維持。 */
 .sketch-navbar {
   display: flex; align-items: center; justify-content: space-between;
   padding: 8px 20px; gap: 12px;
   border-bottom: 2px solid var(--ink);
   background: var(--paper);
+  position: sticky; top: 0; z-index: 30;
 }
 .sketch-navbar-title {
   font-family: 'Caveat', cursive; font-weight: 700; font-size: 32px;


### PR DESCRIPTION
## Summary

PR #171 (= navbar slim 化) の design-reviewer 提案より、navbar に \`position: sticky; top: 0; z-index: 30;\` を追加。スクロール時も navbar (= アプリ名 / 設定 / ログアウト) が常時画面上部に残る = 発表会デモ + 通常利用で **ブランド訴求 + ナビゲーション可用性向上**。

## なぜ低コストで効果大か

- 修正: 1 ファイル 1 行追加 (= sticky 関連 3 プロパティのみ)
- 副作用ゼロ:
  - z-index: 30 < flash toast z-50 → トーストが前面に来る (= 階層整合済、code-reviewer PR #171 で確認済)
  - background: var(--paper) は既に設定済 (= 半透明問題なし)
  - view 構造は無変更 (= regression リスク無)

## Test plan

- [x] \`bundle exec rspec\`: 538 examples 通過
- [x] \`bundle exec rubocop\`: clean
- [ ] マージ → Render auto-deploy
- [ ] 実機 / ブラウザでホーム画面スクロール → navbar が常時上部に残る + flash トースト出現時も navbar の前面に出ることを確認

## 3 者並列レビュー

軽微 polish (1 行追加、設計判断は PR #171 で済) のため、本 PR は省略可候補だが、CLAUDE.md 「PR 規模に関わらず 3 者並列レビュー必須」ルール準拠で実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)