### PR TITLE
polish: 動線リハ反映 — banner_empty を settings_path 化 + about ページ法務リンク濃色化

### DIFF
--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -14,10 +14,10 @@
       <div style="margin-top: 16px;">
         <%= link_to "ホームへ戻る", root_path, class: "sketch-btn sketch-btn-primary" %>
       </div>
-      <p class="sketch-small" style="margin-top: 20px; color: var(--muted);">
-        <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--muted); text-decoration: underline;" %>
+      <p class="sketch-small" style="margin-top: 20px; color: var(--ink-2);">
+        <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--ink-2); text-decoration: underline;" %>
         /
-        <%= link_to "利用規約", terms_path, style: "color: var(--muted); text-decoration: underline;" %>
+        <%= link_to "利用規約", terms_path, style: "color: var(--ink-2); text-decoration: underline;" %>
       </p>
     </div>
   </div>

--- a/app/views/home/_banner_empty.html.erb
+++ b/app/views/home/_banner_empty.html.erb
@@ -10,7 +10,6 @@
     </div>
   </div>
   <div class="sketch-banner-action">
-    <%# PR #33 (settings) 未マージのため /settings をハードコード %>
-    <%= link_to "設定する →", "/settings", class: "sketch-btn sketch-btn-primary" %>
+    <%= link_to "設定する →", settings_path, class: "sketch-btn sketch-btn-primary" %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- AI 動線リハ (= コードベース読み込み、評価者目線シナリオ確認) で浮上した **対称性 / 一貫性の漏れ 2 件** を集約 polish
- 本質バグなし、リスクゼロの整列保守

## 変更内容

### α: `app/views/home/_banner_empty.html.erb` (= ログイン済 Apple Shortcuts 未連携バナー)
- `link_to "設定する →", "/settings"` ハードコード → `settings_path` に変更
- 陳腐化コメント `<%# PR #33 (settings) 未マージのため /settings をハードコード %>` を削除 (= PR #33 はとうにマージ済)
- **Why**: banner_android が PR #185 で同様に \`settings_path\` 化済 → 同等パターンの banner_empty が取り残されていた = **対称性欠落**

### β: `app/views/about/show.html.erb` (= /about ページのフッター法務リンク色)
- 法務リンク色 \`var(--muted)\` → \`var(--ink-2)\` に濃色化 (3 箇所)
- **Why**: ホーム \`index.html.erb\` が PR #189 で同様に濃色化済 → /about が取り残されていた = **一貫性欠落**

## 教材性ポイント
- **対称性 / 一貫性の漏れ**: 同等パターンを別ファイルで揃えるとき、対象を網羅し損ねるとあとで気付かれる。**動線リハ (= ユーザーシナリオで全画面を踏破) で発見** できる類のリスク
- **コメント陳腐化**: 古い経緯コメント (= 「PR #N 未マージのため」) は、その PR がマージされた後は嘘の情報になる。**触る機会があれば削除** が筋

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 557 examples 0 failures
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)