### PR TITLE
polish: .sketch-btn に white-space: nowrap + flex-shrink: 0 追加 (= 設定/ログアウト 2 行折り返し解消)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -101,6 +101,11 @@ body {
   color: var(--ink); text-decoration: none; cursor: pointer;
   box-shadow: 2px 2px 0 var(--ink);
   transition: transform .08s ease, box-shadow .08s ease;
+  /* ボタン内テキストの自動折り返し禁止 (= モバイル幅で「ログ / アウト」2 行折り返しを解消)。
+     flex-shrink: 0 は flex container 内 (= navbar など) でボタンが圧縮されて
+     padding すら奪われ「設 / 定」と縦書き状になる事象を抑える (画像 10 由来)。 */
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 .sketch-btn:hover { transform: translate(-1px, -1px); box-shadow: 3px 3px 0 var(--ink); }
 .sketch-btn:active { transform: translate(2px, 2px); box-shadow: 0 0 0 var(--ink); }


### PR DESCRIPTION
## Summary
画像 10 ユーザー報告: navbar の「設定」「ログアウト」ボタンが **「設/定」「ログ/アウト」と縦書き状の 2 行** になる事象を解消。

## 原因 (= 2 つ重なっていた)

| # | 原因 | 効果 |
|---|---|---|
| 1 | \`white-space\` デフォルトは \`normal\` | ボタン幅が狭いとテキストが自動折り返し → 2 行化 |
| 2 | \`flex-shrink\` デフォルトは \`1\` | flex container (= \`.sketch-navbar-right\`) 内でボタンが圧縮、padding すら奪われ極小化 |

両方が組み合わさって「設 / 定」と 1 文字ずつ縦に並ぶ症状が出る。

## 修正

\`.sketch-btn\` に以下 2 行を追加:

\`\`\`css
.sketch-btn {
  /* 既存 */
  white-space: nowrap;     /* テキスト 1 行強制 */
  flex-shrink: 0;          /* flex container 内で縮まない */
}
\`\`\`

## 教材性
- **flex container 内のボタンの収縮**: flex item は default で \`flex-shrink: 1\` で縮められる。ボタンのように「内容を保ちたい」要素には \`flex-shrink: 0\` を明示するのが定石
- **white-space: nowrap の意義**: ボタンや chip 等「1 行固定で見せたい」UI 要素は \`white-space: nowrap\` を default にしておくのが安全

## 影響範囲
全 \`.sketch-btn\` (= ホーム / Settings / 危険ゾーン等の全ボタン) に効くが、元々ボタンは 1 行表示が想定で意図的な折り返しは無いため副作用無し。\`flex-shrink: 0\` も flex item でないボタン (= block / inline 配置) には影響なし。

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [ ] CI 通過確認
- [ ] モバイル実機で navbar の「設定」「ログアウト」が 1 行表示になることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)