### PR TITLE
polish: AI カード flex 構造修正 + navbar モバイルボタン縮小

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -318,5 +318,12 @@ body {
      縦並びに切り替えて icon + text を 1 ブロック / CTA を次行に展開する (画像 3 由来)。 */
   .sketch-banner       { flex-direction: column; align-items: stretch; }
   .sketch-banner-action { display: flex; justify-content: flex-start; }
+
+  /* navbar はモバイル幅で「タイトル + 名前 + 設定 + ログアウト」が総幅オーバーになり、
+     設定/ログアウトのボタン内テキストが「設/定」「ロ/グ/ア/ウ/ト」と 1 文字ずつ縦書きみたいに
+     圧縮される事象が発生 (画像 6 由来)。名前を非表示にしてスペース確保 + ボタンを padding/font-size
+     縮小で軽量化することで横並び維持。 */
+  .sketch-navbar-name { display: none; }
+  .sketch-navbar-right .sketch-btn { padding: 6px 10px; font-size: 14px; }
 }
 

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -186,53 +186,53 @@
   <%# 右: AI 提案 + ストリーク %>
   <div class="sketch-side">
 
-    <%# AI プラマイ提案カード %>
+    <%# AI プラマイ提案カード。
+        ヘッダだけアバター横の flex、本文以下は flex の外で左端揃え (= 他カードと位置を揃えるため、
+        アバター幅 36px + gap 10px 分の右ズレを回避、画像 5 ユーザー報告由来)。 %>
     <div class="sketch-box dashed" style="background: #fff7e0;">
-      <div style="display: flex; align-items: flex-start; gap: 10px;">
+      <div style="display: flex; align-items: flex-start; gap: 10px; margin-bottom: 8px;">
         <div class="sketch-ai-avatar" aria-hidden="true">AI</div>
-        <div style="flex: 1;">
-          <h3 class="sketch-h"><%= advice.headline %></h3>
-          <% if advice.items.any? %>
-            <div class="sketch-small">
-              きょうのプラスα消費 <strong>+<%= today_kcal %> kcal</strong> なら…
-            </div>
-            <ul style="margin: 8px 0 0 16px; padding: 0; list-style: disc;">
-              <% advice.items.each do |item| %>
-                <li class="sketch-body-text" style="line-height: 1.6;">
-                  <%= item.name %>（<%= item.kcal %>kcal）
-                  <% if item.label %>
-                    <span class="<%= item.label == "余裕" ? "sketch-hl-green" : "sketch-hl-yellow" %>">
-                      <%= item.label %>
-                    </span>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
-            <%# Issue #75: AI 経路で生成された時のみ「Powered by Claude」を控えめに表示 (= フォールバック時は隠す)。
-                ユーザーへの透明性 + 発表会での教材性アピール用。 %>
-            <% if advice.ai_used %>
-              <div class="sketch-small" style="margin-top: 6px; color: var(--muted); font-size: 12px;">
-                Powered by Claude (Anthropic)
-              </div>
-            <% end %>
-            <div style="margin-top: 10px;">
-              <span class="sketch-btn" style="cursor: default; opacity: 0.6;"
-                    title="この機能は近日公開予定です">
-                <%= advice.button_label %>
-              </span>
-              <%# title 属性は mobile でホバー不可のため、下に明示テキストを併置する %>
-              <div class="sketch-small" style="margin-top: 4px;">(近日公開予定)</div>
-            </div>
-          <% else %>
-            <%# Issue #163: 消費 0 kcal (= しきい値未満) 時の空ステート。
-                3 ステップ思想 ① (罪悪感を減らす) のため、食品提案 + button を出さずに優しい body 文言だけを表示。
-                CTA を出さないのは「同期する」ボタンが既にホーム上部にあり、ここで重ねると圧力が二重になるため。 %>
-            <p class="sketch-body-text" style="line-height: 1.6; margin-top: 8px;">
-              <%= advice.body %>
-            </p>
-          <% end %>
-        </div>
+        <h3 class="sketch-h" style="flex: 1; margin: 0;"><%= advice.headline %></h3>
       </div>
+      <% if advice.items.any? %>
+        <div class="sketch-small">
+          きょうのプラスα消費 <strong>+<%= today_kcal %> kcal</strong> なら…
+        </div>
+        <ul style="margin: 8px 0 0 16px; padding: 0; list-style: disc;">
+          <% advice.items.each do |item| %>
+            <li class="sketch-body-text" style="line-height: 1.6;">
+              <%= item.name %>(<%= item.kcal %>kcal)
+              <% if item.label %>
+                <span class="<%= item.label == "余裕" ? "sketch-hl-green" : "sketch-hl-yellow" %>">
+                  <%= item.label %>
+                </span>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+        <%# Issue #75: AI 経路で生成された時のみ「Powered by Claude」を控えめに表示 (= フォールバック時は隠す)。
+            ユーザーへの透明性 + 発表会での教材性アピール用。 %>
+        <% if advice.ai_used %>
+          <div class="sketch-small" style="margin-top: 6px; color: var(--muted); font-size: 12px;">
+            Powered by Claude (Anthropic)
+          </div>
+        <% end %>
+        <div style="margin-top: 10px;">
+          <span class="sketch-btn" style="cursor: default; opacity: 0.6;"
+                title="この機能は近日公開予定です">
+            <%= advice.button_label %>
+          </span>
+          <%# title 属性は mobile でホバー不可のため、下に明示テキストを併置する %>
+          <div class="sketch-small" style="margin-top: 4px;">(近日公開予定)</div>
+        </div>
+      <% else %>
+        <%# Issue #163: 消費 0 kcal (= しきい値未満) 時の空ステート。
+            3 ステップ思想 ① (罪悪感を減らす) のため、食品提案 + button を出さずに優しい body 文言だけを表示。
+            CTA を出さないのは「同期する」ボタンが既にホーム上部にあり、ここで重ねると圧力が二重になるため。 %>
+        <p class="sketch-body-text" style="line-height: 1.6;">
+          <%= advice.body %>
+        </p>
+      <% end %>
     </div>
 
     <%# ストリークカード %>


### PR DESCRIPTION
## Summary
ユーザー局長の実機リハ報告 (画像 5 / 6) を 1 PR で集約 polish。両方とも 1 ファイル軽量変更、リスク極小。

| # | 報告 | 原因 | 対処 |
|---|---|---|---|
| **AI カード右ズレ** (画像 5) | 「今日の消費カロリー...」「プリン...」「バナナ...」「カフェラテ...」「Powered by Claude」「(近日公開予定)」が他カード (30日チャート / ストリーク) より右にズレて見える | 旧構造ではアバター + 本文全体が flex 横並び、本文以下も全部 \`flex: 1\` の中で 36px + gap 10px = 46px 右に shift | ヘッダだけアバター横の flex、本文以下は flex の外に出して左端揃え |
| **navbar モバイル圧縮** (画像 6) | 「設定」「ログアウト」ボタン内テキストが「設/定」「ロ/グ/ア/ウ/ト」と縦書き状に圧縮 | モバイル幅で `.sketch-navbar-right` 内の名前 + 設定 + ログアウト + タイトルが総幅オーバー、ボタン極小化 | 名前を非表示 + ボタン padding/font-size 縮小で横並び維持 |

## 変更内容

### `app/views/home/_dashboard.html.erb` (= AI カード再構成)
旧構造:
\`\`\`erb
<div class="sketch-box">
  <div style="display: flex; gap: 10px;">
    <div class="sketch-ai-avatar">AI</div>
    <div style="flex: 1;">
      <h3>ヘッダ</h3>
      <ul>...</ul>           <!-- 全部 46px 右に shift -->
      ボタン
    </div>
  </div>
</div>
\`\`\`

新構造:
\`\`\`erb
<div class="sketch-box">
  <div style="display: flex; gap: 10px; margin-bottom: 8px;">
    <div class="sketch-ai-avatar">AI</div>
    <h3 style="flex: 1;">ヘッダ</h3>     <!-- アバター横、これだけ flex 内 -->
  </div>
  <ul>...</ul>                            <!-- flex の外、カード左 padding から -->
  ボタン                                   <!-- 同上、左揃え -->
</div>
\`\`\`

### `app/assets/stylesheets/sketchy.css` (= navbar モバイル調整)
\`\`\`css
@media (max-width: 760px) {
  /* ... 既存 ... */
  .sketch-navbar-name { display: none; }
  .sketch-navbar-right .sketch-btn { padding: 6px 10px; font-size: 14px; }
}
\`\`\`

## 教材性ポイント
1. **flex 横並びのカード内 content shift**: アバター + 本文を全部 flex 内に入れると、本文全部がアバター幅ぶん右に shift する。**ヘッダだけ flex 内、本文は flex の外** にすれば左揃え維持
2. **モバイル navbar の総幅オーバー対処**: 「タイトル + 名前 + 複数ボタン」がモバイル幅で潰れる時、**最も情報密度の低い要素 (名前) を非表示** + **ボタンの padding/font-size 縮小** が定石

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [ ] CI 通過確認
- [ ] 本番デプロイ後、モバイル実機で AI カード本文が他カードと左揃え + navbar の設定/ログアウトが横並び維持を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)