### PR TITLE
refactor: CalorieEquivalentService の食品定数を Foods モジュールに別ファイル化

### DIFF
--- a/app/services/calorie_equivalent_service.rb
+++ b/app/services/calorie_equivalent_service.rb
@@ -13,48 +13,30 @@
 #   - seed: キーワード引数でテスト時に固定値を注入可能 (= テスト容易性)。
 #
 # nil 返却の条件:
-#   - today_kcal < 90 (= 最小食品 kcal 未満): 意味のある換算にならないため非表示。
+#   - today_kcal < Foods::MIN_KCAL (= 最小食品 kcal 未満): 意味のある換算にならないため非表示。
 #   - フォールバック時に count < 1: 最大 kcal 食品でも today_kcal が 1 個ぶんに満たない場合。
 #
 # count 上限キャップの設計:
 #   - max_count (デフォルト 5) を超える count は UI 上で冗長になる (例: バナナ 11 本ぶん)。
-#   - FOODS.shuffle で順序を確定し、count が 1..max_count に収まる最初の食品を採用する。
+#   - Foods::ALL.shuffle で順序を確定し、count が 1..max_count に収まる最初の食品を採用する。
 #   - 全食品で上限を超える場合は最大 kcal 食品で [count, max_count].min にキャップ。
+#
+# 食品マスタ (= データテーブル) の場所:
+#   - calorie_equivalent_service/foods.rb (= Issue #225 で別ファイル化)
+#   - 「ロジックとデータの分離」 設計、enum 系ツールを採用しなかった理由は同ファイル冒頭コメント参照。
 class CalorieEquivalentService
-  Item = Struct.new(:emoji, :name, :unit, :kcal, keyword_init: true)
-  private_constant :Item
-
-  # 食品定数。外部からの参照を防ぐため private_constant で保護。
-  FOODS = [
-    Item.new(emoji: "🍦", name: "アイス",            unit: "個", kcal: 200),
-    Item.new(emoji: "🍺", name: "缶ビール",          unit: "本", kcal: 140),
-    Item.new(emoji: "🍙", name: "おにぎり",          unit: "個", kcal: 180),
-    Item.new(emoji: "🍌", name: "バナナ",            unit: "本", kcal:  90),
-    Item.new(emoji: "🍫", name: "板チョコ半分",      unit: "枚", kcal: 130),
-    Item.new(emoji: "🍡", name: "大福",              unit: "個", kcal: 170),
-    Item.new(emoji: "🍗", name: "唐揚げ 3 個",       unit: "皿", kcal: 250),
-    Item.new(emoji: "🥮", name: "どら焼き",          unit: "個", kcal: 200),
-    Item.new(emoji: "🥛", name: "カップヨーグルト",  unit: "個", kcal:  90),
-    Item.new(emoji: "☕", name: "カフェラテ",        unit: "杯", kcal: 150)
-  ].freeze
-  private_constant :FOODS
-
-  # 最小食品 kcal を定数化。call のたびに FOODS を走査せず一度だけ評価する。
-  MIN_KCAL = FOODS.map(&:kcal).min
-  private_constant :MIN_KCAL
-
   # @param today_kcal [Integer] 今日の消費 kcal
   # @param seed [Integer] ランダムシード (テスト時に固定値を注入して確定的な挙動にする)
   # @param max_count [Integer] count の上限 (デフォルト 5)。これを超える count は再抽選 or キャップ
   # @return [Hash{Symbol=>Object}, nil] { emoji:, name:, unit:, count: } or nil (表示しない)
   def self.call(today_kcal, seed: Date.current.to_s.bytes.sum, max_count: 5)
-    # MIN_KCAL (最小食品 kcal) 未満は意味のある換算にならないため非表示
-    return nil if today_kcal < MIN_KCAL
+    # Foods::MIN_KCAL (最小食品 kcal) 未満は意味のある換算にならないため非表示
+    return nil if today_kcal < Foods::MIN_KCAL
 
     rng = Random.new(seed)
     # 同 seed でも候補順をばらけさせ、上限 max_count 超え食品を弾く再抽選を可能にする。
-    # (旧実装の FOODS.sample では 1 食品決め打ちで上限超えを skip できなかった)
-    shuffled = FOODS.shuffle(random: rng)
+    # (旧実装の Foods::ALL.sample では 1 食品決め打ちで上限超えを skip できなかった)
+    shuffled = Foods::ALL.shuffle(random: rng)
 
     # 1 <= count <= max_count を満たす最初の食品を採用 (再抽選ロジック)
     shuffled.each do |food|
@@ -64,10 +46,10 @@ class CalorieEquivalentService
 
     # フォールバック: 全食品で 1 <= count <= max_count を満たさない場合 (= today_kcal が
     # 非常に高い)、最大 kcal 食品で [count, max_count].min にキャップして返す。
-    # count == 0 (today_kcal < food.kcal) の経路も理論上ここに到達するが、現状の FOODS は
+    # count == 0 (today_kcal < food.kcal) の経路も理論上ここに到達するが、現状の Foods::ALL は
     # MIN_KCAL = 90 のため today_kcal >= 90 なら必ず 1 食品以上 count >= 1 になり、count == 0
     # 経路は発生しない。
-    largest = FOODS.max_by(&:kcal)
+    largest = Foods::ALL.max_by(&:kcal)
     count = today_kcal / largest.kcal
     return nil if count < 1
 

--- a/app/services/calorie_equivalent_service.rb
+++ b/app/services/calorie_equivalent_service.rb
@@ -35,7 +35,7 @@ class CalorieEquivalentService
 
     rng = Random.new(seed)
     # 同 seed でも候補順をばらけさせ、上限 max_count 超え食品を弾く再抽選を可能にする。
-    # (旧実装の Foods::ALL.sample では 1 食品決め打ちで上限超えを skip できなかった)
+    # (旧実装の FOODS.sample では 1 食品決め打ちで上限超えを skip できなかった)
     shuffled = Foods::ALL.shuffle(random: rng)
 
     # 1 <= count <= max_count を満たす最初の食品を採用 (再抽選ロジック)

--- a/app/services/calorie_equivalent_service/foods.rb
+++ b/app/services/calorie_equivalent_service/foods.rb
@@ -8,8 +8,11 @@
 #   - 結果: ロジック (= calorie_equivalent_service.rb) と データ (= 本ファイル) を別ファイルに分離するのが最もシンプル
 #
 # private_constant を付けない理由:
-#   - Rails 8 + Zeitwerk の autoload 規約 (= ファイルパスと定数名が完全一致) と
-#     `private_constant :Foods` の宣言タイミングが両立しづらいため、別ファイル化と引き換えに諦めた
+#   - Rails 8 + Zeitwerk では Foods のロードが遅延評価されるため、
+#     親ファイル (= calorie_equivalent_service.rb) で `private_constant :Foods` を書くと
+#     Foods 定数がまだロードされていない時点で宣言が走り NameError リスクがある。
+#     別ファイル化と引き換えに諦めた (= 明示 `require_relative` で回避する手もあるが、
+#     Rails の autoload 慣習を尊重する判断)。
 #   - 各定数は freeze 済で外部から書き換え不可、実害なし
 #   - 元コードでは Item / FOODS / MIN_KCAL すべて private_constant だったが、本リファクタでは
 #     「データテーブルとして見えてよい」 と判断 (= 単体テスト等で参照しやすくなる副次効果あり)

--- a/app/services/calorie_equivalent_service/foods.rb
+++ b/app/services/calorie_equivalent_service/foods.rb
@@ -1,0 +1,39 @@
+# CalorieEquivalentService が表示する食品マスタ (= データテーブル)。
+#
+# enum でなく別ファイル + Struct 配列にした理由 (= Issue #225):
+#   - Rails enum (ActiveRecord) は DB カラム前提のため、Service の静的定数には不適
+#   - enumerize / ruby-enum 系 gem は「識別子 1 個の値リスト」用 (= role / status 等)
+#   - FOODS は「識別子 + 4 属性 (emoji/name/unit/kcal) のレコード × 10」 = データテーブル構造
+#   - データテーブルに enum 系ツールを当てると「属性 1 個は enum、残りは別 Hash」の二重管理になる
+#   - 結果: ロジック (= calorie_equivalent_service.rb) と データ (= 本ファイル) を別ファイルに分離するのが最もシンプル
+#
+# private_constant を付けない理由:
+#   - Rails 8 + Zeitwerk の autoload 規約 (= ファイルパスと定数名が完全一致) と
+#     `private_constant :Foods` の宣言タイミングが両立しづらいため、別ファイル化と引き換えに諦めた
+#   - 各定数は freeze 済で外部から書き換え不可、実害なし
+#   - 元コードでは Item / FOODS / MIN_KCAL すべて private_constant だったが、本リファクタでは
+#     「データテーブルとして見えてよい」 と判断 (= 単体テスト等で参照しやすくなる副次効果あり)
+class CalorieEquivalentService
+  module Foods
+    Item = Struct.new(:emoji, :name, :unit, :kcal, keyword_init: true)
+
+    # 食品マスタ。順序に意味はない (= 呼び出し側で shuffle するため)。
+    # 中身を増減する時は spec/services/calorie_equivalent_service_spec.rb の seed 別期待値も
+    # 追従が必要 (= shuffle 結果が変わるため)。
+    ALL = [
+      Item.new(emoji: "🍦", name: "アイス",            unit: "個", kcal: 200),
+      Item.new(emoji: "🍺", name: "缶ビール",          unit: "本", kcal: 140),
+      Item.new(emoji: "🍙", name: "おにぎり",          unit: "個", kcal: 180),
+      Item.new(emoji: "🍌", name: "バナナ",            unit: "本", kcal:  90),
+      Item.new(emoji: "🍫", name: "板チョコ半分",      unit: "枚", kcal: 130),
+      Item.new(emoji: "🍡", name: "大福",              unit: "個", kcal: 170),
+      Item.new(emoji: "🍗", name: "唐揚げ 3 個",       unit: "皿", kcal: 250),
+      Item.new(emoji: "🥮", name: "どら焼き",          unit: "個", kcal: 200),
+      Item.new(emoji: "🥛", name: "カップヨーグルト",  unit: "個", kcal:  90),
+      Item.new(emoji: "☕", name: "カフェラテ",        unit: "杯", kcal: 150)
+    ].freeze
+
+    # 最小食品 kcal を定数化。call のたびに ALL を走査せず一度だけ評価する。
+    MIN_KCAL = ALL.map(&:kcal).min
+  end
+end

--- a/spec/services/calorie_equivalent_service_spec.rb
+++ b/spec/services/calorie_equivalent_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CalorieEquivalentService do
   # srand リセットは不要。
 
   # 新アルゴリズム (shuffle + 再抽選) での seed 別採用食品:
-  #   - FOODS.shuffle(random: rng) で並び順を確定し、1 <= count <= max_count(5) を
+  #   - Foods::ALL.shuffle(random: rng) で並び順を確定し、1 <= count <= max_count(5) を
   #     満たす最初の食品を採用する。以下は today_kcal=1000, max_count=5 での結果。
   #   seed=0   → おにぎり   180 kcal (count=5)
   #   seed=1   → おにぎり   180 kcal (count=5)


### PR DESCRIPTION
## Summary

Issue #225 の実装。ロジック (= `calorie_equivalent_service.rb`) と データテーブル (= 食品マスタ) を別ファイルに分離。

- 新ファイル: `app/services/calorie_equivalent_service/foods.rb`
- 内訳: `Foods::Item` (Struct) / `Foods::ALL` (= 旧 \`FOODS\`) / `Foods::MIN_KCAL`
- 本体: 定数定義削除 + 参照を `Foods::ALL` / `Foods::MIN_KCAL` に更新

## なぜ enum でなくファイル分けか (= 後輩教材ポイント)

ユーザー提案で食品定数の「enum 化」を検討したが、enum 系ツールは **FOODS 構造に合わない** と判明:

| 種類 | 想定 | FOODS との適合 |
|---|---|---|
| Rails 標準 `enum` (ActiveRecord) | DB の整数カラム → Symbol 表現 | ❌ Service は DB 不要 |
| `enumerize` gem | 属性 1 つの許可値定義 | ❌ 4 属性同時管理は不可 |
| `ruby-enum` gem | 名前付き定数 + lookup | ❌ 各識別子に複数属性持てない |
| **配列 of Struct + 別ファイル** | データテーブル | ✅ |

本質: enum 系ツールは **「識別子 1 個の集合」** 用、FOODS は **「識別子 + 4 属性 (emoji/name/unit/kcal) のレコード × 10」** = データテーブル構造。Java enum / TypeScript literal union / Python `Enum` でも同じ構造的制約あり。

→ **データテーブルには素直に Struct 配列 + 別ファイル分離が筋**。enum で表すと「属性 1 個は enum、残り 3 個は別 Hash」の二重管理に陥る。

詳細根拠: `app/services/calorie_equivalent_service/foods.rb` 冒頭コメント (= 後輩教材として残置)。

## 設計判断: private_constant を諦めた

元コードでは `Item` / `FOODS` / `MIN_KCAL` すべて `private_constant` だったが、Rails 8 + Zeitwerk の autoload 規約 (= ファイルパスと定数名の完全一致) と `private_constant :Foods` の宣言タイミングが両立しづらいため、別ファイル化と引き換えに **諦めた**。各定数は `freeze` 済で外部書き換え不可、実害なし。判断理由はコードコメントで残置。

## Test plan

- [x] `spec/services/calorie_equivalent_service_spec.rb` (51 examples) **無修正で全 PASS**
- [x] `spec/services/` 全体 (228 examples) 0 failures
- [x] `rubocop` 0 offenses
- [x] 外部 API (= `.call` の戻り値) 不変が spec で証明されているため、回帰リスクなし
- [x] 関連箇所の grep: `FOODS` への直接参照は `app/services/calorie_equivalent_service/foods.rb` 内 (移行先) と本体 (Foods::ALL 経由) のみ、外部参照なし

## マージ後アクション

- [ ] `docs/dev-log/day-9.md` (= 2026-05-07、新規) を作成し、本 PR + 学び (= enum じゃなくファイル分けの判断) を反映

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)