### PR TITLE
refactor: BuildHomeDashboardService の状態名 :iphone_with_data → :has_data にリネーム (#161)

### DIFF
--- a/app/services/build_home_dashboard_service.rb
+++ b/app/services/build_home_dashboard_service.rb
@@ -26,7 +26,7 @@ class BuildHomeDashboardService
       today_record = records.find { |r| r.recorded_on == Date.current } || records.last
 
       calorie_savings =
-        if state == :iphone_with_data
+        if state == :has_data
           CalorieSavingsService.call_for_user(user)
         else
           CalorieSavingsService.call(records)
@@ -48,7 +48,7 @@ class BuildHomeDashboardService
 
     # state 判定の優先順位 (= 2026-05-06 Day 8 で見直し):
     # 1. 未ログイン → :guest
-    # 2. 実データあり → :iphone_with_data (= platform に関わらず実データ表示、誤称だが互換性のため名前は据え置き)
+    # 2. 実データあり → :has_data (= platform に関わらず実データ表示。データの有無を最優先で見る軸名)
     # 3. Android UA + データなし → :android (= Capacitor 連携誘導バナー)
     # 4. それ以外 + データなし → :empty (= iOS Shortcut 誘導バナー)
     #
@@ -57,7 +57,7 @@ class BuildHomeDashboardService
     # データの有無を見ずに :android 状態を強制するとデモデータが返る。
     def determine_state(user, request)
       return :guest unless user
-      return :iphone_with_data if user.step_records.exists?
+      return :has_data if user.step_records.exists?
 
       platform = PlatformDetectorService.from_request(request)
       return :android if platform == :android
@@ -68,7 +68,7 @@ class BuildHomeDashboardService
     # 直近 30 日のレコードを返す (チャート描画用)。
     # guest / android / empty は DemoDataService のデモデータで代替。
     def fetch_records(user, state)
-      if state == :iphone_with_data
+      if state == :has_data
         user.step_records
             .where(recorded_on: 30.days.ago.to_date..Date.current)
             .order(:recorded_on)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <%# ホーム画面 — 状態別バナー + dashboard 本体。
-    @dashboard_state が :iphone_with_data のときのみ実データ、それ以外はデモデータ。
+    @dashboard_state が :has_data のときのみ実データ、それ以外はデモデータ。
     バナーは最大1つだけ表示される。 %>
 
 <%# 状態別バナー (ゲスト / Android / データなし) %>
@@ -13,8 +13,8 @@
 <% end %>
 
 <%# 実データ ON でない時は dashboard 上部に「※ サンプルデータ」明示 (誤認防止)。
-    iphone_with_data 状態ではバナーも非表示なので、表示中の dashboard が完全に「自分のデータ」になる。 %>
-<% if @dashboard_state != :iphone_with_data %>
+    has_data 状態ではバナーも非表示なので、表示中の dashboard が完全に「自分のデータ」になる。 %>
+<% if @dashboard_state != :has_data %>
   <div class="sketch-small" style="text-align: right; margin: 8px 0 -4px; padding: 0 4px; color: var(--muted);">
     ※ 表示中の数値はサンプルデータです
   </div>

--- a/docs/refactor-candidates.md
+++ b/docs/refactor-candidates.md
@@ -49,15 +49,7 @@
 - **教材性**: ⭐⭐⭐ 「fat controller を Service にどう剥がすか」のお手本になる
 - **前提テスト**: `webhooks_controller_spec.rb` 充実度確認 (= 多分既にある、要 spec/ 確認)
 
-### 5. `BuildHomeDashboardService` の state 命名整理
-- **場所**: `app/services/build_home_dashboard_service.rb` — `:iphone_with_data` シンボル使用箇所 = 29, 60, 71 行 / `determine_state` メソッド全体 = 50-66 行
-- **現状**: `:iphone_with_data` という名前が誤称 (= 全プラットフォームの実データ表示状態を指している)
-- **ゴール**: `:has_data` 等への改名 (= view / spec / banner partials も追従)
-- **見積**: 小 (= grep + sed レベル)
-- **前提テスト**: `spec/services/build_home_dashboard_service_spec.rb` の state 別挙動 spec 存在確認 (= state を改名するなら spec の expect 値も追従)
-- **教材性**: ⭐⭐ 「コメントで認められた誤称をどう清算するか」
-
-### 6. `CalorieAdviceService` の `body` フィールド整理
+### 5. `CalorieAdviceService` の `body` フィールド整理
 - **場所**: `app/services/calorie_advice_service.rb` — Result Struct 定義 = 14 行 / `body` 使用箇所 = `zero_kcal_result` メソッド (58-60 行)
 - **現状**: 0kcal 専用ステートでだけ使う `body` フィールドが Result Struct に常時存在
 - **ゴール**: 専用 Result クラスに分割 or Null Object パターン

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe "Home", type: :request do
     end
 
     # ─────────────────────────────────────────────────
-    # 状態 :iphone_with_data — ログイン済み + iOS UA + データあり
+    # 状態 :has_data — ログイン済み + iOS UA + データあり
     # ─────────────────────────────────────────────────
-    context "状態 :iphone_with_data (ログイン済み + iPhone UA + step_records あり)" do
+    context "状態 :has_data (ログイン済み + iPhone UA + step_records あり)" do
       let(:user) { create(:user) }
       let!(:step_record) do
         create(:step_record, user: user, recorded_on: Date.current, steps: 9000)
@@ -181,9 +181,9 @@ RSpec.describe "Home", type: :request do
     end
 
     # ─────────────────────────────────────────────────
-    # 状態 :iphone_with_data かつ「今月のレコードがゼロ + 累計あり」 (= 月初励まし発火条件、Issue #70)
+    # 状態 :has_data かつ「今月のレコードがゼロ + 累計あり」 (= 月初励まし発火条件、Issue #70)
     # ─────────────────────────────────────────────────
-    context "状態 :iphone_with_data + 今月 0 + 累計あり (= 月初励まし発火条件、Issue #70)" do
+    context "状態 :has_data + 今月 0 + 累計あり (= 月初励まし発火条件、Issue #70)" do
       # travel_to で日付を固定して月境界 issue を予防 (= code-reviewer 指摘)。
       # CI が月末/月初に走った時の偶発バグを防ぎ、再現性を担保する。
       around { |ex| travel_to(Date.new(2026, 5, 15)) { ex.run } }

--- a/spec/services/build_home_dashboard_service_spec.rb
+++ b/spec/services/build_home_dashboard_service_spec.rb
@@ -101,13 +101,13 @@ RSpec.describe BuildHomeDashboardService do
     # 回帰防止: ログイン済み + Android UA + step_records あり (= Capacitor 同期済 user)
     # 旧版は :android 状態でデモデータを返していた (Issue #158, #159)
     # ─────────────────────────────────────────────────
-    context "state: :iphone_with_data (user あり + Android UA + step_records あり = Capacitor 同期済)" do
+    context "state: :has_data (user あり + Android UA + step_records あり = Capacitor 同期済)" do
       let(:user) { create(:user) }
       let!(:step_record) { create(:step_record, user: user, recorded_on: Date.current, steps: 9000) }
       subject(:result) { described_class.call(user: user, request: build_request(ua: android_ua)) }
 
-      it "state が :iphone_with_data (= Android user でも実データあれば実データ状態を返す)" do
-        expect(result.state).to eq(:iphone_with_data)
+      it "state が :has_data (= Android user でも実データあれば実データ状態を返す)" do
+        expect(result.state).to eq(:has_data)
       end
 
       it "records に DB の StepRecord が含まれる (= デモデータではない)" do
@@ -144,15 +144,15 @@ RSpec.describe BuildHomeDashboardService do
     end
 
     # ─────────────────────────────────────────────────
-    # 状態 :iphone_with_data — ログイン済み + iOS + データあり
+    # 状態 :has_data — ログイン済み + iOS + データあり
     # ─────────────────────────────────────────────────
-    context "state: :iphone_with_data (user あり + iOS UA + step_records あり)" do
+    context "state: :has_data (user あり + iOS UA + step_records あり)" do
       let(:user) { create(:user) }
       let!(:step_record) { create(:step_record, user: user, recorded_on: Date.current, steps: 9000) }
       subject(:result) { described_class.call(user: user, request: build_request(ua: iphone_ua)) }
 
-      it "state が :iphone_with_data" do
-        expect(result.state).to eq(:iphone_with_data)
+      it "state が :has_data" do
+        expect(result.state).to eq(:has_data)
       end
 
       it "display_name が user.name" do


### PR DESCRIPTION
closes #161

## Summary

- 旧名 \`:iphone_with_data\` は PR #160 で「データ優先」判定順に変更後、誤称化していた (= Android Capacitor user も同状態に到達)
- リネーム先: **\`:has_data\`** (= データの有無を判定軸として直接表現、\`:guest\` / \`:android\` / \`:empty\` と並列で読める)
- ロジック変更なし。spec 82 examples 全 PASS
- 旧誤称弁明コメント (\"誤称だが互換性のため名前は据え置き\") を削除し、軸名の意図に書き換え
- ダッシュボード \`docs/refactor-candidates.md\` の候補 #5 削除 + #6 → #5 繰上げ (運用ルール: 完了したら削除)

## 命名候補と判断

| 候補 | 評価 |
|---|---|
| \`:user_with_data\` (Issue 第一候補) | ⭐⭐ guest との対比は読めるが、\`:android\` \`:empty\` もログイン済 user 前提なので \"user_\" の情報量は薄い |
| \`:logged_in_with_data\` | ⭐ 同様に冗長 |
| **\`:has_data\` (採用)** | ⭐⭐⭐ 判定実態 (= データの有無を最優先で見ている) と一致、最短、並列状態と読みやすい |
| \`:real_data\` | ⭐⭐ デモ vs 実の対比は読めるが意味が弱い |

## 影響範囲 (= grep ヒット 0 件確認済)

- \`app/services/build_home_dashboard_service.rb\` (3 箇所 + コメント 1 箇所)
- \`app/views/home/index.html.erb\` (3 箇所)
- \`spec/services/build_home_dashboard_service_spec.rb\` (5 箇所、context + expect + comment)
- \`spec/requests/home_spec.rb\` (4 箇所、context + comment)
- \`docs/refactor-candidates.md\` (候補 #5 削除、#6→#5 繰上げ)
- 歴史的記録 (\`docs/dev-log/day-3.md\` / \`day-8.md\`) は当時の実装状態を述べる文脈なので**意図的に未編集**

## Test plan

- [x] \`bundle exec rspec spec/services/build_home_dashboard_service_spec.rb spec/requests/home_spec.rb\` → 82 examples, 0 failures
- [x] \`bundle exec rubocop\` (.rb files) → no offenses
- [x] \`grep -rn 'iphone_with_data' .\` で実装/spec 残存 0 件 (= 歴史的 dev-log のみ意図的に残存)
- [ ] レビュアー: 命名 \`:has_data\` が \`:guest\` / \`:android\` / \`:empty\` と並べて読める軸名になっているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)