### PR TITLE
polish: ログイン CTA を banner_guest に集約 (= navbar 未ログイン CTA 削除、案 A)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,19 +74,10 @@
           <span class="sketch-navbar-name"><%= current_user.name %></span>
           <%= link_to "設定", settings_path, class: "sketch-btn" %>
           <%= button_to "ログアウト", logout_path, method: :delete, class: "sketch-btn" %>
-        <% else %>
-          <%# 未ログイン時 navbar CTA (Issue #174 D)。
-              banner_guest と CTA が 2 箇所になるが、
-              navbar = グローバル CTA / banner = ホーム内コンテキスト CTA、と役割分担で容認。
-              Capacitor アプリ内では未ログイン状態で navbar 自体が出る経路は存在しないが、
-              banner_guest と同じ intercept を保険として付与する。 %>
-          <div data-controller="capacitor-oauth-login">
-            <%= button_to "ログイン", "/auth/google_oauth2",
-                  method: :post,
-                  class: "sketch-btn sketch-btn-primary",
-                  data: { turbo: false, action: "click->capacitor-oauth-login#intercept" } %>
-          </div>
         <% end %>
+        <%# 未ログイン時の CTA は banner_guest に集約 (= ホーム画面の「サンプル → Google でログイン」ストーリー優先)。
+            navbar に同じ CTA を置くと 2 箇所同時表示で認知負荷が出るため削除。
+            ホーム以外 (/privacy /terms /about) からのログインは「weight daily.」タイトル → root_path → banner CTA で 2 タップ。 %>
       </div>
     </header>
 

--- a/spec/requests/navbar_spec.rb
+++ b/spec/requests/navbar_spec.rb
@@ -2,27 +2,29 @@ require "rails_helper"
 
 # navbar の表示内容を担保する request spec (Issue #174 D)。
 # A (scroll shadow) / B (CSS 変数) は visual な挙動のため request spec では検証しない。
-# D (未ログイン時 navbar CTA) を中心に、ログイン時との分岐を確認する。
+# 案 A (= 未ログイン navbar CTA を削除して banner_guest に集約) 後の検証に書き換え済。
 RSpec.describe "Navbar", type: :request do
+  # response.body から <header>...</header> 部分だけ抽出するヘルパー (= navbar 単体の確認用)。
+  def header_html(body)
+    body.match(%r{<header[^>]*>.*?</header>}m)&.[](0).to_s
+  end
+
   describe "GET /" do
     context "未ログイン時" do
       before { get root_path }
 
-      it "navbar 内にログインボタン (CTA) が含まれる" do
-        # button_to で生成される form action に /auth/google_oauth2 が含まれる
+      it "ホームページに Google ログインボタンが含まれる (= banner_guest 由来、案 A で navbar から banner に集約)" do
         expect(response.body).to include("/auth/google_oauth2")
+        expect(response.body).to include("Google でログイン")
       end
 
-      it "navbar 内に sketch-btn-primary クラスのボタンが含まれる" do
-        expect(response.body).to include("sketch-btn-primary")
+      it "navbar 単体には未ログイン CTA を含まない (= 案 A 反映、認知負荷回避)" do
+        nav = header_html(response.body)
+        expect(nav).not_to include("/auth/google_oauth2")
+        expect(nav).not_to include("ログイン")
       end
 
-      it "「ログイン」文言が含まれる" do
-        expect(response.body).to include("ログイン")
-      end
-
-      it "「設定」リンクを含まない" do
-        # ログイン時専用の navbar アイテムが未ログイン時に露出しないことを確認
+      it "「設定」リンクを含まない (= ログイン時専用 navbar アイテム)" do
         expect(response.body).not_to include(">設定<")
       end
 


### PR DESCRIPTION
## Summary
- 動線リハで判明した違和感「未ログイン時に navbar の『ログイン』と banner_guest の『Google でログイン』の 2 箇所同時表示」を **案 A (= navbar から CTA 削除、banner に集約)** で解消
- 元々 PR #187 (Issue #174 D) で navbar CTA を追加したが、ユーザー局長判断で逆転 (= 認知負荷優先、銀河ブランド訴求優先)

## 変更内容

### `app/views/layouts/application.html.erb`
- \`<% else %>\` 節 (= 未ログイン時の navbar CTA、`button_to "ログイン", "/auth/google_oauth2"` + `data-controller="capacitor-oauth-login"` ラッパー) を削除
- 削除理由を新コメントで残置: 「未ログイン時の CTA は banner_guest に集約」「2 箇所同時表示で認知負荷回避」「ホーム以外からは weight daily. タイトル → root_path → banner CTA で 2 タップ」

### `spec/requests/navbar_spec.rb`
- 未ログイン時 spec を「navbar 単体には CTA が無い + ホーム全体には banner 由来の CTA がある」を担保する形に書き換え
- response.body から `<header>...</header>` 部分だけ抽出する \`header_html\` ヘルパーを追加 (= navbar 単体確認用)
- 9 examples → 8 examples (= 「sketch-btn-primary 含む」アサート削除、banner にも残るので意図不明確だった)

## なぜ案 A か (= ユーザー局長判断)
- カジュアル層は **ホーム画面で第一印象を受ける** = banner_guest の「サンプル → Google でログイン」自然なストーリー優先
- navbar は **「weight daily.」(Caveat + sketchy swoosh)** をブランド要素として主役化
- 「2 個ある違和感」を最も直接解消、ホーム以外でもログイン経路は確保 (= タイトルクリック → ホーム戻り)

## 教材性ポイント
- **CTA の置き場所**: 「グローバル CTA (= navbar) vs コンテキスト CTA (= banner)」のトレードオフ。両方置くと認知負荷、片方に集約するのが筋
- **動線リハで判断逆転**: 実装時 (= PR #187) は「navbar 役割分担で容認」と判断、実機リハで違和感確認 → 逆転 = **動線リハで判断は更新される** という運用例

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures (= 9 → 8 examples で 1 件減)
- [ ] CI 通過確認
- [ ] 本番デプロイ後、未ログインで `/` を開いて navbar に CTA 無い + banner_guest に CTA ある状態を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)