### PR TITLE
refactor: webhooks_controller のドメインロジックを WebhookHealthDataIngestService に切り出し (Tier 2 #4)

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -75,6 +75,13 @@ class WebhooksController < ActionController::API
   # Record audit log entry. Uses keyword argument `user:` so callers can
   # override with nil for unauthorized cases where @webhook_user is unreliable.
   # accepted_count: Issue #52 で追加。何件保存されたかを記録、success 時の中身が空ペイロードかを後追い分析可能にする。
+  #
+  # 監査ログを WebhookHealthDataIngestService に切り出さず controller に残した判断 (= Tier 2 #4 教材ポイント、学び 33):
+  #   - 状態依存: @raw_body (= read_raw_body で読んだ controller state) と @webhook_user (= 認証結果) に直接依存、
+  #     純粋関数化するには 2 引数追加が必要 = 切り出しコストに対する利益が薄い
+  #   - 経路共有: 認証失敗 (unauthorized) 経路で **service 通過前に** 呼ばれる必要がある (= ingest service と独立)
+  #   - 責務分類: 監査ログは「HTTP 経路ごとの出力」 = controller 責務の範疇 (= ingest = ドメイン責務とは分離軸が違う)
+  #   - 切り出し側 (= service 内 parse / upsert) との対比: あちらは引数だけで動く純粋ロジック、こちらは controller state 必須
   def record_delivery!(status:, accepted_count: nil, error_message: nil, user: @webhook_user)
     # Attempt to parse stored body as JSON for richer inspection in the audit log.
     # Falls back to { raw: <string> } when the body is not valid JSON.

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -3,33 +3,24 @@ class WebhooksController < ActionController::API
   # ActionController::API 継承は Rails 標準の API-only パターンで、CSRF 保護 / browser check / cookie /
   # session を含まない (skip_forgery_protection 等の禁止 workaround とは別物 — そもそも入っていない)。
   # 認証は Bearer token (authenticate_webhook!) で行う。
-
-  # ペイロード形式違反 (recorded_on の形式不正など) を表す内部例外。
-  # JSON::ParserError や RecordInvalid と並列で 422 + 監査ログ経路に流すために導入。
-  # webhook 受信エンドポイントは「機械同士の契約」なので fail-fast (silent 正規化しない) 方針。
-  InvalidPayload = Class.new(StandardError)
+  #
+  # ドメインロジック (= ペイロード検証 + パース + 永続化) は WebhookHealthDataIngestService に切り出し済
+  # (= ダッシュボード Tier 2 #4、refactor-candidates.md 由来、fat controller 解消の教材ポイント)。
+  # controller は **HTTP の入出力 + 認証 + 監査ログ** に専念する。
 
   before_action :read_raw_body
   before_action :authenticate_webhook!
 
   def health_data
     parsed = JSON.parse(@raw_body)
-    records_data = parsed["records"]
-
-    unless records_data.is_a?(Array)
-      record_delivery!(status: "invalid", accepted_count: 0, error_message: I18n.t("webhook.errors.missing_records_array"))
-      render json: { error: "Invalid payload" }, status: :unprocessable_content
-      return
-    end
-
-    accepted = upsert_records(records_data)
+    accepted = WebhookHealthDataIngestService.call(records_data: parsed["records"], user: @webhook_user)
     record_delivery!(status: "success", accepted_count: accepted)
     render json: { accepted: accepted }, status: :ok
   rescue JSON::ParserError => e
     Rails.logger.warn("[WebhooksController] JSON parse error: #{e.message.truncate(120)}")
     record_delivery!(status: "invalid", accepted_count: 0, error_message: I18n.t("webhook.errors.json_parse_error"))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
-  rescue InvalidPayload => e
+  rescue WebhookHealthDataIngestService::InvalidPayload => e
     record_delivery!(status: "invalid", accepted_count: 0, error_message: e.message.truncate(120))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   rescue ActiveRecord::RecordInvalid => e
@@ -79,79 +70,6 @@ class WebhooksController < ActionController::API
 
   def extract_bearer_token
     request.headers["Authorization"]&.delete_prefix("Bearer ")&.strip
-  end
-
-  # Strict ISO 8601 (yyyy-MM-dd) parser. 配布版 Apple Shortcut は yyyy-MM-dd zero-padded で送る契約のため、
-  # それ以外のフォーマット (yyyy/MM/dd, M/d/yyyy 米国式 vs 欧州式) を Date.parse で寛容に解釈すると
-  # 「同じ日のつもりが別日として保存」「2 月のデータが 5 月になる」事故を生むため reject する。
-  #
-  # NOTE: Date.strptime("%Y-%m-%d") は仕様上 zero padding 不足 ("2026-5-3") を許容してしまうため、
-  # 正規表現で「正確に 4-2-2 桁」を先に検査してから Date.strptime に渡す二段構え。
-  ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}\z/
-
-  def parse_recorded_on(raw)
-    raise InvalidPayload, I18n.t("webhook.errors.recorded_on_required") if raw.blank?
-    raw_str = raw.to_s
-    unless raw_str.match?(ISO_DATE_FORMAT)
-      raise InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format")
-    end
-    Date.strptime(raw_str, "%Y-%m-%d")
-  rescue Date::Error
-    # 月日の値域違反 (例: "2026-13-99")
-    raise InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format")
-  end
-
-  # 数値フィールド (steps / distance_meters / flights_climbed) を厳格パースする (Issue #52)。
-  # nil は許容 (= partial-update セマンティクス維持) するが、Hash や String など Integer/Float でない型は reject。
-  # 防ぎたい事故: Apple HealthKit Sample object `{ value: 12345, unit: "count" }` が来た時に、
-  # AR の type cast で silent に 0 として保存される (= 「動いてるけど中身がゼロ」の見えないバグ温床)。
-  #
-  # Float は「整数値の Float」(例: 8000.0) のみ許容する。9999.9 のような小数は silent に切り捨てられて
-  # 1 歩ぶん失われる事故を防ぐため reject する (= Apple Shortcuts が JSON 数値を 8000.0 で送る可能性を残しつつ、
-  # 真の小数値は reject、code-reviewer 指摘 ⚠️)。
-  def parse_numeric(raw, field_name)
-    return nil if raw.nil?
-    case raw
-    when Integer
-      raw
-    when Float
-      raise InvalidPayload, I18n.t("webhook.errors.must_be_whole_number", field: I18n.t("webhook.fields.#{field_name}"), value: raw) unless raw == raw.to_i
-      raw.to_i
-    else
-      raise InvalidPayload, I18n.t("webhook.errors.must_be_number", field: I18n.t("webhook.fields.#{field_name}"), value: raw.to_s.truncate(40).gsub(/[[:cntrl:]]/, "?"), type: raw.class)
-    end
-  end
-
-  # Upsert each day's record, updating only the keys present in the payload.
-  # Keys absent from the payload are left unchanged (partial-update semantics).
-  # All-or-nothing: wrap in a transaction so that if any record fails validation
-  # the entire batch rolls back and the caller can safely retry the whole payload.
-  def upsert_records(records_data)
-    accepted = 0
-
-    StepRecord.transaction do
-      records_data.each do |entry|
-        recorded_on = parse_recorded_on(entry["recorded_on"])
-
-        record = StepRecord.find_or_initialize_by(user: @webhook_user, recorded_on: recorded_on)
-
-        # Slice only the keys the caller sent; compact removes nils so that
-        # missing keys do not overwrite existing values with nil/0.
-        # NOTE: we cannot distinguish "key absent" from "explicit 0" because both
-        # arrive as falsy in JSON; partial-update semantics treat absent ≠ 0.
-        updates = {
-          steps:           parse_numeric(entry["steps"], "steps"),
-          distance_meters: parse_numeric(entry["distance_meters"], "distance_meters"),
-          flights_climbed: parse_numeric(entry["flights_climbed"], "flights_climbed")
-        }.compact
-
-        record.assign_attributes(updates)
-        record.save!
-        accepted += 1
-      end
-    end
-
-    accepted
   end
 
   # Record audit log entry. Uses keyword argument `user:` so callers can

--- a/app/services/webhook_health_data_ingest_service.rb
+++ b/app/services/webhook_health_data_ingest_service.rb
@@ -1,0 +1,110 @@
+# Webhook 受信エンドポイント (= WebhooksController#health_data) から切り出された
+# ヘルスデータ ingest ロジック (= ダッシュボード Tier 2 #4 由来、refactor-candidates.md)。
+#
+# 設計思想 (= fat controller 解消の教材):
+#   - controller は HTTP の入出力 (params / response / 監査ログ / 認証) に専念
+#   - service はドメインロジック (ペイロード検証 + パース + 永続化) に専念
+#   - 失敗は **例外ベース** で controller の rescue ladder に委譲 (= 早期 return パターンを統一化)
+#
+# Service が raise する例外:
+#   - InvalidPayload: ペイロード形式違反 (= records が Array でない / recorded_on 形式不正 / 数値型不正)
+#                     → controller で 422 + 監査ログ "invalid" 経路へ
+#   - ActiveRecord::RecordInvalid: AR バリデーション違反 (= 負数 / 不正な日付値域)
+#                                  → controller で同じく 422 + 監査ログ "invalid" 経路へ (service では rescue しない)
+#
+# 旧 controller の `WebhooksController::InvalidPayload` は本 service に昇格 (= 例外の発生源と service が同じ場所にある方が読みやすい)。
+class WebhookHealthDataIngestService
+  # ペイロード形式違反を表す内部例外。controller の rescue ladder で捕まえて 422 + 監査ログ経路へ。
+  # JSON::ParserError や RecordInvalid と並列で 422 経路に流すために導入 (= webhook 受信エンドポイントは
+  # 「機械同士の契約」 なので fail-fast、silent 正規化しない方針)。
+  InvalidPayload = Class.new(StandardError)
+
+  # Strict ISO 8601 (yyyy-MM-dd) parser. 配布版 Apple Shortcut は yyyy-MM-dd zero-padded で送る契約のため、
+  # それ以外のフォーマット (yyyy/MM/dd, M/d/yyyy 米国式 vs 欧州式) を Date.parse で寛容に解釈すると
+  # 「同じ日のつもりが別日として保存」「2 月のデータが 5 月になる」事故を生むため reject する。
+  #
+  # NOTE: Date.strptime("%Y-%m-%d") は仕様上 zero padding 不足 ("2026-5-3") を許容してしまうため、
+  # 正規表現で「正確に 4-2-2 桁」を先に検査してから Date.strptime に渡す二段構え。
+  ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}\z/
+
+  # @param records_data [Array<Hash>, Object] ペイロードの records 配列 (Array 以外は raise)
+  # @param user [User] 認証済 webhook user (= controller の @webhook_user を渡す)
+  # @return [Integer] accepted_count (= 保存できたレコード件数)
+  # @raise [InvalidPayload] records が Array でない / recorded_on の形式不正 / 数値フィールド型不正
+  # @raise [ActiveRecord::RecordInvalid] AR バリデーション違反 (= controller 側で rescue する想定)
+  def self.call(records_data:, user:)
+    raise InvalidPayload, I18n.t("webhook.errors.missing_records_array") unless records_data.is_a?(Array)
+
+    accepted = 0
+
+    # All-or-nothing: wrap in a transaction so that if any record fails validation
+    # the entire batch rolls back and the caller can safely retry the whole payload.
+    StepRecord.transaction do
+      records_data.each do |entry|
+        recorded_on = parse_recorded_on(entry["recorded_on"])
+        record = StepRecord.find_or_initialize_by(user: user, recorded_on: recorded_on)
+
+        # Slice only the keys the caller sent; compact removes nils so that
+        # missing keys do not overwrite existing values with nil/0.
+        # NOTE: we cannot distinguish "key absent" from "explicit 0" because both
+        # arrive as falsy in JSON; partial-update semantics treat absent ≠ 0.
+        updates = {
+          steps:           parse_numeric(entry["steps"], "steps"),
+          distance_meters: parse_numeric(entry["distance_meters"], "distance_meters"),
+          flights_climbed: parse_numeric(entry["flights_climbed"], "flights_climbed")
+        }.compact
+
+        record.assign_attributes(updates)
+        record.save!
+        accepted += 1
+      end
+    end
+
+    accepted
+  end
+
+  def self.parse_recorded_on(raw)
+    raise InvalidPayload, I18n.t("webhook.errors.recorded_on_required") if raw.blank?
+
+    raw_str = raw.to_s
+    unless raw_str.match?(ISO_DATE_FORMAT)
+      raise InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format")
+    end
+
+    Date.strptime(raw_str, "%Y-%m-%d")
+  rescue Date::Error
+    # 月日の値域違反 (例: "2026-13-99")
+    raise InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format")
+  end
+  private_class_method :parse_recorded_on
+
+  # 数値フィールド (steps / distance_meters / flights_climbed) を厳格パースする (Issue #52)。
+  # nil は許容 (= partial-update セマンティクス維持) するが、Hash や String など Integer/Float でない型は reject。
+  # 防ぎたい事故: Apple HealthKit Sample object `{ value: 12345, unit: "count" }` が来た時に、
+  # AR の type cast で silent に 0 として保存される (= 「動いてるけど中身がゼロ」 の見えないバグ温床)。
+  #
+  # Float は「整数値の Float」 (例: 8000.0) のみ許容する。9999.9 のような小数は silent に切り捨てられて
+  # 1 歩ぶん失われる事故を防ぐため reject する (= Apple Shortcuts が JSON 数値を 8000.0 で送る可能性を残しつつ、
+  # 真の小数値は reject、code-reviewer 指摘由来)。
+  def self.parse_numeric(raw, field_name)
+    return nil if raw.nil?
+
+    case raw
+    when Integer
+      raw
+    when Float
+      unless raw == raw.to_i
+        raise InvalidPayload, I18n.t("webhook.errors.must_be_whole_number",
+                                     field: I18n.t("webhook.fields.#{field_name}"),
+                                     value: raw)
+      end
+      raw.to_i
+    else
+      raise InvalidPayload, I18n.t("webhook.errors.must_be_number",
+                                   field: I18n.t("webhook.fields.#{field_name}"),
+                                   value: raw.to_s.truncate(40).gsub(/[[:cntrl:]]/, "?"),
+                                   type: raw.class)
+    end
+  end
+  private_class_method :parse_numeric
+end

--- a/app/services/webhook_health_data_ingest_service.rb
+++ b/app/services/webhook_health_data_ingest_service.rb
@@ -13,6 +13,12 @@
 #                                  → controller で同じく 422 + 監査ログ "invalid" 経路へ (service では rescue しない)
 #
 # 旧 controller の `WebhooksController::InvalidPayload` は本 service に昇格 (= 例外の発生源と service が同じ場所にある方が読みやすい)。
+#
+# unit spec を独立させなかった判断 (= Tier 2 #4 教材ポイント、学び 33 テスタビリティ軸):
+#   - 既存 `spec/requests/webhooks_spec.rb` (= 110 examples) が controller + service 統合テストとして異常系含め網羅
+#   - 切り出し前後で挙動完全保持 (= 旧 controller の private method を service に移しただけ) のため、回帰テスト網は維持
+#   - 将来 service が webhook 以外の経路 (= 例: Strava ingest / batch 取込) から呼ばれるようになったら独立 unit spec を追加検討
+#   - 「Service 切り出し = 即 unit spec 追加」 を機械的に適用しない (= 既存 spec の網羅性で代替可能なら過剰)
 class WebhookHealthDataIngestService
   # ペイロード形式違反を表す内部例外。controller の rescue ladder で捕まえて 422 + 監査ログ経路へ。
   # JSON::ParserError や RecordInvalid と並列で 422 経路に流すために導入 (= webhook 受信エンドポイントは

--- a/docs/refactor-candidates.md
+++ b/docs/refactor-candidates.md
@@ -41,13 +41,7 @@
 
 ## 🥈 Tier 2: 中物 (= 単発 PR で済む粒度)
 
-### 4. `webhooks_controller.rb` の Service 切り出し
-- **場所**: `app/controllers/webhooks_controller.rb` (181 行)
-- **現状**: `parse_recorded_on` / `parse_numeric` / `upsert_records` / `record_delivery!` が Controller 直書き
-- **ゴール**: `WebhookHealthDataIngestService` 等への切り出しで Controller を 30〜40 行台に
-- **見積**: 小〜中
-- **教材性**: ⭐⭐⭐ 「fat controller を Service にどう剥がすか」のお手本になる
-- **前提テスト**: `webhooks_controller_spec.rb` 充実度確認 (= 多分既にある、要 spec/ 確認)
+(現状なし。Day 9 で全 3 件完走 = #4 webhooks_controller 切り出し / #5 旧 BuildHomeDashboardService state 命名 = Issue #161 / #6 → #5 繰上げ後 CalorieAdvice body 分離)
 
 ---
 


### PR DESCRIPTION
ダッシュボード Tier 2 #4 完走 (= refactor-candidates.md 由来、fat controller 解消の教材)。これで Day 9 末時点で **Tier 2 全 3 件完走**。

## Summary

`WebhooksController#health_data` のドメインロジック (= ペイロード検証 + パース + 永続化) を新規 `WebhookHealthDataIngestService` に切り出し、controller は **HTTP 入出力 + 認証 + 監査ログ** に専念。

## 設計判断 (= fat controller 解消の教材)

| 層 | 責務 | 配置 |
|---|---|---|
| controller | HTTP の入出力 / 認証 / 監査ログ | \`WebhooksController\` (= 残置 + ロジック呼出に変更) |
| service | ペイロード検証 + パース + 永続化 | \`WebhookHealthDataIngestService\` (= 新規) |

**失敗は例外ベース**で controller の rescue ladder に委譲 (= 早期 return パターンを rescue ladder に統一)。

## 切り出し範囲 / 残置範囲

| 切り出し (= service へ) | 残置 (= controller に) |
|---|---|
| \`parse_recorded_on\` | \`record_delivery!\` (= 監査ログ、auth 経路でも使う) |
| \`parse_numeric\` | \`read_raw_body\` (= HTTP 入力サイズガード) |
| \`upsert_records\` (本体ロジック) | \`authenticate_webhook!\` / \`extract_bearer_token\` (= 認証) |
| \`ISO_DATE_FORMAT\` 定数 | \`MAX_BODY_BYTES\` 定数 |
| \`InvalidPayload\` 例外 (= service へ昇格) | |

\`record_delivery!\` を controller に残した理由: auth 経路 (= unauthorized 時) でも呼ばれる + \`@raw_body\` / \`@webhook_user\` の controller state に依存 + 監査ログは「HTTP の各経路の出力」 として controller の責務。

## 影響範囲 (= 3 ファイル、+117/-95 行)

- \`app/controllers/webhooks_controller.rb\` (= 181 → **99 行 (-45%)**)
- \`app/services/webhook_health_data_ingest_service.rb\` (= 新規 110 行、コメント含む)
- \`docs/refactor-candidates.md\` (= Tier 2 #4 削除、「現状なし」 更新)
- 既存 spec: **無修正**

## 規模感

中規模リファクタ (= 1 ファイル切り出し / +117/-95 行 / 既存 spec 無修正で挙動保持)。**軽量 Issue ルール (= 1 PR 完結) は適用外、🟢 提案は別 Issue 起票が筋**。

## Test plan

- [x] \`bundle exec rspec spec/requests/webhooks_spec.rb spec/models/webhook_delivery_spec.rb\` → 118 examples 無修正で全 PASS
- [x] \`bundle exec rspec\` (= full suite) → 585 examples 0 failures
- [x] \`bundle exec rubocop\` → 0 offenses
- [ ] レビュアー: 「controller / service 責務分離」 の 2 軸 (= 「HTTP 入出力 vs ドメインロジック」) が後輩教材として読めるか確認
- [ ] レビュアー: \`record_delivery!\` を controller に残した判断 (= auth 経路でも使う + @raw_body 依存) が妥当か確認

## Day 9 学びとの連動

| 学び | 適用 |
|---|---|
| 学び 27 (= データテーブル構造) | (関連薄) |
| 学び 30 (= Concern vs private 4 観点) | 同型: HTTP 入出力 vs ドメインロジックの責務分離判断 |
| 学び 32 (= 特殊ステート 4 段階) | (関連薄、Struct 分離とは別軸) |
| **新候補 (= 学び 33 候補)** | **fat controller の Service 切り出し判断軸 (= 何を切り出すか / 何を残すか)** = 道具選定の構造化シリーズ 4 例目候補 |

→ 学び 33 として dev-log で確立予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)