### PR TITLE
polish: banner_android UX ループ解消 + Settings に Web Android user 向け案内追加 (#162, #184)

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -12,6 +12,7 @@ class SettingsController < ApplicationController
     @webhook_deliveries = current_user.webhook_deliveries
                                       .order(received_at: :desc)
                                       .limit(WEBHOOK_HISTORY_LIMIT)
+    @show_android_app_promo = PlatformDetectorService.web_android?(request)
   end
 
   def regenerate_token

--- a/app/services/platform_detector_service.rb
+++ b/app/services/platform_detector_service.rb
@@ -9,4 +9,12 @@ class PlatformDetectorService
 
     :other
   end
+
+  # Capacitor アプリ起動時の overrideUserAgent には "Android" + "WeightDialyCapacitor" が含まれるため、
+  # 「Web 版 Android UA」は Android かつ WeightDialyCapacitor 不在で判定する。
+  # Issue #184 (= Settings に Web Android user 向け案内セクション出し分け) で使用。
+  def self.web_android?(request)
+    ua = request.user_agent.to_s
+    ua.match?(/Android/) && !ua.match?(/WeightDialyCapacitor/)
+  end
 end

--- a/app/views/home/_banner_android.html.erb
+++ b/app/views/home/_banner_android.html.erb
@@ -1,16 +1,17 @@
-<%# Android ユーザー向けバナー。Capacitor アプリ版で Health Connect 連携が可能。 %>
+<%# Android ユーザー向けバナー。Capacitor アプリで Health Connect 経由の自動送信が可能。
+    CTA 文言「設定を見る」は #126 (= APK sideload 配布) 完了まで維持。配布開始時に
+    「アプリを入手する」 + 直接ダウンロード CTA に書き換える予定 (= Issue #162 design 提案)。 %>
 <div class="sketch-banner sketch-banner-android" role="banner">
   <div class="sketch-banner-body">
     <span class="sketch-banner-icon">🤖</span>
     <div>
       <p class="sketch-banner-text">
-        <strong>Android アプリ版</strong>で Health Connect と連携できます。
-        いまはサンプルデータで雰囲気をご覧ください。iPhone なら「ショートカット」で今すぐ自動連携できます。
+        Android スマホから Health Connect 経由で歩数を自動送信できます。
+        いまはサンプルデータで雰囲気をご覧ください。
       </p>
     </div>
   </div>
   <div class="sketch-banner-action">
-    <%# PR #33 (settings) 未マージのため /settings をハードコード %>
-    <%= link_to "設定を見る", "/settings", class: "sketch-btn" %>
+    <%= link_to "設定を見る", settings_path, class: "sketch-btn sketch-btn-primary" %>
   </div>
 </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -85,6 +85,22 @@
     </p>
   <% end %>
 
+  <%# Web 版 Android user 向け案内 (Issue #184)。Capacitor 検知時はサーバ側で web_android? = false になり非表示、
+      かつ既存の native-health セクション (下記) が JS で代替表示される。UX ループ解消が目的。 %>
+  <% if @show_android_app_promo %>
+    <div class="sketch-box" style="margin-bottom: 24px;">
+      <h2 class="sketch-h" style="margin-bottom: 8px;">📱 Android Health Connect 連携</h2>
+      <p class="sketch-body-text" style="margin-bottom: 12px;">
+        お手元の Android スマホから Health Connect 経由で歩数 / 距離 / 階段を自動同期できます。
+        同期されたデータは Web 版にログインしてダッシュボードで閲覧できます。
+      </p>
+      <p class="sketch-body-text" style="margin-bottom: 0;">
+        現在 Android アプリのインストール手順を準備中です。
+        それまでは <strong>サンプルデータ</strong>で雰囲気をお試しください。
+      </p>
+    </div>
+  <% end %>
+
   <%# Health Connect 連携 (Android のみ、Capacitor 検知で動的表示。Web 版では非表示のまま) %>
   <div data-controller="native-health"
        data-native-health-webhook-token-value="<%= current_user.webhook_token %>"

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe "Home", type: :request do
   end
 
   shared_examples "banner_android が表示される" do
-    it "「Android アプリ版」「Health Connect」を含む" do
+    it "「Android スマホ」「Health Connect」を含む" do
       # 子 6 (#125) で Capacitor アプリ版が完成したため文言更新済 (PR #140)
       # PR #142 design レビューで「dogfood 中」エンジニア語をカジュアル層向けに削除 (= 1 行 polish)
-      expect(response.body).to include("Android アプリ版")
+      # Issue #162 で「Android アプリ版」(主アプリ感) → 「Android スマホから〜送信」(送信補助感) に再調整
+      expect(response.body).to include("Android スマホ")
       expect(response.body).to include("Health Connect")
     end
   end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -272,6 +272,53 @@ RSpec.describe "Settings", type: :request do
         end
       end
     end
+
+    # -------------------------------------------------------------------------
+    # Web Android user 向けプロモセクション出し分け (Issue #184)
+    # -------------------------------------------------------------------------
+    context "UA 別 Android アプリ案内セクション出し分け" do
+      let(:user) { create(:user) }
+
+      before { login(user) }
+
+      context "Web 版 Android Chrome UA でアクセスしたとき" do
+        before do
+          get settings_path, headers: {
+            "HTTP_USER_AGENT" => "Mozilla/5.0 (Linux; Android 13; SM-S908U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+          }
+        end
+
+        it "「インストール手順を準備中」セクションを表示する (= Web Android user 向け新セクション、Issue #184)" do
+          # 新セクションのタイトル (= 「📱 Android Health Connect 連携」) は既存の Capacitor 検知時セクションと
+          # 同一文字列のため、新セクション固有の本文「インストール手順を準備中」で識別する。
+          expect(response.body).to include("インストール手順を準備中")
+        end
+      end
+
+      context "Android Capacitor アプリ (WeightDialyCapacitor を含む UA) でアクセスしたとき" do
+        before do
+          get settings_path, headers: {
+            "HTTP_USER_AGENT" => "Mozilla/5.0 (Linux; Android 13; SM-S908U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 WeightDialyCapacitor"
+          }
+        end
+
+        it "「インストール手順を準備中」セクションを表示しない (= 既存 native-health セクションが JS で代替表示)" do
+          expect(response.body).not_to include("インストール手順を準備中")
+        end
+      end
+
+      context "PC ブラウザ (Desktop UA) でアクセスしたとき" do
+        before do
+          get settings_path, headers: {
+            "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36"
+          }
+        end
+
+        it "「インストール手順を準備中」セクションを表示しない (= Android UA でないため非表示)" do
+          expect(response.body).not_to include("インストール手順を準備中")
+        end
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/services/platform_detector_service_spec.rb
+++ b/spec/services/platform_detector_service_spec.rb
@@ -1,12 +1,16 @@
 require "rails_helper"
 
 RSpec.describe PlatformDetectorService, type: :request do
-  # from_request は request オブジェクトの user_agent を参照するため、
-  # request spec 内で GET / を呼んで request を実体として渡す代わりに、
+  # from_request / web_android? は request オブジェクトの user_agent を参照するため、
   # 軽量な double でインターフェースを満たす。
   def detector_for(ua_string)
     fake_request = instance_double(ActionDispatch::Request, user_agent: ua_string)
     PlatformDetectorService.from_request(fake_request)
+  end
+
+  def web_android_for(ua_string)
+    fake_request = instance_double(ActionDispatch::Request, user_agent: ua_string)
+    PlatformDetectorService.web_android?(fake_request)
   end
 
   describe ".from_request" do
@@ -48,6 +52,41 @@ RSpec.describe PlatformDetectorService, type: :request do
 
       it "空文字を :other と判定する" do
         expect(detector_for("")).to eq(:other)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # .web_android? (Issue #184)
+  # Capacitor アプリ (WeightDialyCapacitor を UA に含む) は false、
+  # 純粋な Android Web ブラウザは true。
+  # ---------------------------------------------------------------------------
+  describe ".web_android?" do
+    context "Android Web ブラウザ (Capacitor なし)" do
+      it "Android Chrome UA を true と判定する" do
+        ua = "Mozilla/5.0 (Linux; Android 13; SM-S908U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+        expect(web_android_for(ua)).to be(true)
+      end
+    end
+
+    context "Android Capacitor アプリ (WeightDialyCapacitor を UA に含む)" do
+      it "Capacitor UA を false と判定する" do
+        ua = "Mozilla/5.0 (Linux; Android 13; SM-S908U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 WeightDialyCapacitor"
+        expect(web_android_for(ua)).to be(false)
+      end
+    end
+
+    context "iOS デバイス" do
+      it "iPhone UA を false と判定する" do
+        ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+        expect(web_android_for(ua)).to be(false)
+      end
+    end
+
+    context "PC ブラウザ" do
+      it "Mac Chrome UA を false と判定する" do
+        ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36"
+        expect(web_android_for(ua)).to be(false)
       end
     end
   end


### PR DESCRIPTION
## Summary
- close #162
- close #184
- 案 E (= 2 Issue 因果セット) で UX ループを構造解消
  - **Before**: banner_android「設定を見る」→ Settings → Android セクションは Capacitor 検知時のみ表示 → Web 版 Android user は何も見えない
  - **After**: Web 版 Android UA でもサーバ側で別セクション (= 同タイトル + 「インストール手順を準備中」) を出すことで導線が成立

## 変更内容

### 1. `app/services/platform_detector_service.rb`
- `web_android?(request)` クラスメソッド追加 (= UA に Android 含み WeightDialyCapacitor 含まないで判定)
- 既存 `from_request` と並列の責務、UA 判定ロジックを 1 箇所に集約

### 2. `app/controllers/settings_controller.rb#show`
- `@show_android_app_promo = PlatformDetectorService.web_android?(request)` 算出

### 3. `app/views/home/_banner_android.html.erb` (Issue #162)
- 文言「**Android アプリ版**で〜」→「**Android スマホ**から Health Connect 経由で歩数を自動送信できます」に再調整 (= 主アプリ誤認回避、Apple Shortcuts と並列の送信補助感)
- 「iPhone なら〜」一文削除 (= Android user 向けバナーで iPhone 言及は切り捨て感)
- CTA クラス `sketch-btn` → `sketch-btn sketch-btn-primary`
- リンク先 `/settings` → `settings_path` (Rails Way)
- 陳腐化コメント (`PR #33 未マージのため`) 削除
- 新コメント追加: CTA 文言「設定を見る」は #126 (= APK sideload 配布) 完了まで維持、配布開始時に「アプリを入手する」へ書き換え予定

### 4. `app/views/settings/show.html.erb` (Issue #184)
既存の native-health セクション (= L88-、Capacitor 検知時のみ JS で表示) の **直前** に新セクション挿入:
- タイトル: 「📱 Android Health Connect 連携」(= 既存セクションと同一、機能の連続性を示す)
- 本文: 「お手元の Android スマホから Health Connect 経由で歩数 / 距離 / 階段を自動同期できます。同期されたデータは Web 版にログインしてダッシュボードで閲覧できます。」
- 状態: 「現在 Android アプリのインストール手順を準備中です。それまではサンプルデータで雰囲気をお試しください。」
- サーバ UA で排他制御 (= Capacitor 検知時は \`@show_android_app_promo = false\` で非描画 → 既存セクションが JS で表示)

### 5. spec
- `platform_detector_service_spec.rb`: `web_android?` の 4 ケース追加 (= Android Web Chrome / Android Capacitor / iPhone / Desktop)
- `settings_spec.rb`: UA 別新セクション出し分け 3 ケース追加 (= 識別子は新セクション固有の「インストール手順を準備中」文字列)
- `home_spec.rb`: shared_examples を新文言「Android スマホ」に追従

## 3 者並列レビュー反映状況
- code-reviewer: ✅ `settings_path` 化反映 / `web_android?` UA 判定ロジック妥当
- strategic-reviewer: ✅ 案 E (= 2 Issue 因果セット) の判断適正、PR 本文に CTA 文言の #126 連動方針を明記 (本セクション)
- design-reviewer: ✅ must-fix「v1.0」「しばらくお待ち」削除、文言を「アプリ取得後の本来体験 + 取得手段準備中 + 暫定 sample」の 3 段構成に書き直し (= ユーザー局長との認識合わせ反映)

## 認識整理 (= 教材性)
- 主戦場 = Web アプリ、Capacitor アプリは API 送信補助 (= Apple Shortcuts と並列ポジション)
- Android Health Connect 連携機能 **そのもの** は実装済 (= 子 6 #125 完走)、未整備なのは **APK の sideload 配布手段** (= 子 7 #126)
- 評価者 (= APK 入手手段なし) には Web 版でのサンプル体験のみ、APK 入手後は Web 版でも自データのダッシュボードが見れる (= 共通バックエンド)

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 547 examples 0 failures
- [x] \`script/run \"bundle exec rubocop\"\` で 0 件
- [ ] CI 通過確認
- [ ] Web 版 Android Chrome ブラウザで Settings 画面を確認 (= 評価者目線、本日 19:00 公開後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)