### PR TITLE
feat: OGP / meta description 最小整備 (= 公開前 SNS 共有プレビュー対応)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
         用意でき次第 og:image / twitter:card を差し替える (= 別 PR、本日後刻 or 発表会後)。 %>
     <% page_title = content_for?(:title) ? content_for(:title) : "weight daily. — 日常のちいさな歩きを自動で拾う" %>
     <% page_description = content_for?(:description) ? content_for(:description) : "通勤通学で歩く・階段を選ぶ等の日常の小さな前向きな選択を、自動で拾って褒めてくれる Web アプリ。" %>
+    <%# og:image / twitter:image を 1 箇所に集約 (= 将来ドメイン変更や OGP 専用画像差し替え時の修正漏れ防止)。 %>
+    <% ogp_image_url = "https://weight-dialy.onrender.com/icon.png" %>
 
     <title><%= page_title %></title>
     <meta name="description" content="<%= page_description %>">
@@ -24,13 +26,13 @@
     <meta property="og:title" content="<%= page_title %>">
     <meta property="og:description" content="<%= page_description %>">
     <meta property="og:url" content="<%= request.original_url %>">
-    <meta property="og:image" content="https://weight-dialy.onrender.com/icon.png">
+    <meta property="og:image" content="<%= ogp_image_url %>">
 
     <%# Twitter Card — summary は正方形小サムネ。専用 1200x630 OGP 画像が用意でき次第 summary_large_image に格上げ。 %>
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="<%= page_title %>">
     <meta name="twitter:description" content="<%= page_description %>">
-    <meta name="twitter:image" content="https://weight-dialy.onrender.com/icon.png">
+    <meta name="twitter:image" content="<%= ogp_image_url %>">
 
     <%= yield :head %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,36 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "weight_dialy" %></title>
+    <%# title / description / OGP のデフォルト値。各画面で content_for(:title) などで上書き可能。
+        OGP 画像は本日時点で既存の /icon.png を流用 (= summary card)。専用 1200x630 OGP 画像が
+        用意でき次第 og:image / twitter:card を差し替える (= 別 PR、本日後刻 or 発表会後)。 %>
+    <% page_title = content_for?(:title) ? content_for(:title) : "weight daily. — 日常のちいさな歩きを自動で拾う" %>
+    <% page_description = content_for?(:description) ? content_for(:description) : "通勤通学で歩く・階段を選ぶ等の日常の小さな前向きな選択を、自動で拾って褒めてくれる Web アプリ。" %>
+
+    <title><%= page_title %></title>
+    <meta name="description" content="<%= page_description %>">
     <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="weight_dialy">
+    <meta name="application-name" content="weight daily.">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+
+    <%# OGP (Open Graph Protocol) — Slack / LinkedIn / Discord / Twitter で URL 貼った時のプレビュー用。
+        og:url は request.original_url で動的生成 (= /privacy /terms 等の個別ページもそれぞれ正しい URL に)。
+        og:image はフルパス必須 (= 相対だと一部クライアントで失敗)、本番 URL ハードコード。 %>
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="weight daily.">
+    <meta property="og:title" content="<%= page_title %>">
+    <meta property="og:description" content="<%= page_description %>">
+    <meta property="og:url" content="<%= request.original_url %>">
+    <meta property="og:image" content="https://weight-dialy.onrender.com/icon.png">
+
+    <%# Twitter Card — summary は正方形小サムネ。専用 1200x630 OGP 画像が用意でき次第 summary_large_image に格上げ。 %>
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="<%= page_title %>">
+    <meta name="twitter:description" content="<%= page_description %>">
+    <meta name="twitter:image" content="https://weight-dialy.onrender.com/icon.png">
 
     <%= yield :head %>
 


### PR DESCRIPTION
## Summary
- 公開フォーム提出 (= 本日 19:00 / 18:30 リミット) 前に SNS 共有時のプレビューを整備
- **最小セット**: title 装飾化 + meta description + OGP 6 タグ + Twitter Card 4 タグ、既存 \`/icon.png\` を流用
- 専用 1200x630 OGP 画像が用意でき次第、og:image 差し替え + \`summary_large_image\` 格上げを別 PR で予定

## 変更内容

### `app/views/layouts/application.html.erb` の `<head>`
- \`<title>\` デフォルト: \`weight_dialy\` → \`weight daily. — 日常のちいさな歩きを自動で拾う\` (= sketchy 装飾の顔として整える)
- \`<meta name=\"description\">\` 新規 (= 通勤通学カジュアル層向けコンセプト)
- \`application-name\` も \`weight_dialy\` → \`weight daily.\` に統一
- OGP (Open Graph Protocol) 6 タグ追加:
  - \`og:type\` / \`og:site_name\` / \`og:title\` / \`og:description\` / \`og:url\` (= \`request.original_url\` 動的) / \`og:image\` (= \`https://weight-dialy.onrender.com/icon.png\` ハードコード)
- Twitter Card 4 タグ追加:
  - \`twitter:card\` = \`summary\` (= 正方形 icon 流用、専用画像準備後に \`summary_large_image\` 格上げ)
  - \`twitter:title\` / \`twitter:description\` / \`twitter:image\`
- 各画面で \`content_for(:title)\` / \`content_for(:description)\` で上書き可能 (= 既存 title 上書きパターン踏襲)

## 設計判断 (= 教材性ポイント)
- **og:image は絶対 URL 必須**: 相対パスだと一部 SNS クライアント (= Discord, LinkedIn 等) でプレビュー失敗。本番 URL ハードコードが最も確実
- **og:url は動的化**: \`request.original_url\` で各ページ (= /privacy, /terms 等) が正しい URL でシェアされる
- **twitter:card = summary 暫定**: \`summary_large_image\` は 1200x630 推奨、既存 192px icon は要件未達 → 暫定 summary、画像準備後に格上げ

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 557 examples 0 failures
- [ ] CI 通過確認
- [ ] 本番デプロイ後、Twitter Card Validator / OGP Debug ツールでプレビュー確認 (= 任意、本人作業)

🤖 Generated with [Claude Code](https://claude.com/claude-code)