### PR TITLE
refactor: SessionsController のログイン後 session 確立ロジックを private method に抽出 (#228)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,10 +29,8 @@ class SessionsController < ApplicationController
                   allow_other_host: true
     else
       # 通常 Web 経由: 従来通り Rails session を直接張る
-      reset_session
-      session[:user_id] = user.id
       Rails.logger.info("OAuth login completed via web (user_id=#{user.id})")
-      redirect_to root_path, notice: "ログインしました"
+      establish_session_and_redirect_home(user.id)
     end
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error("OAuth login failed: #{e.message}")
@@ -48,9 +46,7 @@ class SessionsController < ApplicationController
       return redirect_to root_path, alert: "ログインの確認に失敗しました。もう一度お試しください"
     end
 
-    reset_session
-    session[:user_id] = token.user_id
-    redirect_to root_path, notice: "ログインしました"
+    establish_session_and_redirect_home(token.user_id)
   end
 
   def destroy
@@ -61,5 +57,24 @@ class SessionsController < ApplicationController
   def failure
     # OAuth フロー中断 (= ユーザーがキャンセル / Custom Tabs から戻った等) の専用文言
     redirect_to root_path, alert: "Google ログインがキャンセルされました。再度お試しください"
+  end
+
+  private
+
+  # 通常 Web 経由 OAuth (= sessions#create) と Capacitor token 消費 (= sessions#auto_login) の
+  # ログイン後 session 確立を共通化。session fixation 排除のため reset_session を必ず噛ませる。
+  #
+  # なぜ Concern でなく private method か (= Issue #228 教材ポイント):
+  #   - 共有相手は同一コントローラ内 2 箇所のみ → Concern (= 複数コントローラ間共有用) は過剰抽象化
+  #   - 重複は 3 行 × 2 箇所、private メソッド 1 個で十分解消可能
+  #   - CLAUDE.md「過剰な抽象化 / DRY (3 回出てから抽象化)」 にもまだ届かない (= 2 箇所)
+  #   - Rails 慣習: 同一コントローラ内重複は private、複数コントローラ間重複は Concern
+  #
+  # logger.info は呼び出し側に残置 (= 「OAuth web 経由」 と「Capacitor token 消費」 の文脈差を
+  # 各経路で明示するため、共通化すると経路が読めなくなる)。
+  def establish_session_and_redirect_home(user_id)
+    reset_session
+    session[:user_id] = user_id
+    redirect_to root_path, notice: "ログインしました"
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,6 +23,8 @@ class SessionsController < ApplicationController
       # Capacitor 由来: Custom Tabs cookie storage に session を作っても WebView 側からは読めないため、
       # one-time token を発行 → custom URL scheme で Capacitor アプリへ転送 → WebView 側 /auto_login で消費して session 確立、というブリッジを組む。
       ott = OneTimeLoginToken.issue!(user: user)
+      # NOTE: ここでは establish_session_and_redirect_home を呼ばない (= session を張って root_path に飛ばすメソッドのため、
+      # Capacitor 経路では session 確立せず custom URL scheme へ転送する必要があり、共通化すると壊れる)。
       reset_session # Custom Tabs 側 session に残骸を残さない (= ブリッジ完了後は WebView 側 session のみが正)
       Rails.logger.info("OAuth login completed via Capacitor bridge (user_id=#{user.id})")
       redirect_to "com.weightdialy.app://oauth_callback?token=#{ott.token}",
@@ -46,6 +48,7 @@ class SessionsController < ApplicationController
       return redirect_to root_path, alert: "ログインの確認に失敗しました。もう一度お試しください"
     end
 
+    Rails.logger.info("auto_login completed via Capacitor WebView (user_id=#{token.user_id})")
     establish_session_and_redirect_home(token.user_id)
   end
 
@@ -64,11 +67,14 @@ class SessionsController < ApplicationController
   # 通常 Web 経由 OAuth (= sessions#create) と Capacitor token 消費 (= sessions#auto_login) の
   # ログイン後 session 確立を共通化。session fixation 排除のため reset_session を必ず噛ませる。
   #
-  # なぜ Concern でなく private method か (= Issue #228 教材ポイント):
-  #   - 共有相手は同一コントローラ内 2 箇所のみ → Concern (= 複数コントローラ間共有用) は過剰抽象化
-  #   - 重複は 3 行 × 2 箇所、private メソッド 1 個で十分解消可能
-  #   - CLAUDE.md「過剰な抽象化 / DRY (3 回出てから抽象化)」 にもまだ届かない (= 2 箇所)
-  #   - Rails 慣習: 同一コントローラ内重複は private、複数コントローラ間重複は Concern
+  # なぜ Concern でなく private method か (= Issue #228 教材ポイント、4 観点で機械的に判定):
+  #   1. 共有相手: 同一コントローラ内 2 箇所のみ → Concern (= 複数コントローラ間共有用) は過剰抽象化
+  #   2. 重複粒度: 3 行 × 2 箇所、private メソッド 1 個で十分解消可能
+  #   3. CLAUDE.md「過剰な抽象化 / DRY (3 回出てから抽象化)」 の適用粒度:
+  #      ここでの「抽象化」 は Concern / 基底クラス / DSL 等の **構造的分離** に対する制約。
+  #      同一クラス内 private 抽出は「整理」 に該当するため 2 箇所でも抽出可。
+  #   4. テスタビリティ: 3 行 / redirect のみ → request spec で十分カバー、独立 unit test 不要 → Concern にする動機なし
+  #   → Rails 慣習: 同一コントローラ内重複は private、複数コントローラ間重複は Concern
   #
   # logger.info は呼び出し側に残置 (= 「OAuth web 経由」 と「Capacitor token 消費」 の文脈差を
   # 各経路で明示するため、共通化すると経路が読めなくなる)。


### PR DESCRIPTION
closes #228

## Summary

\`create\` メソッド web 経由ブランチ と \`auto_login\` の **ログイン後 session 確立 3 行重複** を \`establish_session_and_redirect_home(user_id)\` private メソッドに抽出。

## なぜ Concern でなく private method か (= 教材ポイント)

ユーザー局長から「concern に移すのはどうか?」 提案。検証結果 **concern 化は構造的に過剰** と判明:

| 観点 | 検証 | 結論 |
|---|---|---|
| 共有する相手 | 同一コントローラ内 2 箇所のみ | Concern (= 複数コントローラ間共有用) は過剰抽象化 |
| 重複の粒度 | 3 行 × 2 箇所 | private メソッド 1 個で十分 |
| CLAUDE.md 方針 | 「過剰な抽象化 / DRY (= 3 回出てから抽象化)」 | まだ 2 箇所 = 「3 回」 未満 |

→ **同一コントローラ内重複は private、複数コントローラ間重複は Concern**、という Rails 慣習に従うのが筋。

判断記録は private method 直前のコードコメントに残置 (= memory \`feedback_code_as_communication.md\` 「設計判断は永続コメントで伝える」 整合)。

## logger.info の扱い

呼び出し側に残置 (= 「OAuth web 経由」 と「Capacitor token 消費」 の文脈差を各経路で明示するため、共通化すると経路が読めなくなる)。

## 影響範囲 (= 1 ファイル、+21/-6 行)

- \`app/controllers/sessions_controller.rb\` のみ
- ロジック変更なし、純粋なメソッド抽出
- 既存 spec **無修正で全 PASS** (= Issue #228 完了条件達成)

## スコープ外 (= 触らない)

- **Capacitor 経由ロジック** (= \`create\` 内の \`if capacitor_oauth\` ブランチ): redirect 先と log message が違うため private method 化せず、現状のまま (= ダッシュボード Tier 1 #2 で別途整理)
- **destroy / failure**: そもそも重複していない、現状のまま

## Day 9 学び 27 / 28 との連動

| 学び | 適用 |
|---|---|
| 学び 27 (= 道具選定: enum vs ファイル分け) | 同型: Concern vs private method の道具選定を構造軸で判断 |
| 学び 28 (= リネーム refactor の 3 層線引き) | 別系統: 本 PR はリネームではなく抽出だが、判断記録の永続化原則は同じ |

## レビュー方針 (= memory `feedback_light_issue_one_pr_completion.md`、本日確立)

本 PR は **軽量 Issue** (= 1 ファイル / 21 行追加 / ロジック影響なし) のため、3 者並列レビューで出た **🟡 軽微 + 🟢 提案を別 Issue に分離せず、本 PR の追加コミットですべて吸収** します。

## Test plan

- [x] \`bundle exec rspec spec/requests/sessions_spec.rb\` → 既存 25 examples 無修正で全 PASS
- [x] \`bundle exec rspec\` (= full suite) → 560 examples 0 failures
- [x] \`bundle exec rubocop\` → 0 offenses
- [ ] レビュアー: 「Concern でなく private method」 の判断記録が後輩教材として読めるか確認
- [ ] レビュアー: logger.info を呼び出し側に残した判断 (= 経路文脈の保持) が妥当か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)