### PR TITLE
docs: リファクタ候補ダッシュボード新設 + 4 モード運用導入

### DIFF
--- a/docs/refactor-candidates.md
+++ b/docs/refactor-candidates.md
@@ -34,6 +34,7 @@
 - **現状**: 新規利用は既に禁止、既存は触ったタイミングで置換中
 - **ゴール**: `btn` / `card` / `navbar` / `alert` 等を sketch-* に統一
 - **見積**: 大 (= 1 PR 1 partial の小分けが筋)
+- **前提テスト**: なし (= system spec が薄いため、1 partial ずつスクショ目視 + 触ったタイミング置換が現実解)
 - **関連**: CLAUDE.md「🎨 スタイル使い分けルール」
 
 ---
@@ -49,17 +50,19 @@
 - **前提テスト**: `webhooks_controller_spec.rb` 充実度確認 (= 多分既にある、要 spec/ 確認)
 
 ### 5. `BuildHomeDashboardService` の state 命名整理
-- **場所**: `app/services/build_home_dashboard_service.rb:50-66`
+- **場所**: `app/services/build_home_dashboard_service.rb` — `:iphone_with_data` シンボル使用箇所 = 29, 60, 71 行 / `determine_state` メソッド全体 = 50-66 行
 - **現状**: `:iphone_with_data` という名前が誤称 (= 全プラットフォームの実データ表示状態を指している)
 - **ゴール**: `:has_data` 等への改名 (= view / spec / banner partials も追従)
 - **見積**: 小 (= grep + sed レベル)
+- **前提テスト**: `spec/services/build_home_dashboard_service_spec.rb` の state 別挙動 spec 存在確認 (= state を改名するなら spec の expect 値も追従)
 - **教材性**: ⭐⭐ 「コメントで認められた誤称をどう清算するか」
 
 ### 6. `CalorieAdviceService` の `body` フィールド整理
-- **場所**: `app/services/calorie_advice_service.rb:14`, 30-32
+- **場所**: `app/services/calorie_advice_service.rb` — Result Struct 定義 = 14 行 / `body` 使用箇所 = `zero_kcal_result` メソッド (58-60 行)
 - **現状**: 0kcal 専用ステートでだけ使う `body` フィールドが Result Struct に常時存在
 - **ゴール**: 専用 Result クラスに分割 or Null Object パターン
 - **見積**: 小
+- **前提テスト**: `spec/services/calorie_advice_service_spec.rb` の 0 kcal 経路カバレッジ確認
 - **教材性**: ⭐⭐ 「特殊ステートの表現方法 3 種比較」
 
 ---

--- a/docs/refactor-candidates.md
+++ b/docs/refactor-candidates.md
@@ -1,0 +1,80 @@
+# 📋 リファクタ候補ダッシュボード
+
+> **目的**: 「今日はリファクタモード」と宣言した時に、ここから 1 つ選んで着手するための候補一覧。
+> **更新方針**: 候補が増えた時に追記。完了したら削除 → 該当日の `docs/dev-log/day-N.md` にサマリ記載。
+
+## 🎯 選び方の指針
+
+- **着手前にテスト確認**: その候補に対応する RSpec/system spec があるか。**なければテスト追加 PR を先に切る**。
+- **規模感の目安**: 1 PR で完結する粒度。大きい候補は子 Issue に分割。
+- **教材性を意識**: weight_dialy は学習教材も兼ねるため、リファクタ過程自体が後輩への教材になる切り口を優先。
+
+---
+
+## 🥇 Tier 1: 大物 (= 着手前に Issue 起票推奨)
+
+### 1. Phase 3 三重防衛 (`allow_browser`) の解消
+- **場所**: `app/controllers/application_controller.rb:14-23`
+- **現状**: Capacitor / Android WebView / Mobile Chrome の 3 種を bypass する応急対応 (PR #140 → #142 → #146 → 子 6 で段階拡張)
+- **ゴール**: Capacitor の deep link / app links で OAuth 後にアプリへ戻る経路を確立 → bypass 不要に
+- **副作用懸念**: Web 版モバイル Chrome ユーザー向け allow_browser が現状緩んでいる (= セキュリティ実害なしだが UX 防御が弱まっている)
+- **関連**: コメントで明示「v1.1 で対応予定」
+- **見積**: 中 (= Capacitor 周りの再現環境とハイブリッド OAuth 知識必須)
+- **前提テスト**: OAuth 流入経路の system spec が必要
+
+### 2. Capacitor OAuth ブリッジ整理 (`sessions_controller.rb`)
+- **場所**: `app/controllers/sessions_controller.rb` (= 65 行、`capacitor_start` + `auto_login` で肥大)
+- **現状**: Web OAuth と Capacitor OAuth で別経路、後者は one-time token で WebView に session を渡す
+- **ゴール**: 共通化 + 命名整理 (= `sessions#create` の入口を 1 本化)
+- **見積**: 中
+- **関連メモリ**: `feedback_hybrid_app_oauth_pattern.md` (= 設計確立経緯)
+
+### 3. daisyUI → sketch-* 全置換
+- **場所**: `app/views/**/*.html.erb` 全般 (+ partials)
+- **現状**: 新規利用は既に禁止、既存は触ったタイミングで置換中
+- **ゴール**: `btn` / `card` / `navbar` / `alert` 等を sketch-* に統一
+- **見積**: 大 (= 1 PR 1 partial の小分けが筋)
+- **関連**: CLAUDE.md「🎨 スタイル使い分けルール」
+
+---
+
+## 🥈 Tier 2: 中物 (= 単発 PR で済む粒度)
+
+### 4. `webhooks_controller.rb` の Service 切り出し
+- **場所**: `app/controllers/webhooks_controller.rb` (181 行)
+- **現状**: `parse_recorded_on` / `parse_numeric` / `upsert_records` / `record_delivery!` が Controller 直書き
+- **ゴール**: `WebhookHealthDataIngestService` 等への切り出しで Controller を 30〜40 行台に
+- **見積**: 小〜中
+- **教材性**: ⭐⭐⭐ 「fat controller を Service にどう剥がすか」のお手本になる
+- **前提テスト**: `webhooks_controller_spec.rb` 充実度確認 (= 多分既にある、要 spec/ 確認)
+
+### 5. `BuildHomeDashboardService` の state 命名整理
+- **場所**: `app/services/build_home_dashboard_service.rb:50-66`
+- **現状**: `:iphone_with_data` という名前が誤称 (= 全プラットフォームの実データ表示状態を指している)
+- **ゴール**: `:has_data` 等への改名 (= view / spec / banner partials も追従)
+- **見積**: 小 (= grep + sed レベル)
+- **教材性**: ⭐⭐ 「コメントで認められた誤称をどう清算するか」
+
+### 6. `CalorieAdviceService` の `body` フィールド整理
+- **場所**: `app/services/calorie_advice_service.rb:14`, 30-32
+- **現状**: 0kcal 専用ステートでだけ使う `body` フィールドが Result Struct に常時存在
+- **ゴール**: 専用 Result クラスに分割 or Null Object パターン
+- **見積**: 小
+- **教材性**: ⭐⭐ 「特殊ステートの表現方法 3 種比較」
+
+---
+
+## 🥉 Tier 3: 小物 (= 暇なときに)
+
+(現状なし。発見次第追記)
+
+---
+
+## 📚 参考
+
+- 過去のリファクタ実績は `docs/dev-log/day-N.md` の各日サマリに散在
+- 業界標準アーキテクチャ教材化は **Issue #219** で別建てされている (= リファクタとは独立トラック)
+- 関連メモリ:
+  - `feedback_codebase_walkthrough_cadence.md` (= コード解説/学習ペース)
+  - `project_ruby_basics_learning_track.md` (= 学習進捗)
+  - `feedback_session_mode_declaration.md` (= 4 モード運用)


### PR DESCRIPTION
## Summary

- 学習 / 新規機能 / リファクタ / 調査・計画 の **4 モード切替運用** を導入するにあたり、リファクタトラックの再開地点として `docs/refactor-candidates.md` を整備
- 6 候補 (Tier 1 大物 × 3 / Tier 2 中物 × 3) を「場所 / 現状 / ゴール / 副作用懸念 / 見積 / 前提テスト / 教材性」 込みで列挙
- 連動 memory (= 検出条件・動作定義) は `feedback_session_mode_declaration.md` で別途整備済 (= リポジトリ外)

## 背景

29 PR を一気にマージした Day 8 直後、コードベースの全容把握が霧散しているのを自覚。気分・必要に応じて 4 モードを切り替える運用に移行することで、各トラックの「前回どこまで」を独立に管理できる体制を作る。

## 候補一覧 (詳細はファイル本体)

### 🥇 Tier 1 (= 着手前に Issue 起票推奨)
1. Phase 3 三重防衛 (`allow_browser`) の解消 — `application_controller.rb`
2. Capacitor OAuth ブリッジ整理 — `sessions_controller.rb`
3. daisyUI → sketch-* 全置換 — `app/views/**/*.html.erb`

### 🥈 Tier 2 (= 単発 PR で完結)
4. `webhooks_controller.rb` の Service 切り出し (181 → 40 行)
5. `BuildHomeDashboardService` の `state` 命名整理 (`:iphone_with_data` 誤称)
6. `CalorieAdviceService` の `body` フィールド整理

## Test plan

- [x] 文書のみの変更 (= 実コード変更なし、テスト不要)
- [x] Markdown が GitHub 上で意図通りレンダリングされる (= ヘッダ・テーブル・リスト)
- [x] 連動メモリ `feedback_session_mode_declaration.md` 内のリンク参照が `docs/refactor-candidates.md` で一致

## マージ後アクション

- マージ後、即「リファクタモード」を起動して候補から 1 件着手予定
- マージ反映として `docs/dev-log/day-8.md` に追記 (= dev-log 運用ルール)

🤖 Generated with [Claude Code](https://claude.com/claude-code)