### PR TITLE
polish: webhook 422 エラー文言を I18n 化 + カジュアル層向け日本語化 (#83)

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -17,7 +17,7 @@ class WebhooksController < ActionController::API
     records_data = parsed["records"]
 
     unless records_data.is_a?(Array)
-      record_delivery!(status: "invalid", accepted_count: 0, error_message: "missing 'records' array")
+      record_delivery!(status: "invalid", accepted_count: 0, error_message: I18n.t("webhook.errors.missing_records_array"))
       render json: { error: "Invalid payload" }, status: :unprocessable_content
       return
     end
@@ -26,7 +26,8 @@ class WebhooksController < ActionController::API
     record_delivery!(status: "success", accepted_count: accepted)
     render json: { accepted: accepted }, status: :ok
   rescue JSON::ParserError => e
-    record_delivery!(status: "invalid", accepted_count: 0, error_message: "JSON parse error: #{e.message.truncate(120)}")
+    Rails.logger.warn("[WebhooksController] JSON parse error: #{e.message.truncate(120)}")
+    record_delivery!(status: "invalid", accepted_count: 0, error_message: I18n.t("webhook.errors.json_parse_error"))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   rescue InvalidPayload => e
     record_delivery!(status: "invalid", accepted_count: 0, error_message: e.message.truncate(120))
@@ -34,7 +35,8 @@ class WebhooksController < ActionController::API
   rescue ActiveRecord::RecordInvalid => e
     # 個々のレコードのバリデーション違反 (負数 / 不正な日付等) を 500 ではなく 422 + 監査ログで返す。
     # rails-implementer の意図 (全体失敗方式) を実装まで貫徹するため。
-    record_delivery!(status: "invalid", accepted_count: 0, error_message: "RecordInvalid: #{e.message.truncate(120)}")
+    Rails.logger.warn("[WebhooksController] RecordInvalid: #{e.message.truncate(120)}")
+    record_delivery!(status: "invalid", accepted_count: 0, error_message: I18n.t("webhook.errors.record_invalid"))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   end
 
@@ -71,7 +73,7 @@ class WebhooksController < ActionController::API
     return if token_valid
 
     # Intentionally vague: do not reveal whether the token or the user was the problem.
-    record_delivery!(status: "unauthorized", error_message: "bearer token mismatch or missing", user: nil)
+    record_delivery!(status: "unauthorized", error_message: I18n.t("webhook.errors.unauthorized"), user: nil)
     render json: { error: "Unauthorized" }, status: :unauthorized and return
   end
 
@@ -87,19 +89,16 @@ class WebhooksController < ActionController::API
   # 正規表現で「正確に 4-2-2 桁」を先に検査してから Date.strptime に渡す二段構え。
   ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}\z/
 
-  # truncate を inspect の前にかけることで、攻撃者が巨大な recorded_on 値 (1MB body キャップ内で
-  # 数百 KB を詰める) を送った時に、エラーメッセージ生成段階で巨大文字列が一時的にヒープに乗るのを防ぐ。
   def parse_recorded_on(raw)
-    raise InvalidPayload, "recorded_on is required" if raw.blank?
+    raise InvalidPayload, I18n.t("webhook.errors.recorded_on_required") if raw.blank?
     raw_str = raw.to_s
-    truncated = raw_str.truncate(40).inspect
     unless raw_str.match?(ISO_DATE_FORMAT)
-      raise InvalidPayload, "recorded_on must be yyyy-MM-dd format: got #{truncated}"
+      raise InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format")
     end
     Date.strptime(raw_str, "%Y-%m-%d")
   rescue Date::Error
     # 月日の値域違反 (例: "2026-13-99")
-    raise InvalidPayload, "recorded_on must be yyyy-MM-dd format: got #{truncated}"
+    raise InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format")
   end
 
   # 数値フィールド (steps / distance_meters / flights_climbed) を厳格パースする (Issue #52)。
@@ -116,10 +115,10 @@ class WebhooksController < ActionController::API
     when Integer
       raw
     when Float
-      raise InvalidPayload, "#{field_name} must be a whole number, got Float #{raw}" unless raw == raw.to_i
+      raise InvalidPayload, I18n.t("webhook.errors.must_be_whole_number", field: I18n.t("webhook.fields.#{field_name}"), value: raw) unless raw == raw.to_i
       raw.to_i
     else
-      raise InvalidPayload, "#{field_name} must be a number, got #{raw.class}: #{raw.to_s.truncate(40).inspect}"
+      raise InvalidPayload, I18n.t("webhook.errors.must_be_number", field: I18n.t("webhook.fields.#{field_name}"), value: raw.to_s.truncate(40).gsub(/[[:cntrl:]]/, "?"), type: raw.class)
     end
   end
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,16 @@
+ja:
+  webhook:
+    fields:
+      steps: 歩数
+      distance_meters: 距離
+      flights_climbed: 登った階数
+    errors:
+      missing_records_array: "Shortcut からのデータが届きませんでした。Shortcut を再度実行してみてください。"
+      json_parse_error: "Shortcut からのデータを読み取れませんでした。Shortcut を再度実行してみてください。"
+      record_invalid: "データの値に問題がありました。Shortcut を再度実行してみてください。"
+      # 運用ログ用、開発者向け文言なので英語維持 (= 本人画面に出ない経路、user: nil で audit log のみ)
+      unauthorized: "bearer token mismatch or missing"
+      recorded_on_required: "記録日の情報が含まれていません"
+      recorded_on_invalid_format: "日付がうまく読み取れませんでした。Shortcut を最新版に更新してください。"
+      must_be_whole_number: "%{field} は整数で送ってください: 受信値=%{value} (Float)"
+      must_be_number: "%{field} は数値で送ってください: 受信値=%{value} (型: %{type})"

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
     it "records the WebhookDelivery with user = nil (PII protection)" do
       expect(WebhookDelivery.last.user).to be_nil
     end
+
+    it "records the unauthorized error_message via I18n (観点 4: I18n キー欠落検出)" do
+      # authenticate_webhook! が I18n.t("webhook.errors.unauthorized") を error_message に渡すことを確認。
+      # キー名 typo や ja.yml からのキー削除があれば "translation missing:" が混入し fail する。
+      expect(WebhookDelivery.last.error_message).to eq(I18n.t("webhook.errors.unauthorized"))
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -246,8 +252,8 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
       expect(WebhookDelivery.last.status).to eq("invalid")
     end
 
-    it "includes 'JSON parse error' in the error_message" do
-      expect(WebhookDelivery.last.error_message).to include("JSON parse error")
+    it "includes 'Shortcut からのデータを読み取れませんでした' in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("Shortcut からのデータを読み取れませんでした")
     end
   end
 
@@ -269,8 +275,8 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
       expect(WebhookDelivery.last.status).to eq("invalid")
     end
 
-    it "includes 'missing records array' context in the error_message" do
-      expect(WebhookDelivery.last.error_message).to include("missing 'records' array")
+    it "includes 'Shortcut からのデータが届きませんでした' in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("Shortcut からのデータが届きませんでした")
     end
   end
 
@@ -309,8 +315,8 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
       expect(WebhookDelivery.last.status).to eq("invalid")
     end
 
-    it "includes 'recorded_on is required' in the error_message" do
-      expect(WebhookDelivery.last.error_message).to include("recorded_on is required")
+    it "includes '記録日の情報が含まれていません' in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("記録日の情報が含まれていません")
     end
   end
 
@@ -337,8 +343,8 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
           expect(WebhookDelivery.last.status).to eq("invalid")
         end
 
-        it "mentions 'recorded_on must be yyyy-MM-dd' in the error_message" do
-          expect(WebhookDelivery.last.error_message).to include("recorded_on must be yyyy-MM-dd")
+        it "mentions '日付がうまく読み取れませんでした' in the error_message" do
+          expect(WebhookDelivery.last.error_message).to include("日付がうまく読み取れませんでした")
         end
       end
     end
@@ -364,8 +370,8 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
         expect(response).to have_http_status(:unprocessable_content)
       end
 
-      it "mentions 'recorded_on is required' in the error_message (blank check)" do
-        expect(WebhookDelivery.last.error_message).to include("recorded_on is required")
+      it "mentions '記録日の情報が含まれていません' in the error_message (blank check)" do
+        expect(WebhookDelivery.last.error_message).to include("記録日の情報が含まれていません")
       end
     end
 
@@ -409,8 +415,8 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
       expect(WebhookDelivery.last.status).to eq("invalid")
     end
 
-    it "includes 'RecordInvalid' in the error_message" do
-      expect(WebhookDelivery.last.error_message).to include("RecordInvalid")
+    it "includes 'データの値に問題がありました' in the error_message" do
+      expect(WebhookDelivery.last.error_message).to include("データの値に問題がありました")
     end
   end
 
@@ -491,7 +497,9 @@ RSpec.describe "POST /webhooks/health_data", type: :request do
         end
 
         it "mentions the field name in error_message" do
-          expect(WebhookDelivery.last.error_message).to include(field.to_s)
+          # I18n 化後はフィールド名が日本語 (歩数 / 距離 / 登った階数) になる。
+          # 英語キー名 (steps 等) は含まれなくなるため、共通文言「は数値で送ってください」で確認する。
+          expect(WebhookDelivery.last.error_message).to include("は数値で送ってください").or include("は整数で送ってください")
         end
       end
     end


### PR DESCRIPTION
## Summary
- close #83
- Apple Shortcuts → Webhook 422 reject 時の `WebhookDelivery#error_message` を英語ハードコードから I18n 化、カジュアル層向け文言に統一
- 生例外 message (JSON::ParserError / RecordInvalid) は本人画面に晒さず `Rails.logger.warn` に格納するよう変更 (= design must-fix 対応)
- `config.i18n.default_locale = :ja` 設定済 + `rails-i18n` 導入済の上に、初の `config/locales/ja.yml` 新規作成

## 変更内容
### `config/locales/ja.yml` 新規作成
- `webhook.errors.*` 8 キー / `webhook.fields.*` 3 キー
- カジュアル層向け文言 (= 「Shortcut を再度実行してみてください」「Shortcut を最新版に更新してください」等のアクション誘導)
- `unauthorized` のみ **運用ログ用として英語維持** (= `user: nil` で audit log のみ、本人画面に出ない経路、コメント明記)

### `app/controllers/webhooks_controller.rb`
- 英語ハードコード 8 箇所を `I18n.t(...)` に置換
- `rescue JSON::ParserError` / `rescue ActiveRecord::RecordInvalid` 経路で `Rails.logger.warn` 追加 (= 生 message を本人画面ではなくログに残す)
- `parse_recorded_on` を簡素化 (= `truncated.inspect` 計算削除、`%{value}` interpolation 削除)
- `parse_numeric` の `must_be_number` 経路で `inspect` → `gsub(/[[:cntrl:]]/, "?")` に変更 (= ダブルクォート除去 + 制御文字置換)

### `spec/requests/webhooks_spec.rb`
- 既存アサーション 7 箇所を新文言に更新
- `shared_examples \"rejects unauthorized request\"` に I18n キー欠落検出ケース 1 件追加 (= `expect(WebhookDelivery.last.error_message).to eq(I18n.t(\"webhook.errors.unauthorized\"))`)

## レビュー反映状況 (= 3 者並列レビュー)
- code-reviewer: ✅ truncate 維持 / interpolation 整合性 / rubocop 0 件
- strategic-reviewer: ✅ スコープ適正 (11 キーは YAGNI 遵守) / `unauthorized` 英語維持の教材性ポイント
- design-reviewer: ✅ must-fix (= 生例外 message が本人画面に流入リスク) を `Rails.logger.warn` 経路で対応 / 推奨コピー改善 4 件すべて反映

## 教材性ポイント
- `default_locale = :ja` 設定済みでも `ja.yml` を作らないと `webhook.errors.*` のような独自キーは missing translation 警告になる
- I18n 化は **「ユーザー向け文言 / 運用ログ向け文言」を分けて判断** する。全部翻訳するのが正解ではない (= `unauthorized` 値英語維持の判断根拠)
- 生例外 message を本人画面に晒さず `Rails.logger.warn` に分離する設計 (= 開発者デバッグと UX を両立)

## Test plan
- [x] `script/run \"bundle exec rspec spec/requests/webhooks_spec.rb\"` で 110 examples 0 failures
- [x] `script/run \"bundle exec rubocop app/controllers/webhooks_controller.rb spec/requests/webhooks_spec.rb\"` で 0 件
- [ ] CI 通過確認
- [ ] Settings 画面の Webhook 送信ログで日本語文言が表示されること (= 発表会後の実機確認、本 PR 範囲外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)