### PR TITLE
polish: モバイル比率修正 + Web 下切れ予防 4 件集約

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -29,7 +29,9 @@
   --navbar-height: 64px;
 }
 
-/* body 全体を紙質背景に。layout から bg-base-200 は外す前提。 */
+/* body 全体を紙質背景に。layout から bg-base-200 は外す前提。
+   min-height 100vh は viewport 短コンテンツ時に下端余白が崩れる事象 (= Web 版で稀に「下が切れる」) への予防策。 */
+html, body { min-height: 100vh; }
 body {
   background: var(--paper);
   background-image:
@@ -226,8 +228,11 @@ body {
 }
 .sketch-banner-action { flex-shrink: 0; }
 
-/* ---- Dashboard ラッパー ---- */
-.sketch-dashboard { padding-bottom: 32px; }
+/* ---- Dashboard ラッパー ----
+   padding-bottom 48px は 下段カードの box-shadow (3px 3px 0) や frame アクセサリーが
+   viewport 下端で見切れないようにするための余裕。32px だと scroll restoration や
+   font load 時の layout shift で稀に「下が切れる」事象が発生していたため、48px に増量 (= 予防的)。 */
+.sketch-dashboard { padding-bottom: 48px; }
 
 /* ---- トップバー ---- */
 .sketch-topbar {
@@ -292,17 +297,26 @@ body {
   margin-right: 4px;
 }
 
-/* ---- 下段 4 カードグリッド ---- */
+/* ---- 下段 4 カードグリッド ----
+   minmax(0, 1fr) は CSS Grid の min-width: auto デフォルト挙動 (= grid item 内容が長いと
+   grid 全体が container を超えて bleed する) を抑える。30px Caveat の「+5.4」「7,200」等が
+   モバイル幅 (= 2 列) で右切れしていた事象 (画像 1 由来) への対処。 */
 .sketch-bottom-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 10px;
 }
 
 /* ---- レスポンシブ (760px 以下: グリッドを縦積みに) ---- */
 @media (max-width: 760px) {
   .sketch-main-grid   { grid-template-columns: 1fr; }
-  .sketch-bottom-grid { grid-template-columns: repeat(2, 1fr); }
+  .sketch-bottom-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .sketch-topbar      { flex-direction: column; align-items: flex-start; gap: 6px; }
+
+  /* banner はモバイル幅で flex 横並び + flex-shrink: 0 のボタンが幅を奪い、テキスト領域が
+     極小に潰れる (= 「これは / サンプ / ルデー / タで / す。」と 1-3 文字ずつ折り返し) ため、
+     縦並びに切り替えて icon + text を 1 ブロック / CTA を次行に展開する (画像 3 由来)。 */
+  .sketch-banner       { flex-direction: column; align-items: stretch; }
+  .sketch-banner-action { display: flex; justify-content: flex-start; }
 }
 


### PR DESCRIPTION
## Summary
ユーザー局長の実機リハで報告された 3 つの違和感を 1 PR で集約解消。CSS のみ 26 行変更、spec 影響なし。

| # | 報告 | 原因 | 対処 |
|---|---|---|---|
| **A** | モバイル下段 4 グリッドカードが画面右端で切れる (画像 1) | CSS Grid の \`min-width: auto\` デフォルトで grid item 内容 (= 30px Caveat 数値) が grid セルを超え container を bleed | \`grid-template-columns: repeat(N, minmax(0, 1fr))\` に変更 |
| **B** | モバイル banner_guest が「これ/サン/プル/デー/タで/す」と 1-3 文字ずつ折り返し縦長潰れ (画像 3) | flex 横並び + \`flex-shrink: 0\` ボタンがモバイル幅で幅を奪い、テキスト領域極小化 | \`@media (max-width: 760px)\` で \`flex-direction: column\` 縦並び化 |
| **C-2** | Web 版で稀に下が切れる事象 (= 再現性なし、画像 4 はその時は OK) | viewport 短コンテンツ時の reflow / scroll restoration で下端余白崩れ | \`html, body { min-height: 100vh; }\` 追加 (= 予防的) |
| **C-3** | 同上 | \`.sketch-dashboard\` の padding-bottom 32px が box-shadow 込みで余裕不足 | padding-bottom を 32 → 48px に増量 (= 予防的) |

## 変更内容
\`app/assets/stylesheets/sketchy.css\` の以下 4 箇所を修正、各箇所コメントで原因・対処・対応画像参照を残置:
- L26-27: \`html, body { min-height: 100vh }\` 追加 (= C-2)
- L233: \`.sketch-dashboard padding-bottom\` 32 → 48px (= C-3)
- L297-302: \`.sketch-bottom-grid\` の grid-template-columns に \`minmax(0, 1fr)\` (= A)
- L307-318: \`@media (max-width: 760px)\` 内に banner 縦並び化 + bottom-grid に \`minmax(0, 1fr)\` (= A + B)

## 教材性ポイント
1. **CSS Grid の \`min-width: auto\` 落とし穴**: grid item は default で content の min-width 分は縮まらず、grid 全体が container を bleed する。\`minmax(0, 1fr)\` で抑える定石パターン
2. **Flexbox + \`flex-shrink: 0\` の罠**: モバイル幅で固定幅 item が flexible item を圧迫、メディアクエリで縦並び切替が現実的解
3. **再現性なし問題への予防的対処**: \`min-height: 100vh\` + padding-bottom 増量 は治る保証なしだが、設計上の弱点を埋める典型策

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [ ] CI 通過確認
- [ ] 本番デプロイ後、モバイル実機 (= Android Chrome 等) でホームのカード右切れ + banner 縦長解消を目視
- [ ] Web 版 (= デスクトップ Chrome / Firefox) で「下が切れる」事象再発しないか暫く様子見 (= 再現性ないため確認は時間軸要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)