### PR TITLE
docs: day-8.md に PR #185 反映 (= Issue #162 + #184 案 E close)

### DIFF
--- a/docs/dev-log/day-8.md
+++ b/docs/dev-log/day-8.md
@@ -17,7 +17,7 @@ GW 7 日目、発表会当日。Day 7 (= 5/5) で **子 1-5a (= MVP) 完成** + 
 
 ---
 
-## 🏆 達成したこと (= 計 12 PR + 子 6 完走 + Day 7 連鎖バグ 3 件 + 3 ステップ思想バグ 1 件 + 法務 Health Connect 対応 1 件 + Capacitor splash polish 1 件 + navbar 2 連 polish + Settings ポリシーリンク移動 1 件 + Webhook 422 文言 I18n 化 1 件 + v1.1 backlog 5 件集約)
+## 🏆 達成したこと (= 計 13 PR + 子 6 完走 + Day 7 連鎖バグ 3 件 + 3 ステップ思想バグ 1 件 + 法務 Health Connect 対応 1 件 + Capacitor splash polish 1 件 + navbar 2 連 polish + Settings ポリシーリンク移動 1 件 + Webhook 422 文言 I18n 化 1 件 + banner_android UX ループ解消 1 件 + v1.1 backlog 5 件集約)
 
 ### マージ済み PR (= 10 本)
 
@@ -35,6 +35,7 @@ GW 7 日目、発表会当日。Day 7 (= 5/5) で **子 1-5a (= MVP) 完成** + 
 | #173 | – | polish: navbar sticky 化 (= position: sticky + top: 0 + z-index: 30、スクロール時も常時上部表示でブランド訴求 + ナビ可用性向上、design-reviewer #171 提案、3 者全員 Approve) |
 | #180 | #90 | polish: Settings ポリシーリンクを退会セクション後 (= フッター的) に移動 + 「退会前に規約を確認したい場合はこちら」補足、コメントに「インフォームドコンセント色 vs フッター UX 色」設計トレードオフ明示 |
 | #182 | #83 | polish: Webhook 422 エラー文言を I18n 化 + カジュアル層向け日本語化 (= `config/locales/ja.yml` 新規 8 errors キー / 3 fields キー、生例外 message は `Rails.logger.warn` に分離して本人画面非露出、`unauthorized` 値のみ運用ログ用として英語維持、design-reviewer must-fix 反映 + 推奨コピー 4 件全採用) |
+| #185 | #162, #184 | polish: banner_android UX ループ解消 + Settings に Web Android user 向け案内追加 (= **案 E** で 2 Issue 1 PR、`PlatformDetectorService.web_android?` 新設で Capacitor 排除 UA 判定、Settings 新セクションは既存 native-health セクションとサーバ UA で排他制御、文言は「アプリ取得後の本来体験 + 取得手段準備中 + 暫定 sample」3 段構成 — ユーザー局長との認識合わせで「Web 主戦場 / Capacitor は API 送信補助 / 配布 = sideload」の前提整理が大きな成果) |
 
 ### close した Issue (= 8 件)
 - **#125 子 6 (= Capacitor 実機 E2E)** — 本日完走、Issue #40 B スコープのほぼ全達成
@@ -47,6 +48,8 @@ GW 7 日目、発表会当日。Day 7 (= 5/5) で **子 1-5a (= MVP) 完成** + 
 - **#49** (= navbar 高さ膨張、UI 最終段階 polish) — PR #171 で close、design-reviewer 事前相談 → 候補 3 で「タップ領域犠牲なし + 見た目改善」両立解
 - **#90** (= Settings ポリシーリンクをフッター位置に) — PR #180 で close、設計トレードオフ (= インフォームドコンセント vs フッター UX) コメント残置で教材性確保
 - **#83** (= Webhook 422 エラー文言の日本語化) — PR #182 で close、`ja.yml` 新規導入で他機能の I18n 拡張への雛形に。design 推奨 4 件全採用 + must-fix (生例外 message 露出) を `Rails.logger.warn` 分離で対応、教材性ポイントは「全部翻訳するのが正解ではない / ユーザー向け文言と運用ログ向け文言を分ける」
+- **#162** (= banner_android 文言と CTA を Android user 向けに最適化) — PR #185 で close、案 E 内の片半分。「Android アプリ版」表記 → 「Android スマホから〜送信」(= 主アプリ感解消、Apple Shortcuts と並列の送信補助感) + sketch-btn-primary 化 + settings_path 化
+- **#184** (= Settings 画面に Web 版 Android user 向け Health Connect セクション追加、本日起票 + 本日 close) — PR #185 で close、案 E 内のもう片半分。banner_android CTA の UX ループ (= 飛び先で Android 関連手がかりが何も無い) を構造解消するための新セクション追加
 
 ### 起票した Issue (= v1.1 backlog 集約 7 件)
 
@@ -289,13 +292,13 @@ How to apply:
 
 ## 📊 統計
 
-- マージした PR: **12 本** (= #153 Phase 3 + #154 AssetLinks + #156 flightsClimbed + #157 granted + #160 state 判定 + #165 0 kcal バナナ余裕 + #167 /privacy HC 明記 + #169 splash paper 色 + #171 navbar slim 化 + #173 navbar sticky 化 + #180 Settings ポリシーリンク移動 + #182 Webhook 422 I18n 化)
-- close した Issue: **10 件** (= #125 子 6 / #158 デモ表記 / #159 設定導線残 / #163 0 kcal バナナ余裕 / #131 /privacy HC 明記 / #150 deep link 回復導線 / #128 splash 色 / #49 navbar 高さ slim 化 / #90 Settings ポリシーリンク位置 / #83 Webhook 422 文言)
-- 起票した Issue (= v1.1 backlog): **7 件** (= #161 / #162 / #174 / #175 / #176 / #177 / #178、特に #174-#178 は元 11 個別候補を 5 grouping に集約)
-- 全体 spec: 431 → **528 examples** (= +97、Phase 3 関連 35 + state 判定回帰防止 4 + 0 kcal 空ステート 9 + Webhook I18n unauthorized 検証 1 + 既存差分)
+- マージした PR: **13 本** (= #153 Phase 3 + #154 AssetLinks + #156 flightsClimbed + #157 granted + #160 state 判定 + #165 0 kcal バナナ余裕 + #167 /privacy HC 明記 + #169 splash paper 色 + #171 navbar slim 化 + #173 navbar sticky 化 + #180 Settings ポリシーリンク移動 + #182 Webhook 422 I18n 化 + #185 banner_android UX ループ解消)
+- close した Issue: **12 件** (= #125 子 6 / #158 デモ表記 / #159 設定導線残 / #163 0 kcal バナナ余裕 / #131 /privacy HC 明記 / #150 deep link 回復導線 / #128 splash 色 / #49 navbar 高さ slim 化 / #90 Settings ポリシーリンク位置 / #83 Webhook 422 文言 / #162 banner_android polish / #184 Settings Web Android セクション)
+- 起票した Issue (= v1.1 backlog): **8 件** (= #161 / #162 / #174 / #175 / #176 / #177 / #178 + 当日内 #184 起票即 close、#174-#178 は元 11 個別候補を 5 grouping に集約)
+- 全体 spec: 431 → **547 examples** (= +116、Phase 3 関連 35 + state 判定回帰防止 4 + 0 kcal 空ステート 9 + Webhook I18n unauthorized 検証 1 + PlatformDetectorService.web_android? 7 + Settings UA 別出し分け 3 + 既存差分)
 - 教訓: **4 件** (= 学び 21 AssetLinks 端末ガチャ / 学び 22 permission flow 完走 / 学び 23 state 判定はデータ最優先 / 学び 24 事前デザイン相談)
 - つまずき / 学び: **10 件** (= 当初 6 件 + 朝の連鎖発見 saga 3 件 + 0 kcal バナナ余裕 1 件)
-- セッション時間: **約 8 時間** (= 朝 06:00〜13:30 過ぎ、+ 発表会前の polish 後追い 1-2 件、発表会まで残り ~5h)
+- セッション時間: **約 8.5 時間** (= 朝 06:00〜14:30 過ぎ、発表会まで残り ~4.5h)
 
 ---
 


### PR DESCRIPTION
## Summary
- PR #185 (= 案 E、banner_android UX ループ解消 + Settings に Web Android user 向け案内追加) を day-8.md に追記
- close Issue リスト + 統計欄を更新

## Test plan
- [x] day-8.md を render で目視確認
- [x] 案 E の認識整理経緯を残置 (= 「Web 主戦場 / Capacitor は API 送信補助 / 配布 = sideload」)

🤖 Generated with [Claude Code](https://claude.com/claude-code)