### PR TITLE
polish: 公開前最終 4 件 — Settings 見出し中立化 + viewport-fit + 法務リンク濃色化 + banner ログイン不要明示

### DIFF
--- a/app/views/home/_banner_android.html.erb
+++ b/app/views/home/_banner_android.html.erb
@@ -7,7 +7,7 @@
     <div>
       <p class="sketch-banner-text">
         Android スマホから Health Connect 経由で歩数を自動送信できます。
-        いまはサンプルデータで雰囲気をご覧ください。
+        ログイン不要で、いまはサンプルデータで雰囲気をご覧いただけます。
       </p>
     </div>
   </div>

--- a/app/views/home/_banner_android.html.erb
+++ b/app/views/home/_banner_android.html.erb
@@ -7,7 +7,7 @@
     <div>
       <p class="sketch-banner-text">
         Android スマホから Health Connect 経由で歩数を自動送信できます。
-        ログイン不要で、いまはサンプルデータで雰囲気をご覧いただけます。
+        ログイン不要で、いまはサンプルデータで雰囲気を見てみてください。
       </p>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -34,9 +34,9 @@
 
 <%# ポリシーフッター (= 未ログインでも到達できる経路) %>
 <div style="margin-top: 2rem; padding: 1rem; text-align: center;">
-  <p class="sketch-small" style="color: var(--muted)">
-    <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--muted); text-decoration: underline;" %>
+  <p class="sketch-small" style="color: var(--ink-2)">
+    <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--ink-2); text-decoration: underline;" %>
     /
-    <%= link_to "利用規約", terms_path, style: "color: var(--muted); text-decoration: underline;" %>
+    <%= link_to "利用規約", terms_path, style: "color: var(--ink-2); text-decoration: underline;" %>
   </p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title><%= content_for(:title) || "weight_dialy" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="weight_dialy">
     <meta name="mobile-web-app-capable" content="yes">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -2,10 +2,12 @@
 
 <div class="sketch-page-narrow" style="max-width: 36rem;">
 
-  <%# ヘッダー %>
-  <h1 class="sketch-hh" style="margin-bottom: 6px;">Apple Shortcuts 連携</h1>
+  <%# ヘッダー (= データ連携の入口、iPhone Shortcuts / Android Health Connect 両方を内包する。
+       元は「Apple Shortcuts 連携」固定だったが、Android Chrome 評価者が「自分には関係ない設定ページ」と
+       感じる UX 課題が公開前 design レビューで判明 → 中立タイトルに変更し、リード文で対応端末を明示。) %>
+  <h1 class="sketch-hh" style="margin-bottom: 6px;">データ連携の設定</h1>
   <p class="sketch-body-text" style="margin-bottom: 24px;">
-    iPhone のショートカットアプリと連携して、毎日の歩数を自動で取り込みます。
+    iPhone は Apple Shortcuts、Android は Health Connect から、毎日の歩数を自動で取り込みます。
   </p>
 
   <%# Step 1: Webhook トークン %>

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -54,8 +54,12 @@ RSpec.describe "Settings", type: :request do
         expect(response.body).to include(webhooks_health_data_url)
       end
 
-      it "レスポンスボディに「Apple Shortcuts 連携」を含む" do
-        expect(response.body).to include("Apple Shortcuts 連携")
+      it "レスポンスボディに「データ連携の設定」見出しを含む (= Android user に「関係ない設定」感を出さないため中立タイトル化、公開前 polish)" do
+        expect(response.body).to include("データ連携の設定")
+      end
+
+      it "レスポンスボディにリード文の「Apple Shortcuts」を含む (= 既存対応端末の明示)" do
+        expect(response.body).to include("Apple Shortcuts")
       end
 
       it "レスポンスボディに「Step 1」を含む" do


### PR DESCRIPTION
## Summary
- design-reviewer の **公開前 Web 最終チェック** で浮上した軽量 fix 4 件を 1 PR で投入
- 公開フォーム提出 (= 本日 19:00) 前の最終 polish、いずれも 1-3 行の軽量変更でリスク極小

## 変更内容

### i: Settings 見出し中立化 (`app/views/settings/show.html.erb`)
- 見出し「Apple Shortcuts 連携」→「データ連携の設定」(= 中立タイトル)
- リード文を更新: 「iPhone は Apple Shortcuts、Android は Health Connect から、毎日の歩数を自動で取り込みます。」
- **Why**: Android Chrome 評価者が Settings を開いた時に「自分には関係ない設定ページに来てしまった」と感じる UX 課題を回避 (= design 公開前最終チェック指摘)

### ii: viewport-fit=cover 追加 (`app/views/layouts/application.html.erb`)
- `<meta name="viewport" content="width=device-width,initial-scale=1">` → `,viewport-fit=cover` 追加
- **Why**: iPhone Safari で Home Screen 追加した場合のノッチ / ホームインジケータ侵入対策。評価者は通常ブラウザで触る想定なので影響低だが、念のため

### iii: ホーム法務リンク濃色化 (`app/views/home/index.html.erb`)
- ホームフッターの「プライバシーポリシー / 利用規約」リンク色 `var(--muted)` → `var(--ink-2)`
- **Why**: 現状リンクが薄すぎて評価者が法務の存在自体に気づかない可能性。`var(--ink-2)` まで濃くするだけで「ちゃんとポリシーがある」信頼感が上がる (= スクール評価加点要素)

### iv: banner_android「ログイン不要」明示 (`app/views/home/_banner_android.html.erb`)
- 文言「いまはサンプルデータで雰囲気をご覧ください。」→「**ログイン不要で**、いまはサンプルデータで雰囲気をご覧いただけます。」
- **Why**: Android 評価者が「自分には使えないアプリ」と判断して早期離脱するのを防ぐ。サンプルデータが **ログインなしで見られる** ことを明示 (= design 公開前最終チェック指摘)

## spec 更新
- `spec/requests/settings_spec.rb`: 見出し変更に追従して 1 ケースを 2 ケースに分割 (= 見出し「データ連携の設定」+ リード文「Apple Shortcuts」)
- 557 examples 0 failures

## 公開前最終チェック (design-reviewer 結果サマリ)
- ✅ 3 秒テスト / タップ領域 / コントラスト / 入力時ズーム / 法務整備 すべて OK
- ✅ 評価者動線 (未ログイン → ログイン → Settings → 規約) で画面崩れ / エラー無し
- ✅ 重大問題なし、本 PR は **付加価値 polish のみ**

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 557 examples 0 failures
- [ ] CI 通過確認
- [ ] 各画面の見た目確認 (= ローカル / 本番、特に法務リンク色の濃さと banner 文言)

🤖 Generated with [Claude Code](https://claude.com/claude-code)