### PR TITLE
polish: navbar X グループ — scroll shadow + 高さ CSS 変数化 + 未ログイン CTA (#174 A+B+D)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -55,6 +55,9 @@ body {
   border-bottom: 2px solid var(--ink);
   background: var(--paper);
   position: sticky; top: 0; z-index: 30;
+  /* transition は本体側に置く: .is-scrolled 側にだけ書くと付く方向のみ効いて
+     外す方向 (scroll up) で shadow が即時消滅して「バグっぽい」印象になるため (3 者レビュー指摘)。 */
+  transition: box-shadow .15s ease;
 }
 .sketch-navbar-title {
   font-family: 'Caveat', cursive; font-weight: 700; font-size: 32px;
@@ -73,10 +76,10 @@ body {
 }
 /* scroll 中は浮遊感として shadow を付与。
    navbar_scroll_controller.js が window.scrollY > 4px のとき .is-scrolled を element に付与する。
-   transition: box-shadow は CSS 側で宣言し、JS は class の付け外しのみ担当 (= 責務分離)。 */
+   transition は .sketch-navbar 本体に書いてあるため両方向 (付く / 外す) で .15s ease が効く。
+   JS は class の付け外しのみ担当 (= 責務分離)。 */
 .sketch-navbar.is-scrolled {
   box-shadow: 0 2px 6px rgba(0,0,0,.12);
-  transition: box-shadow .15s ease;
 }
 .sketch-navbar-right { display: flex; align-items: center; gap: 12px; }
 .sketch-navbar-name {

--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -22,6 +22,11 @@
   --danger: #cc0000;
   --danger-bg: #ffe5e5;
   --danger-soft-border: rgba(204,0,0,0.35); /* sketch-box-danger-soft 用、削除より弱い警告強度 */
+  /* navbar 高さ参照変数。navbar 自体の高さは padding/content で決まり、この変数に引きずられない。
+     参照側 (flash toast の top-offset 等) が --navbar-height を使うことで、
+     navbar 高さを変更した際に参照箇所を一括更新できる (= Issue #174 B)。
+     現在値 64px = padding 8px×2 + ボタン約 46px + border-bottom 2px (= Issue #49 slim 化後の実測値)。 */
+  --navbar-height: 64px;
 }
 
 /* body 全体を紙質背景に。layout から bg-base-200 は外す前提。 */
@@ -65,6 +70,13 @@ body {
   background-position: 0 100%;
   background-size: 100% 42%;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 30' preserveAspectRatio='none'><path d='M0,8 C18,0 38,12 56,3 C74,0 88,11 100,4 L100,25 C82,29 62,22 44,26 C26,30 12,23 0,27 Z' fill='%23ffd23f' fill-opacity='0.95'/></svg>");
+}
+/* scroll 中は浮遊感として shadow を付与。
+   navbar_scroll_controller.js が window.scrollY > 4px のとき .is-scrolled を element に付与する。
+   transition: box-shadow は CSS 側で宣言し、JS は class の付け外しのみ担当 (= 責務分離)。 */
+.sketch-navbar.is-scrolled {
+  box-shadow: 0 2px 6px rgba(0,0,0,.12);
+  transition: box-shadow .15s ease;
 }
 .sketch-navbar-right { display: flex; align-items: center; gap: 12px; }
 .sketch-navbar-name {

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
-// flash 自体は layout 側の <div class="fixed top-24 ... z-50"> 配下にあり document flow から外れているため、
+// flash 自体は layout 側の <div class="fixed top-[calc(var(--navbar-height)+16px)] ... z-50"> 配下にあり document flow から外れているため、
+// top offset は CSS 変数 --navbar-height (sketchy.css :root) で navbar 高さと連動する (= Issue #174 B)。
 // 表示/消滅とも下のコンテンツがズレることはない。よって close() はシンプルな opacity フェード → remove で完結する。
 // FOUC 対策: HTML 側で初期 opacity-0 + transition-opacity を仕込んでおき、connect() で次フレームに opacity-0
 // を外す → 自然な fade-in。JS 無効環境では layout 側の <noscript> CSS で opacity:1 が強制適用され、flash が

--- a/app/javascript/controllers/navbar_scroll_controller.js
+++ b/app/javascript/controllers/navbar_scroll_controller.js
@@ -1,0 +1,42 @@
+import { Controller } from "@hotwired/stimulus"
+
+// scroll 位置に応じて navbar に .is-scrolled class を付与し、CSS で box-shadow (浮遊感) を表現する。
+//
+// throttle: rAF (requestAnimationFrame) を使い、1 フレームごとに最大 1 回だけ DOM 操作を走らせる。
+// scroll イベントが 60fps 超で発火しても rAF キューが詰まるだけで DOM 更新は 1 フレーム 1 回。
+// THRESHOLD = 4px: 意図しない誤検知 (= inertia スクロールの微小バウンス) を無視する最小値。
+//
+// disconnect: page を離れた / Turbo navigation で element が外れたときに
+// scroll リスナーを確実に除去してメモリリークを防ぐ。
+export default class extends Controller {
+  static THRESHOLD = 4
+
+  connect() {
+    this.ticking = false
+    this.onScroll = this.handleScroll.bind(this)
+    window.addEventListener("scroll", this.onScroll, { passive: true })
+    // 初期状態をページリロード時にも正しく反映する
+    this.updateClass()
+  }
+
+  disconnect() {
+    window.removeEventListener("scroll", this.onScroll)
+  }
+
+  handleScroll() {
+    if (this.ticking) return
+    this.ticking = true
+    requestAnimationFrame(() => {
+      this.updateClass()
+      this.ticking = false
+    })
+  }
+
+  updateClass() {
+    if (window.scrollY > this.constructor.THRESHOLD) {
+      this.element.classList.add("is-scrolled")
+    } else {
+      this.element.classList.remove("is-scrolled")
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
   </head>
 
   <body>
-    <header class="sketch-navbar">
+    <header class="sketch-navbar" data-controller="navbar-scroll">
       <%= link_to root_path, class: "sketch-navbar-title" do %>
         weight <span class="sketch-swoosh">daily.</span>
       <% end %>
@@ -43,17 +43,30 @@
           <span class="sketch-navbar-name"><%= current_user.name %></span>
           <%= link_to "設定", settings_path, class: "sketch-btn" %>
           <%= button_to "ログアウト", logout_path, method: :delete, class: "sketch-btn" %>
+        <% else %>
+          <%# 未ログイン時 navbar CTA (Issue #174 D)。
+              banner_guest と CTA が 2 箇所になるが、
+              navbar = グローバル CTA / banner = ホーム内コンテキスト CTA、と役割分担で容認。
+              Capacitor アプリ内では未ログイン状態で navbar 自体が出る経路は存在しないが、
+              banner_guest と同じ intercept を保険として付与する。 %>
+          <div data-controller="capacitor-oauth-login">
+            <%= button_to "ログイン", "/auth/google_oauth2",
+                  method: :post,
+                  class: "sketch-btn sketch-btn-primary",
+                  data: { turbo: false, action: "click->capacitor-oauth-login#intercept" } %>
+          </div>
         <% end %>
       </div>
     </header>
 
     <%# flash はトースト風に画面上部 fixed で重ねる (document flow から外れるため、表示/非表示で下のコンテンツがズレない)。
-        top-20 (80px) は navbar 高さ 約 64px (= padding 16px + ボタン約 46px + border-bottom 2px、Issue #49 slim 化後) + 余白 約 16px。
-        Issue #49 で navbar 高さを 74px → 約 64px に縮めたのに合わせて top-24 → top-20 に追従、トーストが navbar 直下から自然に出る。
+        top offset は CSS 変数 --navbar-height (= 64px) + 余白 16px で計算 (= Issue #174 B)。
+        --navbar-height は :root で定義済み (sketchy.css)。参照側のみ変数を使い、navbar 自体の高さは
+        padding/content/border で決まる (= slim 化挙動を壊さないため変数を navbar 本体には適用しない)。
         FOUC 対策: 初期 opacity-0 + Stimulus connect() で fade-in。JS 無効フォールバックは <head> の <noscript><style> 参照。
         見た目は sketchy トーストに差し替え (sketch-toast)、フェード挙動 (flash_controller.js) は変更しない。 %>
     <% if flash[:notice] || flash[:alert] %>
-      <div class="fixed top-20 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-md space-y-2">
+      <div class="fixed top-[calc(var(--navbar-height)+16px)] left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-md space-y-2">
         <% if flash[:notice] %>
           <div class="sketch-toast notice opacity-0" role="alert" data-controller="flash">
             <span class="sketch-toast-message"><%= flash[:notice] %></span>

--- a/spec/requests/navbar_spec.rb
+++ b/spec/requests/navbar_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+# navbar の表示内容を担保する request spec (Issue #174 D)。
+# A (scroll shadow) / B (CSS 変数) は visual な挙動のため request spec では検証しない。
+# D (未ログイン時 navbar CTA) を中心に、ログイン時との分岐を確認する。
+RSpec.describe "Navbar", type: :request do
+  describe "GET /" do
+    context "未ログイン時" do
+      before { get root_path }
+
+      it "navbar 内にログインボタン (CTA) が含まれる" do
+        # button_to で生成される form action に /auth/google_oauth2 が含まれる
+        expect(response.body).to include("/auth/google_oauth2")
+      end
+
+      it "navbar 内に sketch-btn-primary クラスのボタンが含まれる" do
+        expect(response.body).to include("sketch-btn-primary")
+      end
+
+      it "「ログイン」文言が含まれる" do
+        expect(response.body).to include("ログイン")
+      end
+
+      it "「設定」リンクを含まない" do
+        # ログイン時専用の navbar アイテムが未ログイン時に露出しないことを確認
+        expect(response.body).not_to include(">設定<")
+      end
+
+      it "「ログアウト」ボタンを含まない" do
+        expect(response.body).not_to include("ログアウト")
+      end
+    end
+
+    context "ログイン済み時" do
+      let(:user) { create(:user) }
+
+      before do
+        mock_google_oauth2(uid: user.uid, email: user.email, name: user.name)
+        get auth_callback_path(provider: "google_oauth2")
+        get root_path
+      end
+
+      it "navbar 内にユーザー名が含まれる" do
+        expect(response.body).to include(user.name)
+      end
+
+      it "「設定」リンクが含まれる" do
+        expect(response.body).to include("設定")
+      end
+
+      it "「ログアウト」ボタンが含まれる" do
+        expect(response.body).to include("ログアウト")
+      end
+
+      it "未ログイン時の navbar CTA (capacitor-oauth-login コンテナ) を含まない" do
+        # 未ログイン用の div[data-controller="capacitor-oauth-login"] が navbar に出ないことを確認。
+        # banner_guest は表示されないため response.body に capacitor-oauth-login が残る場合は navbar 由来。
+        # ログイン済みでは banner_guest 自体も非表示なので、capacitor-oauth-login は完全に出ないはず。
+        expect(response.body).not_to include("capacitor-oauth-login")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Issue #174 navbar polish set のうち **X グループ (= 軽量 3 件)** を 1 PR で実装
  - **A**: scroll 時 box-shadow (= 浮遊感)
  - **B**: navbar 高さ CSS 変数化 + flash toast 参照連動
  - **D**: 未ログイン navbar に「ログイン」CTA 追加
- **C (= ハンバーガーメニュー) は撤退**、ViewComponents 導入 (#56) と並行検討で v1.x 持ち越し (= Issue #174 にコメント追加予定)

## 変更内容

### A: scroll shadow
- 新規 Stimulus controller `navbar_scroll_controller.js` (= scrollY > 4 で `.is-scrolled` class 付け外し、rAF throttle、`passive: true` listener、`disconnect` で確実に listener 解除)
- `app/assets/stylesheets/sketchy.css` に `.sketch-navbar.is-scrolled` の `box-shadow: 0 2px 6px rgba(0,0,0,.12)` 追加
- transition は `.sketch-navbar` **本体側**に置き両方向 (= 付く / 外す) を `.15s ease` に統一 (= 3 者レビュー指摘反映)

### B: 高さ CSS 変数化
- `:root` に `--navbar-height: 64px` 追加
- flash toast 位置を `top-20` (= ハードコード 80px) → `top-[calc(var(--navbar-height)+16px)]` に変更
- application.html.erb / flash_controller.js の関連コメントも CSS 変数連動に追従
- ⚠️ 設計ルール: navbar 自体の高さは変数を **使わない** (= 双方向依存回避、参照側のみ変数を使う一方向ルール)

### D: 未ログイン navbar CTA
- `<% else %>` 節に `button_to "ログイン", "/auth/google_oauth2", method: :post, class: "sketch-btn sketch-btn-primary"` 追加
- 文言は **「ログイン」維持** (= a-1、375px モバイル幅での折り返し回避を優先、banner_guest「Google でログイン」との不統一は許容)
- Capacitor intercept (`data-controller="capacitor-oauth-login"`) を保険付与 (= banner_guest と実装パターン揃え)

### spec
- `spec/requests/navbar_spec.rb` 新規 9 ケース (= 未ログイン時 CTA / ログイン時設定+ログアウトのみ / 文言確認)
- 全体 547 → 556 examples 0 failures

## 3 者並列レビュー反映状況
- **code-reviewer**: ✅ transition 方向 fix 反映 / Stimulus lifecycle 妥当 / Tailwind 4 arbitrary value 妥当
- **strategic-reviewer**: ✅ スコープ適正 / 教材性◎ (= rAF throttle + CSS 変数の一方向ルール + button_to a11y の 3 パターン同居) / **C 連投撤退推奨を採用**
- **design-reviewer**: ✅ scroll shadow 値 (= rgba(0,0,0,.12)) は paper トーンに適正 / transition 両方向 fix 反映 / CTA 文言は a-1 (折り返し優先) 採用

## 教材性ポイント
1. **Stimulus controller の典型**: rAF throttle + passive listener + disconnect クリーンアップ
2. **CSS 変数で散らばった値を一元化**: 「定義側は変数に依存させない、参照側のみ変数を使う」一方向ルール (= sketchy.css コメント参照)
3. **Tailwind 4 arbitrary value で CSS 変数連動**: `top-[calc(var(--navbar-height)+16px)]`

## C 撤退理由 (= strategic 指摘 + ユーザー判断)
- 残時間 4h で a11y 一式 (= focus trap + Escape + aria-expanded + drawer モーション) は駆け込み実装の典型的失敗パターン
- 現状 navbar に「設定 / ログアウト」しか乗らないため、ハンバーガーで隠す動機が薄い
- 「メニュー項目を切り出す」 = ViewComponents 導入 (#56) のタイミングで合わせて再設計が筋

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [x] \`script/run \"bundle exec rubocop\"\` で 0 件
- [ ] CI 通過確認
- [ ] scroll 動作確認 (= ローカル / 本番 で 4px 超 scroll で shadow 出現、戻すとフェードアウト)
- [ ] flash toast 位置が変数連動で正しく出るか目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)