### PR TITLE
polish: welcome モーダルを毎回表示 + 「以降表示しない」チェックボックス追加

### DIFF
--- a/app/javascript/controllers/welcome_modal_controller.js
+++ b/app/javascript/controllers/welcome_modal_controller.js
@@ -1,28 +1,29 @@
 import { Controller } from "@hotwired/stimulus"
 
-// 初回アクセス時のウェルカムモーダル制御。
-// localStorage に「見た」フラグを保存し、2 回目以降は表示しない。
+// ウェルカムモーダル制御。
+// デフォルトは毎回表示、ユーザーが「以降表示しない」チェックボックスを ON にした時のみ
+// localStorage にフラグ保存して次回以降非表示にする (= UX: 見たくなったらまた見られる、見なくなりたい人だけ抑制)。
 //
 // 使い方:
 //   <div data-controller="welcome-modal">
 //     <div data-welcome-modal-target="overlay" style="display: none; ...">
 //       ...モーダル内容...
+//       <input type="checkbox" data-welcome-modal-target="dontShowAgain"> 以降表示しない
 //       <button data-action="click->welcome-modal#close">閉じる</button>
 //     </div>
 //   </div>
 //
 // 設計判断:
-//   - localStorage を使う (= cookie / session より軽量、サーバ往復なし)
-//   - localStorage 不可 (= プライベートブラウズ等) でも初回表示は走らせる (= 異常系で UX 悪化させない)
-//   - キャッシュキーをアプリ名で名前空間化して将来の衝突回避
+//   - 「毎回表示 + opt-out」: 初回モーダル定石の「1 回限り」より、UX 自由度を優先 (= ユーザー局長判断)
+//   - localStorage 不可 (= プライベートブラウズ等) でも閉じる動作は壊れない (= UX 異常系考慮)
 
-const STORAGE_KEY = "weight-daily:welcome-modal:seen"
+const STORAGE_KEY = "weight-daily:welcome-modal:hidden"
 
 export default class extends Controller {
-  static targets = ["overlay"]
+  static targets = ["overlay", "dontShowAgain"]
 
   connect() {
-    if (this.alreadySeen()) return
+    if (this.userOptedOut()) return
     this.show()
   }
 
@@ -36,7 +37,9 @@ export default class extends Controller {
   close() {
     this.overlayTarget.style.display = "none"
     this.overlayTarget.setAttribute("aria-hidden", "true")
-    this.markSeen()
+    if (this.hasDontShowAgainTarget && this.dontShowAgainTarget.checked) {
+      this.markOptedOut()
+    }
     if (this._keydownHandler) {
       window.removeEventListener("keydown", this._keydownHandler)
       this._keydownHandler = null
@@ -54,7 +57,7 @@ export default class extends Controller {
     if (event.key === "Escape") this.close()
   }
 
-  alreadySeen() {
+  userOptedOut() {
     try {
       return localStorage.getItem(STORAGE_KEY) === "true"
     } catch (_) {
@@ -62,7 +65,7 @@ export default class extends Controller {
     }
   }
 
-  markSeen() {
+  markOptedOut() {
     try {
       localStorage.setItem(STORAGE_KEY, "true")
     } catch (_) {

--- a/app/views/home/_welcome_modal.html.erb
+++ b/app/views/home/_welcome_modal.html.erb
@@ -38,6 +38,15 @@
         </p>
       </div>
 
+      <%# 「以降表示しない」チェックボックス。ON で閉じると localStorage に opt-out フラグが保存され、次回以降非表示。
+          OFF (= デフォルト) で閉じると、次回も表示される (= 局長判断「毎回出す + opt-out 選択肢」)。 %>
+      <label style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px; cursor: pointer; font-family: 'Kalam', cursive; font-size: 14px; color: var(--ink-2);">
+        <input type="checkbox"
+               data-welcome-modal-target="dontShowAgain"
+               style="width: 16px; height: 16px; cursor: pointer;">
+        以降表示しない
+      </label>
+
       <button type="button"
               class="sketch-btn sketch-btn-primary"
               style="width: 100%;"


### PR DESCRIPTION
## Summary
- ユーザー局長要望: 「初回 1 回限り」 → 「毎回表示 + opt-out 選択肢」へ仕様変更
- ホーム未ログイン時に毎回 welcome モーダル表示、ユーザーが「以降表示しない」をチェックして閉じた時のみ次回非表示

## 変更内容

### `welcome_modal_controller.js`
- localStorage キー `seen` → `hidden` に意味反転
- \`connect\` で「ユーザーが opt-out した場合」のみスキップ、それ以外は表示
- \`close\` で \`dontShowAgain\` チェックボックスが ON の時のみ localStorage 保存
- target に `dontShowAgain` 追加

### `_welcome_modal.html.erb`
「確認しました」ボタンの上に「以降表示しない」チェックボックス追加。sketchy トーンの軽量 label。

## UX 判断
- **デフォルト「毎回表示」**: 初回モーダル定石の「1 回限り」より、UX 自由度を優先。見たい人は何度でも見られる
- **明示的 opt-out**: ユーザーがチェックを能動的にオンにした時だけ非表示化。見過ごしを防ぐ
- **既存ユーザーへの影響**: localStorage キーが "seen" → "hidden" に変わるので、PR #214 で既に「見た」フラグを保存したブラウザでも今度は再度モーダルが出る (= 仕様変更の通知になる)

## Test plan
- [x] \`script/run \"bundle exec rspec\"\` で 556 examples 0 failures
- [ ] CI 通過確認
- [ ] 本番デプロイ後、未ログインで毎回モーダル表示を確認
- [ ] チェックボックス OFF + 閉じる → 再リロードで再表示される
- [ ] チェックボックス ON + 閉じる → 再リロードで非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)