### PR TITLE
feat: 初回アクセス welcome モーダル追加 (= iPhone Shortcuts 案内 + Android 近日公開予定注意)

### DIFF
--- a/app/javascript/controllers/welcome_modal_controller.js
+++ b/app/javascript/controllers/welcome_modal_controller.js
@@ -1,0 +1,72 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 初回アクセス時のウェルカムモーダル制御。
+// localStorage に「見た」フラグを保存し、2 回目以降は表示しない。
+//
+// 使い方:
+//   <div data-controller="welcome-modal">
+//     <div data-welcome-modal-target="overlay" style="display: none; ...">
+//       ...モーダル内容...
+//       <button data-action="click->welcome-modal#close">閉じる</button>
+//     </div>
+//   </div>
+//
+// 設計判断:
+//   - localStorage を使う (= cookie / session より軽量、サーバ往復なし)
+//   - localStorage 不可 (= プライベートブラウズ等) でも初回表示は走らせる (= 異常系で UX 悪化させない)
+//   - キャッシュキーをアプリ名で名前空間化して将来の衝突回避
+
+const STORAGE_KEY = "weight-daily:welcome-modal:seen"
+
+export default class extends Controller {
+  static targets = ["overlay"]
+
+  connect() {
+    if (this.alreadySeen()) return
+    this.show()
+  }
+
+  show() {
+    this.overlayTarget.style.display = "flex"
+    this.overlayTarget.setAttribute("aria-hidden", "false")
+    this._keydownHandler = this.keydown.bind(this)
+    window.addEventListener("keydown", this._keydownHandler)
+  }
+
+  close() {
+    this.overlayTarget.style.display = "none"
+    this.overlayTarget.setAttribute("aria-hidden", "true")
+    this.markSeen()
+    if (this._keydownHandler) {
+      window.removeEventListener("keydown", this._keydownHandler)
+      this._keydownHandler = null
+    }
+  }
+
+  // 背景 (overlay 自体) クリックで閉じる、内部の sketch-box クリックは無視
+  backdropClose(event) {
+    if (event.target === this.overlayTarget) {
+      this.close()
+    }
+  }
+
+  keydown(event) {
+    if (event.key === "Escape") this.close()
+  }
+
+  alreadySeen() {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === "true"
+    } catch (_) {
+      return false
+    }
+  }
+
+  markSeen() {
+    try {
+      localStorage.setItem(STORAGE_KEY, "true")
+    } catch (_) {
+      // localStorage 不可環境ではフラグ保存できないが、モーダルは開閉できるので UX は壊れない
+    }
+  }
+}

--- a/app/views/home/_welcome_modal.html.erb
+++ b/app/views/home/_welcome_modal.html.erb
@@ -1,0 +1,49 @@
+<%# 初回アクセス時のウェルカムモーダル。Stimulus welcome_modal_controller が制御。
+    localStorage に「見た」フラグ保存、2 回目以降は表示なし。
+    背景クリック / Escape / 「確認しました」ボタンで閉じる。 %>
+<div data-controller="welcome-modal">
+  <div data-welcome-modal-target="overlay"
+       aria-hidden="true"
+       aria-modal="true"
+       role="dialog"
+       aria-labelledby="welcome-modal-title"
+       style="display: none; position: fixed; inset: 0; z-index: 9999; align-items: center; justify-content: center; background: rgba(0,0,0,0.5); padding: 16px; overflow-y: auto;"
+       data-action="click->welcome-modal#backdropClose">
+    <div class="sketch-box" style="width: min(94vw, 28rem); background: var(--paper); position: relative; max-height: 90vh; overflow-y: auto;">
+
+      <h2 id="welcome-modal-title" class="sketch-h" style="margin-bottom: 12px;">👋 weight daily へようこそ</h2>
+
+      <p class="sketch-body-text" style="margin-bottom: 16px;">
+        通勤通学で歩く・階段を選ぶ等の<strong>日常の小さな前向きな選択</strong>を、自動で拾って褒めてくれる Web アプリです。
+      </p>
+
+      <%# iPhone ユーザー向け案内 %>
+      <div class="sketch-box filled" style="margin-bottom: 12px; padding: 12px; box-shadow: none;">
+        <p class="sketch-h" style="margin-bottom: 8px; font-size: 18px;">📱 iPhone をお使いの方</p>
+        <p class="sketch-body-text" style="margin-bottom: 8px;">
+          Apple Shortcuts で歩数を自動連携できます:
+        </p>
+        <ol class="sketch-body-text" style="padding-left: 20px; margin: 0; line-height: 1.7;">
+          <li>Google でログイン</li>
+          <li>Settings から Shortcut をインストール</li>
+          <li>1 日 1 回自動で歩数が記録されます</li>
+        </ol>
+      </div>
+
+      <%# Android ユーザー向け案内 %>
+      <div class="sketch-box filled" style="margin-bottom: 16px; padding: 12px; box-shadow: none;">
+        <p class="sketch-h" style="margin-bottom: 8px; font-size: 18px;">🤖 Android をお使いの方</p>
+        <p class="sketch-body-text" style="margin: 0;">
+          Android アプリ版は <strong>近日公開予定</strong>です。それまでは <strong>サンプルデータ</strong>でダッシュボードの機能をお試しください (ログイン不要)。
+        </p>
+      </div>
+
+      <button type="button"
+              class="sketch-btn sketch-btn-primary"
+              style="width: 100%;"
+              data-action="click->welcome-modal#close">
+        確認しました
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -32,6 +32,14 @@
         food_equivalent: @food_equivalent %>
 </div>
 
+<%# 初回アクセス welcome モーダル (= localStorage 判定で 1 回限り表示)。
+    未ログイン時のみ表示 — ログイン済 user は既にアプリ使い方を理解している前提 +
+    モーダル文中に「Google でログイン」を含むため、ログイン済の home_spec assertion (= response.body から
+    Google でログインを除外) との整合のためログイン後は描画しない。 %>
+<% unless logged_in? %>
+  <%= render "welcome_modal" %>
+<% end %>
+
 <%# ポリシーフッター (= 未ログインでも到達できる経路) %>
 <div style="margin-top: 2rem; padding: 1rem; text-align: center;">
   <p class="sketch-small" style="color: var(--ink-2)">


### PR DESCRIPTION
## Summary
- ユーザー局長依頼: 初回アクセスユーザーに iPhone での登録方法と Android はサンプル体験になる旨を案内するモーダル
- ホーム **未ログイン時** の初回アクセスで表示、localStorage で「見た」フラグを保存して 2 回目以降は非表示

## 変更内容

### `app/javascript/controllers/welcome_modal_controller.js` 新規 (= 72 行)
Stimulus controller。connect 時に localStorage チェック → 未読なら表示。背景クリック / Escape / 「確認しました」ボタンで閉じる。閉じた時に localStorage に `weight-daily:welcome-modal:seen` フラグ保存。

### `app/views/home/_welcome_modal.html.erb` 新規 (= 49 行)
Sketch スタイルのモーダル partial。
- ヘッダ: 「👋 weight daily へようこそ」
- 概要: 1 文 (= アプリのコンセプト)
- 📱 iPhone セクション: Apple Shortcuts 連携の 3 step ガイド
- 🤖 Android セクション: アプリ版近日公開予定、サンプルデータ体験可 (ログイン不要)
- 「確認しました」ボタン (= sketch-btn-primary)
- ARIA: \`role="dialog"\` / \`aria-modal\` / \`aria-labelledby\`

### `app/views/home/index.html.erb` 変更
\`<% unless logged_in? %><%= render "welcome_modal" %><% end %>\` で未ログイン時のみ描画。

**未ログイン時のみ理由**:
- ログイン済 user は既にアプリ使い方を理解している
- モーダル文中に「Google でログイン」文字列が含まれるため、ログイン済 user 向けの home_spec assertion (= response.body から「Google でログイン」を除外) との整合

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [ ] CI 通過確認
- [ ] 本番デプロイ後、未ログイン状態でホームを開いてモーダル表示を確認
- [ ] 「確認しました」or 背景クリック or Escape で閉じる動作
- [ ] 2 回目アクセスでモーダル非表示を確認 (= localStorage 効果)
- [ ] ログイン済 user でモーダル非表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)