### PR TITLE
polish: 0 歩警告強化 + navbar モバイル左寄せ + ボタン padding 戻し

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -322,8 +322,12 @@ body {
   /* navbar はモバイル幅で「タイトル + 名前 + 設定 + ログアウト」が総幅オーバーになり、
      設定/ログアウトのボタン内テキストが「設/定」「ロ/グ/ア/ウ/ト」と 1 文字ずつ縦書きみたいに
      圧縮される事象が発生 (画像 6 由来)。名前を非表示にしてスペース確保 + ボタンを padding/font-size
-     縮小で軽量化することで横並び維持。 */
+     縮小で軽量化することで横並び維持。
+     PR #204 で padding 6px 10px / font-size 14px に縮小したが、それでも縦書き状の圧縮が解消されず
+     (画像 8 由来) → space-between から flex-start に変更してボタン群を左寄せにし、
+     ボタンに割り当て可能な横幅を確保。padding は 8px 14px に戻して読みやすさ優先。 */
+  .sketch-navbar { justify-content: flex-start; }
   .sketch-navbar-name { display: none; }
-  .sketch-navbar-right .sketch-btn { padding: 6px 10px; font-size: 14px; }
+  .sketch-navbar-right .sketch-btn { padding: 8px 14px; font-size: 14px; }
 }
 

--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -195,6 +195,15 @@ export default class extends Controller {
   }
 
   formatSummary(data) {
+    // 0 歩は Health Connect 自体にデータが届いていない可能性が高い。
+    // よくある原因: ① Health Connect で「データソース」(= 歩数計測アプリ) が未設定
+    //             ② エミュレータ (= 物理歩数センサー無し)
+    //             ③ 計測アプリの書き込み権限 OFF
+    // ユーザー局長が「同期成功 → 実は 0 歩」のミスリードでハマった事例から、明示的に「Health Connect 側を見て」と誘導する。
+    if ((data.step_count || 0) === 0) {
+      return "⚠️ Health Connect から本日のデータが取得できません。Health Connect アプリで「データソース」が設定され、歩数計測アプリ (デイリーステップ / Google Fit 等) の書き込みが有効か確認してください。"
+    }
+
     const steps = (data.step_count || 0).toLocaleString()
     const km = ((data.distance_meters || 0) / 1000).toFixed(1) // ホーム画面と同じ 1 桁表示
     const floors = data.floors_climbed


### PR DESCRIPTION
## Summary
2 件のユーザー局長報告 (= 同期 0 歩ミスリード + navbar ボタン縦書き状圧縮) を 1 PR で集約 polish。

## 変更内容

### 1. 0 歩警告強化 (`app/javascript/controllers/native_health_controller.js`)
**Before**: \`✅ 今日のデータを取得しました — 0 歩 / 0.0 km / 階段なし\` (= 0 値でも「成功」表示)
**After**: \`⚠️ Health Connect から本日のデータが取得できません。Health Connect アプリで「データソース」が設定され、歩数計測アプリ (デイリーステップ / Google Fit 等) の書き込みが有効か確認してください。\`

**Why**: 局長 16:11 報告「正常に同期 → ホームで 0 歩のまま」事例。原因は **Health Connect 自体に歩数 0** (= データソース未設定)、本番 DB 調査で確定 (= 直近 6 件の WebhookDelivery 全部 0 値)。「同期成功」表示が誤解を招くため、0 歩時に明示的に Health Connect 設定確認を誘導。

### 2. navbar モバイル左寄せ + ボタン padding 戻し (`app/assets/stylesheets/sketchy.css`)
**Before**: \`.sketch-navbar { justify-content: space-between }\` + \`.sketch-btn { padding: 6px 10px }\` (= PR #204 で縮小)
**After**: モバイル幅で \`.sketch-navbar { justify-content: flex-start }\` + \`.sketch-btn { padding: 8px 14px }\`

**Why**: 画像 8 由来。PR #204 の縮小では「設/定」「ロ/グ/ア/ウ/ト」の縦書き状圧縮を解消しきれず。両端寄せ → 左寄せに変えてボタン群に割り当て可能な横幅を増やし、padding を読みやすさ優先で戻す。

## 教材性ポイント
1. **「成功表示」の罠**: API レスポンス 200 + accepted_count 1 でも、中身が 0 値だとユーザー体験は「失敗」。**意味のある成功** (= 数値 > 0) と「処理は通った」を区別して UI 表示する
2. **navbar モバイル幅対処の段階的調整**: 名前非表示 (PR #204) → ボタン縮小 (PR #204) → 左寄せ + ボタン padding 戻し (本 PR) と段階を踏んだ。ボタンを縮め過ぎると読めなくなる、レイアウト方向 (= space-between → flex-start) で根本対処する方が筋

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [ ] CI 通過確認
- [ ] 本番デプロイ後、Capacitor アプリで 0 歩同期して警告メッセージ表示を確認
- [ ] モバイル実機で navbar の「設定」「ログアウト」が 1 行で表示されること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)