### PR TITLE
test: WebhookHealthDataIngestService の unit spec を追加 (Issue #242, Tier 3 完走)

### DIFF
--- a/app/services/webhook_health_data_ingest_service.rb
+++ b/app/services/webhook_health_data_ingest_service.rb
@@ -14,11 +14,13 @@
 #
 # 旧 controller の `WebhooksController::InvalidPayload` は本 service に昇格 (= 例外の発生源と service が同じ場所にある方が読みやすい)。
 #
-# unit spec を独立させなかった判断 (= Tier 2 #4 教材ポイント、学び 33 テスタビリティ軸):
-#   - 既存 `spec/requests/webhooks_spec.rb` (= 110 examples) が controller + service 統合テストとして異常系含め網羅
-#   - 切り出し前後で挙動完全保持 (= 旧 controller の private method を service に移しただけ) のため、回帰テスト網は維持
-#   - 将来 service が webhook 以外の経路 (= 例: Strava ingest / batch 取込) から呼ばれるようになったら独立 unit spec を追加検討
-#   - 「Service 切り出し = 即 unit spec 追加」 を機械的に適用しない (= 既存 spec の網羅性で代替可能なら過剰)
+# unit spec の判断履歴 (= Tier 2 #4 教材ポイント、学び 33 テスタビリティ軸):
+#   - PR #241 (切り出し時): 既存 `spec/requests/webhooks_spec.rb` (= 110 examples) が controller + service 統合テストとして
+#     異常系含め網羅 / 切り出し前後で挙動完全保持のため、unit spec は **将来別経路 (= Strava ingest 等) 追加時に検討** と判断
+#   - PR #244 (= Issue #242 で起票、本日 follow-up 着地): **「契約のドキュメント化」 教材性向上 + 他 service との一貫性**
+#     を主動機に、別経路追加待たず unit spec 前倒し追加 (= `spec/services/webhook_health_data_ingest_service_spec.rb`、22 examples)
+#   - 教材ポイント: 「Service 切り出し = 即 unit spec 追加」 を機械的に適用せず、判定軸 4 つ (= 学び 33) で都度判断する。
+#     **判断の前提が変わったら判断を更新する** (= PR #241 → #244 で teaching moment、weight_dialy の判断ログ運用と一致)。
 class WebhookHealthDataIngestService
   # ペイロード形式違反を表す内部例外。controller の rescue ladder で捕まえて 422 + 監査ログ経路へ。
   # JSON::ParserError や RecordInvalid と並列で 422 経路に流すために導入 (= webhook 受信エンドポイントは

--- a/spec/services/webhook_health_data_ingest_service_spec.rb
+++ b/spec/services/webhook_health_data_ingest_service_spec.rb
@@ -1,0 +1,247 @@
+require "rails_helper"
+
+# Issue #242 (= Tier 3 候補、PR #241 由来) で追加された service 単体 spec。
+#
+# 既存の `spec/requests/webhooks_spec.rb` (= 110 examples) は controller + service の統合テストとして
+# 挙動保持を担保しているが、本 spec は **service の契約をコードでドキュメント化** することを主目的とする
+# (= Day 9 学び 33 テスタビリティ軸: 「Service 切り出し時、別経路から呼ばれるようになったら独立 unit spec 追加」 の準備)。
+#
+# 役割分担:
+#   - request spec (= webhooks_spec): HTTP 入出力 + 認証 + 監査ログ + ステータスコード等の controller 結合検証
+#   - unit spec (= 本 spec): `.call` の引数 → 戻り値 / 例外 の純粋契約、private parse_* の境界値検証
+RSpec.describe WebhookHealthDataIngestService do
+  let(:user) { create(:user) }
+
+  describe ".call" do
+    # ─────────────────────────────────────────────────
+    # 正常系: 戻り値 = accepted_count、副作用 = StepRecord upsert
+    # ─────────────────────────────────────────────────
+    context "正常系" do
+      it "records_data が空配列 → accepted = 0、StepRecord 作成なし" do
+        accepted = described_class.call(records_data: [], user: user)
+        expect(accepted).to eq(0)
+        expect(StepRecord.count).to eq(0)
+      end
+
+      it "1 件のレコード → accepted = 1、StepRecord 1 件作成" do
+        records = [ { "recorded_on" => "2026-05-01", "steps" => 8000, "distance_meters" => 5000, "flights_climbed" => 12 } ]
+        accepted = described_class.call(records_data: records, user: user)
+
+        expect(accepted).to eq(1)
+        expect(StepRecord.count).to eq(1)
+        record = StepRecord.last
+        expect(record.user).to eq(user)
+        expect(record.recorded_on).to eq(Date.new(2026, 5, 1))
+        expect(record.steps).to eq(8000)
+        expect(record.distance_meters).to eq(5000)
+        expect(record.flights_climbed).to eq(12)
+      end
+
+      it "複数レコード → accepted = N、StepRecord N 件作成" do
+        records = [
+          { "recorded_on" => "2026-05-01", "steps" => 8000 },
+          { "recorded_on" => "2026-05-02", "steps" => 9000 },
+          { "recorded_on" => "2026-05-03", "steps" => 7500 }
+        ]
+        accepted = described_class.call(records_data: records, user: user)
+
+        expect(accepted).to eq(3)
+        expect(StepRecord.count).to eq(3)
+      end
+
+      it "既存レコードがあれば update (= upsert: 同じ user + recorded_on で find_or_initialize_by)" do
+        create(:step_record, user: user, recorded_on: Date.new(2026, 5, 1), steps: 1000)
+
+        records = [ { "recorded_on" => "2026-05-01", "steps" => 9999 } ]
+        accepted = described_class.call(records_data: records, user: user)
+
+        expect(accepted).to eq(1)
+        expect(StepRecord.count).to eq(1) # = 新規作成しない、既存を更新
+        expect(StepRecord.last.steps).to eq(9999)
+      end
+
+      it "partial update: ペイロードに無い field は既存値を保持 (= absent ≠ 0 セマンティクス)" do
+        # 既存レコード (steps=1000, distance_meters=500, flights_climbed=10)
+        create(:step_record, user: user, recorded_on: Date.new(2026, 5, 1),
+               steps: 1000, distance_meters: 500, flights_climbed: 10)
+
+        # ペイロードは steps だけ送る
+        records = [ { "recorded_on" => "2026-05-01", "steps" => 8000 } ]
+        described_class.call(records_data: records, user: user)
+
+        record = StepRecord.last
+        expect(record.steps).to eq(8000)
+        expect(record.distance_meters).to eq(500) # = 既存値保持
+        expect(record.flights_climbed).to eq(10)  # = 既存値保持
+      end
+
+      it "整数値の Float (= 8000.0) は Integer に変換して保存" do
+        records = [ { "recorded_on" => "2026-05-01", "steps" => 8000.0 } ]
+        described_class.call(records_data: records, user: user)
+
+        expect(StepRecord.last.steps).to eq(8000)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 異常系: records_data が Array でない → InvalidPayload raise
+    # ─────────────────────────────────────────────────
+    context "InvalidPayload raise (= records_data の型不正)" do
+      it "records_data が nil → raise + StepRecord 作成なし" do
+        expect {
+          described_class.call(records_data: nil, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, I18n.t("webhook.errors.missing_records_array"))
+        expect(StepRecord.count).to eq(0)
+      end
+
+      it "records_data が Hash → raise" do
+        expect {
+          described_class.call(records_data: { "records" => [] }, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload)
+      end
+
+      it "records_data が文字列 → raise" do
+        expect {
+          described_class.call(records_data: "not an array", user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 異常系: recorded_on の形式不正 → InvalidPayload raise (= 旧 parse_recorded_on の境界値)
+    # ─────────────────────────────────────────────────
+    context "InvalidPayload raise (= recorded_on の形式不正)" do
+      it "recorded_on が nil → required エラー" do
+        records = [ { "recorded_on" => nil, "steps" => 8000 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, I18n.t("webhook.errors.recorded_on_required"))
+      end
+
+      it "recorded_on が空文字 → required エラー" do
+        records = [ { "recorded_on" => "", "steps" => 8000 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, I18n.t("webhook.errors.recorded_on_required"))
+      end
+
+      it "recorded_on が ISO 8601 以外 (= 2026/05/01) → invalid_format" do
+        records = [ { "recorded_on" => "2026/05/01", "steps" => 8000 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format"))
+      end
+
+      it "recorded_on の zero padding 不足 (= 2026-5-1) → invalid_format" do
+        # Date.strptime は zero padding 不足を許容するが、本 service は ISO_DATE_FORMAT 正規表現で先に reject
+        records = [ { "recorded_on" => "2026-5-1", "steps" => 8000 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format"))
+      end
+
+      it "recorded_on が月日値域違反 (= 2026-13-99) → invalid_format (Date::Error rescue 経由)" do
+        records = [ { "recorded_on" => "2026-13-99", "steps" => 8000 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, I18n.t("webhook.errors.recorded_on_invalid_format"))
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # 異常系: 数値フィールド型不正 → InvalidPayload raise (= 旧 parse_numeric の境界値)
+    # Apple HealthKit Sample object `{ value: 12345, unit: "count" }` のような silent 0 化を防ぐ
+    # ─────────────────────────────────────────────────
+    context "InvalidPayload raise (= 数値フィールド型不正)" do
+      it "steps が Hash (= HealthKit Sample object 風) → raise (= silent 0 化防止)" do
+        records = [ { "recorded_on" => "2026-05-01", "steps" => { "value" => 12345, "unit" => "count" } } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, /must_be_number|数値|number/i)
+      end
+
+      it "distance_meters が文字列 → raise" do
+        records = [ { "recorded_on" => "2026-05-01", "distance_meters" => "5000" } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload)
+      end
+
+      it "flights_climbed が小数値 Float (= 9999.9) → raise (= silent 切り捨て防止、整数値 Float は別途許容)" do
+        records = [ { "recorded_on" => "2026-05-01", "flights_climbed" => 9999.9 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload, /whole_number|整数/i)
+      end
+
+      it "steps が nil は許容 (= raise しない、partial update セマンティクス)" do
+        # nil は parse_numeric が return nil → updates から compact で除外、
+        # 新規レコードは schema default (= 0) が入る。partial update の真価は既存レコードへの上書きで現れる
+        # (= 上の正常系「partial update: ペイロードに無い field は既存値を保持」 で検証済)。
+        records = [ { "recorded_on" => "2026-05-01", "steps" => nil, "distance_meters" => 5000 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.not_to raise_error
+        expect(StepRecord.last.distance_meters).to eq(5000)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # ActiveRecord::RecordInvalid は service で rescue せず controller に委譲
+    # (= バリデーション違反 = 全体失敗方式、controller 側で 422 + 監査ログ "invalid" 経路へ)
+    # ─────────────────────────────────────────────────
+    context "ActiveRecord::RecordInvalid を controller に委譲" do
+      it "負数 steps は AR バリデーションで raise (= service は rescue しない)" do
+        records = [ { "recorded_on" => "2026-05-01", "steps" => -100 } ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    # ─────────────────────────────────────────────────
+    # トランザクション境界: 1 件失敗で全件ロールバック (= all-or-nothing)
+    # 「リトライ時に同じペイロードを安全に再送できる」 セマンティクスを保証
+    # ─────────────────────────────────────────────────
+    context "トランザクション境界 (= 1 件失敗で全件ロールバック)" do
+      it "2 件中 2 件目が AR バリデーション違反 → 1 件目もロールバック (= StepRecord 0 件)" do
+        records = [
+          { "recorded_on" => "2026-05-01", "steps" => 8000 },
+          { "recorded_on" => "2026-05-02", "steps" => -100 } # 負数 → AR バリデーション違反
+        ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(StepRecord.count).to eq(0) # = 1 件目も保存されていない
+      end
+
+      it "3 件中 2 件目が parse 失敗 → 1 件目もロールバック (= InvalidPayload も transaction 内で発生)" do
+        records = [
+          { "recorded_on" => "2026-05-01", "steps" => 8000 },
+          { "recorded_on" => "2026/05/02", "steps" => 9000 }, # 形式不正 → InvalidPayload
+          { "recorded_on" => "2026-05-03", "steps" => 7500 }
+        ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(WebhookHealthDataIngestService::InvalidPayload)
+
+        expect(StepRecord.count).to eq(0)
+      end
+
+      it "既存レコードがある状態で失敗 → 既存レコードは変更されない" do
+        existing = create(:step_record, user: user, recorded_on: Date.new(2026, 5, 1), steps: 1000)
+
+        records = [
+          { "recorded_on" => "2026-05-01", "steps" => 9999 }, # 既存を更新する予定
+          { "recorded_on" => "2026-05-02", "steps" => -100 }  # 失敗
+        ]
+        expect {
+          described_class.call(records_data: records, user: user)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(existing.reload.steps).to eq(1000) # = 更新されていない
+      end
+    end
+  end
+end

--- a/spec/services/webhook_health_data_ingest_service_spec.rb
+++ b/spec/services/webhook_health_data_ingest_service_spec.rb
@@ -9,6 +9,12 @@ require "rails_helper"
 # 役割分担:
 #   - request spec (= webhooks_spec): HTTP 入出力 + 認証 + 監査ログ + ステータスコード等の controller 結合検証
 #   - unit spec (= 本 spec): `.call` の引数 → 戻り値 / 例外 の純粋契約、private parse_* の境界値検証
+#
+# 本 spec で **検証しない** もの (= 逆引き、後輩教材として境界明示):
+#   - HTTP ヘッダ / 認証トークン / ステータスコード (401 / 422 / 200) → webhooks_spec 担当
+#   - WebhookDelivery 監査ログの内容 → webhooks_spec 担当
+#   - I18n.t() の翻訳結果 (= 文面そのもの) → 翻訳変更で壊れない bilingual 耐性のため、
+#     キー名のキーワード一致 regex (= `/must_be_number|数値|number/i`) で意図検証する
 RSpec.describe WebhookHealthDataIngestService do
   let(:user) { create(:user) }
 
@@ -151,6 +157,11 @@ RSpec.describe WebhookHealthDataIngestService do
     # ─────────────────────────────────────────────────
     # 異常系: 数値フィールド型不正 → InvalidPayload raise (= 旧 parse_numeric の境界値)
     # Apple HealthKit Sample object `{ value: 12345, unit: "count" }` のような silent 0 化を防ぐ
+    #
+    # NOTE: 以下の regex assertion は **I18n キー名のキーワード一致** で検証する設計 (= `/must_be_number/` や `/whole_number/`)。
+    # 翻訳文面 (= ja.yml の値) に depend させないことで、文言改善 / 英語 fallback / 多言語化に耐える。
+    # 「I18n.t() で完全一致」 では補間引数 (%{field} / %{value}) の都合で展開が不安定、
+    # 「実展開文字列を regex」 では翻訳変更で簡単に壊れる、という両極を避けた中庸として採用。
     # ─────────────────────────────────────────────────
     context "InvalidPayload raise (= 数値フィールド型不正)" do
       it "steps が Hash (= HealthKit Sample object 風) → raise (= silent 0 化防止)" do
@@ -183,6 +194,7 @@ RSpec.describe WebhookHealthDataIngestService do
           described_class.call(records_data: records, user: user)
         }.not_to raise_error
         expect(StepRecord.last.distance_meters).to eq(5000)
+        expect(StepRecord.last.steps).to eq(0) # = schema default、コードコメントの主張を assertion で証明
       end
     end
 
@@ -202,6 +214,10 @@ RSpec.describe WebhookHealthDataIngestService do
     # ─────────────────────────────────────────────────
     # トランザクション境界: 1 件失敗で全件ロールバック (= all-or-nothing)
     # 「リトライ時に同じペイロードを安全に再送できる」 セマンティクスを保証
+    #
+    # NOTE: rails_helper の `use_transactional_fixtures = true` 配下では各 example が SAVEPOINT でラップされ
+    # テスト後に自動ロールバックされる。service 内 `StepRecord.transaction` は SAVEPOINT をネストする形になり、
+    # Rails のデフォルト動作で内側 SAVEPOINT が ROLLBACK TO SAVEPOINT され期待通りに動作する。
     # ─────────────────────────────────────────────────
     context "トランザクション境界 (= 1 件失敗で全件ロールバック)" do
       it "2 件中 2 件目が AR バリデーション違反 → 1 件目もロールバック (= StepRecord 0 件)" do


### PR DESCRIPTION
closes #242

ダッシュボード Tier 3 唯一の候補 (= PR #241 由来) を完走。本 PR マージで **Tier 2 + Tier 3 ともに更地化** (= 残るは Tier 1 大物 3 件)。

## Summary

PR #241 (= Tier 2 #4 完走、\`WebhookHealthDataIngestService\` 切り出し) の 3 者並列レビューで code-reviewer + strategic-reviewer 共通🟢 提案 (= service unit spec 独立化) を別 Issue #242 に切り出して吸収。本 PR で実装。

## 役割分担 (= 既存 request spec との関係)

| spec | 役割 |
|---|---|
| \`spec/requests/webhooks_spec.rb\` (= 110 examples) | HTTP 入出力 + 認証 + 監査ログ + ステータスコード等の **controller 結合検証** |
| \`spec/services/webhook_health_data_ingest_service_spec.rb\` (= 本 PR、22 examples) | \`.call\` の引数 → 戻り値 / 例外の **純粋契約**、private parse_* の **境界値検証** |

## カバー範囲 (= 22 examples、6 context)

| context | 件数 | 検証内容 |
|---|---|---|
| 正常系 | 6 | 空配列 / 1 件 / 複数 / upsert / partial update / 整数値 Float |
| InvalidPayload (records_data 型不正) | 3 | nil / Hash / 文字列 |
| InvalidPayload (recorded_on 形式不正) | 5 | nil / 空文字 / \`2026/05/01\` / \`2026-5-1\` / \`2026-13-99\` (Date::Error rescue 経由) |
| InvalidPayload (数値フィールド型不正) | 4 | Hash (= HealthKit Sample object 風) / 文字列 / 小数 Float / nil 許容 |
| AR RecordInvalid 委譲 | 1 | service は rescue しない、controller に委譲 |
| トランザクション境界 | 3 | AR バリデーション違反 / parse 失敗 / 既存レコード保護 |

## Day 9 学び 33 テスタビリティ軸との連動

学び 33 で確立した「Service 切り出し時、別経路から呼ばれるようになったら独立 unit spec 追加」 の **準備実装**。本 PR 時点では「将来別経路から呼ばれた時の安全網」 だが、**「service の契約をコードでドキュメント化する」 教材性向上** が即時の主目的。

既存 request spec で挙動保持は担保済 (= PR #241 で 110 examples 無修正で全 PASS) の上で **追加で** unit spec を持つ構造。プロジェクト慣習 (= 他 service `build_home_dashboard_service_spec.rb` / `calorie_advice_service_spec.rb` 等は全て unit spec 持ち) との一貫性確保。

## 影響範囲 (= 1 ファイル、+247 行)

- \`spec/services/webhook_health_data_ingest_service_spec.rb\` (= 新規)
- 既存実装 / 既存 spec: **無修正** (= 純粋テスト追加)

## レビュー方針 (= 軽量 Issue)

本 PR は **軽量 Issue** (= 1 ファイル / spec 追加のみ / 既存挙動変更なし) のため、3 者並列レビューで出た **🟡 軽微 + 🟢 提案を別 Issue に分離せず、本 PR の追加コミットですべて吸収** します。

## Test plan

- [x] \`bundle exec rspec spec/services/webhook_health_data_ingest_service_spec.rb\` → 22 examples 0 failures
- [x] \`bundle exec rspec\` (= full suite) → 607 examples 0 failures (= 旧 585 + 22)
- [x] \`bundle exec rubocop spec/services/webhook_health_data_ingest_service_spec.rb\` → 0 offenses
- [ ] レビュアー: 役割分担 (= request spec vs unit spec) の境界が後輩教材として読めるか確認
- [ ] レビュアー: 6 context の構造化 (= 正常系 / InvalidPayload 3 種 / AR 委譲 / トランザクション境界) が適切か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)