### PR TITLE
docs: day-8.md に PR #196 反映 (= OGP リッチ移行 Claude Design 1200x630)

### DIFF
--- a/docs/dev-log/day-8.md
+++ b/docs/dev-log/day-8.md
@@ -17,7 +17,7 @@ GW 7 日目、発表会当日。Day 7 (= 5/5) で **子 1-5a (= MVP) 完成** + 
 
 ---
 
-## 🏆 達成したこと (= 計 17 PR + 子 6 完走 + Day 7 連鎖バグ 3 件 + 3 ステップ思想バグ 1 件 + 法務 Health Connect 対応 1 件 + Capacitor splash polish 1 件 + navbar 2 連 polish + Settings ポリシーリンク移動 1 件 + Webhook 422 文言 I18n 化 1 件 + banner_android UX ループ解消 1 件 + navbar X グループ 1 件 + 公開前最終 polish 4 件集約 1 件 + OGP 最小整備 1 件 + 動線リハ反映 polish 1 件 + v1.1 backlog 5 件集約)
+## 🏆 達成したこと (= 計 18 PR + 子 6 完走 + Day 7 連鎖バグ 3 件 + 3 ステップ思想バグ 1 件 + 法務 Health Connect 対応 1 件 + Capacitor splash polish 1 件 + navbar 2 連 polish + Settings ポリシーリンク移動 1 件 + Webhook 422 文言 I18n 化 1 件 + banner_android UX ループ解消 1 件 + navbar X グループ 1 件 + 公開前最終 polish 4 件集約 1 件 + OGP 最小整備 1 件 + 動線リハ反映 polish 1 件 + OGP リッチ移行 1 件 + v1.1 backlog 5 件集約)
 
 ### マージ済み PR (= 10 本)
 
@@ -40,6 +40,7 @@ GW 7 日目、発表会当日。Day 7 (= 5/5) で **子 1-5a (= MVP) 完成** + 
 | #189 | – | polish: 公開前最終 4 件集約 (= design-reviewer 公開前 Web 最終チェック反映、Settings 見出し「Apple Shortcuts 連携」→「データ連携の設定」中立化 + リード文で iPhone/Android 両 OS 明示 / viewport-fit=cover meta 追加 / ホーム法務リンク色 var(--muted) → var(--ink-2) 濃色化で信頼感向上 / banner_android 文言「ログイン不要で見てみてください」追加で Android 評価者の早期離脱回避 — code 指摘 safe-area-inset 補正は v1.1 別 Issue #190 で起票) |
 | #192 | – | feat: OGP / meta description 最小整備 (= title「weight_dialy」→「weight daily. — 日常のちいさな歩きを自動で拾う」、meta description / OGP 6 タグ / Twitter Card 4 タグ追加、og:image は既存 /icon.png 流用 + summary card 暫定、`og:url` は `request.original_url` 動的生成、専用 1200x630 画像準備でき次第 summary_large_image 格上げ予定 — SNS 共有時のプレビュー対応で公開後の長期 ROI 向上) |
 | #194 | – | polish: 動線リハ反映 — banner_empty を settings_path 化 + about ページ法務リンク濃色化 (= AI コードベース動線リハで対称性/一貫性の漏れ 2 件発見。α: banner_empty.html.erb 「/settings」ハードコードを settings_path に + 陳腐化コメント削除 (banner_android #185 と対称性回復)、β: about/show.html.erb 法務リンク色 var(--muted) → var(--ink-2) (ホーム index #189 と一貫性回復)) |
+| #196 | – | feat: OGP リッチ画像移行 — Claude Design 由来 1200x630 PNG (= ユーザー局長が claude.ai/design で作成した sketchy トーン HTML プロトタイプを bundle 受領、puppeteer 経由で headless Chrome レンダリング → 2400x1260 retina PNG 自動生成、`bin/render_ogp.sh` で再生成可能、フォントは Caveat/Kalam/Patrick Hand 英字 + Klee One 日本語 + Noto Color Emoji 絵文字の 3 段フォールバック、application.html.erb で og:image を /ogp.png に差し替え + twitter:card を summary_large_image 格上げ — Claude Design HTML プロトタイプ → 静的 PNG レンダリング 教材性◎) |
 
 ### close した Issue (= 8 件)
 - **#125 子 6 (= Capacitor 実機 E2E)** — 本日完走、Issue #40 B スコープのほぼ全達成
@@ -296,7 +297,7 @@ How to apply:
 
 ## 📊 統計
 
-- マージした PR: **17 本** (= 上記 + #194 動線リハ反映 polish)
+- マージした PR: **18 本** (= 上記 + #196 OGP リッチ移行)
 - close した Issue: **13 件** (= 12 件 + #106 既対応確認による close) + Issue #174 部分 close (= A+B+D 完了、C のみ v1.1 持ち越し)
 - 起票した Issue (= v1.1 backlog): **9 件** (= 当日内 #190 safe-area-inset 補正起票追加)
 - 全体 spec: 431 → **557 examples** (= +126)


### PR DESCRIPTION
## Summary
- PR #196 (= OGP リッチ移行 Claude Design 由来 1200x630 PNG) を day-8.md に追記
- 統計: 18 PR に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)