### PR TITLE
polish: Settings Capacitor 検知セクションに Health Connect データソース要件ガイダンスを追加 (#218)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -159,6 +159,17 @@ body {
   color: var(--ink-2); font-size: 13px; line-height: 1.4;
 }
 
+/* 注記ブロック (= 補足情報の視覚明示)。border-left で「ここは追加情報」 を一目で示す。
+   Issue #218 で確立 (= sketch-box 内の paper-2 背景だけだと外側 paper との contrast が 1.08:1 で区別不能、
+   border-left + paper-2 + line-height で「補足」 「警告」 のフラグ機能が働く)。 */
+.sketch-note {
+  border-left: 3px solid var(--ink-2);
+  background: var(--paper-2);
+  padding: 8px 12px;
+  border-radius: 4px;
+  line-height: 1.5;
+}
+
 /* status バッジ。border-radius + padding + 黒文字 (6.73:1 / 7:1+) で AA 確実。 */
 .sketch-status {
   display: inline-block; padding: 2px 8px; border: 1px solid var(--ink); border-radius: 4px;

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -114,11 +114,11 @@
     </p>
 
     <%# Issue #218: 同期前事前ガイダンス。Health Connect 自体にデータが届いていないと同期成功 (= 200 OK)
-        でも 0 歩で保存される事故 (= 局長実体験由来、PR #206 で同期後警告と二段構え) を未然に防ぐ。 %>
-    <p class="sketch-small"
-       style="background: var(--paper-2); padding: 8px 12px; border-radius: 4px; margin-bottom: 12px;">
-      ※ Health Connect に <strong>Google Fit / Samsung Health 等の書き込み許可</strong>が必要です。
-      同期して 0 歩のままの場合は、<strong>Health Connect → データとアクセス</strong> で書き込みアプリの設定をご確認ください。
+        でも 0 歩で保存される事故 (= 局長実体験由来、PR #206 で同期後警告と二段構え) を未然に防ぐ。
+        sketch-note クラス (= sketchy.css、border-left + paper-2 背景) で「補足」 視覚明示。 %>
+    <p class="sketch-small sketch-note" style="margin-bottom: 12px;">
+      ※ 歩数アプリ (<strong>Google Fit</strong> や <strong>Samsung Health</strong> など) から Health Connect へデータが渡る設定になっているとスムーズに同期できます。
+      0 歩のままの場合は、Health Connect アプリの「<strong>データとアクセス</strong>」 で書き込み設定をご確認ください。
     </p>
 
     <p data-native-health-target="status" class="sketch-body-text" style="margin-bottom: 16px;">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -112,6 +112,15 @@
     <p class="sketch-small" style="margin-bottom: 12px;">
       Android アプリ版で Health Connect から歩数 / 距離 / 階段を取得 → サーバーへ自動同期します。
     </p>
+
+    <%# Issue #218: 同期前事前ガイダンス。Health Connect 自体にデータが届いていないと同期成功 (= 200 OK)
+        でも 0 歩で保存される事故 (= 局長実体験由来、PR #206 で同期後警告と二段構え) を未然に防ぐ。 %>
+    <p class="sketch-small"
+       style="background: var(--paper-2); padding: 8px 12px; border-radius: 4px; margin-bottom: 12px;">
+      ※ Health Connect に <strong>Google Fit / Samsung Health 等の書き込み許可</strong>が必要です。
+      同期して 0 歩のままの場合は、<strong>Health Connect → データとアクセス</strong> で書き込みアプリの設定をご確認ください。
+    </p>
+
     <p data-native-health-target="status" class="sketch-body-text" style="margin-bottom: 16px;">
       確認中...
     </p>


### PR DESCRIPTION
closes #218

## Summary

局長実体験由来の事前案内追加 (= 同期して 0 歩のままになる事故を未然に防ぐ)。Settings の Capacitor 検知セクションに、**Google Fit / Samsung Health 等の書き込み許可が必要** 旨のガイダンスを sketch-small 注記ブロックで明示。

## 二段構え誘導

| 段階 | 場所 | 実装 |
|---|---|---|
| 同期前 (= **本 PR**) | Settings UI | 「Google Fit / Samsung Health 書き込み許可必要」 + 「Health Connect → データとアクセス」 への具体的アクション誘導 |
| 同期後 (= 既実装) | PR #206 (= \`native_health_controller.js\` の \`formatSummary\`) | 0 歩時の警告 + 「データソース確認」 誘導 |

## 影響範囲

- \`app/views/settings/show.html.erb\` (= +9 行、Capacitor 検知セクション内に sketch-small 注記追加)
- 既存挙動: 完全保持

## レビュー方針 (= 軽量 Issue)

本 PR は **軽量 Issue** (= 1 ファイル / +9 行 / view 文言追加のみ) のため、3 者並列レビューで出た **🟡 軽微 + 🟢 提案を別 Issue に分離せず、本 PR の追加コミットですべて吸収** します。

## Test plan

- [x] \`bundle exec rspec spec/requests\` → 276 examples 0 failures
- [ ] レビュアー: ガイダンス文言が局長実体験 (= デイリーステップアプリは Health Connect 非対応 → Google Fit 導入で解決) を踏まえて適切な誘導になっているか確認
- [ ] レビュアー: sketch-small 注記の配置 (= description 直後、status 直前) が UX 上妥当か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)