### PR TITLE
polish: モバイル navbar ボタン群を 6px 下にずらして視覚バランス調整

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -334,5 +334,8 @@ body {
   .sketch-navbar { justify-content: flex-start; }
   .sketch-navbar-name { display: none; }
   .sketch-navbar-right .sketch-btn { padding: 8px 14px; font-size: 14px; }
+  /* モバイル幅では sketch-navbar-title (= 「weight daily.」 Caveat 32px) が 2 行折り返しになるため、
+     ボタン群を少し下にずらして daily. の下半分付近に揃え、視覚バランスを取る (画像 11 ユーザー報告由来、微調整レベル)。 */
+  .sketch-navbar-right { margin-top: 6px; }
 }
 


### PR DESCRIPTION
## Summary
画像 11 ユーザー報告: タイトル「weight daily.」が Caveat 32px で 2 行折り返し時、ボタン群が上寄り過ぎてバランス悪い → モバイル幅 (760px 以下) で **`.sketch-navbar-right` に `margin-top: 6px`** 追加で daily. の下半分付近に揃える。

## 変更内容
\`\`\`css
@media (max-width: 760px) {
  /* 既存... */
  .sketch-navbar-right { margin-top: 6px; }
}
\`\`\`

微調整レベル (= 6px)、デスクトップ影響なし、副作用なし。

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [ ] CI 通過確認
- [ ] モバイル実機で navbar の視覚バランス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)