### PR TITLE
polish: privacy / terms 改訂履歴セクションを <h2> + <ul> に構造化 (#91)

### DIFF
--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -99,13 +99,15 @@
   </div>
 
   <%# 改訂履歴セクション (= Issue #91): 1 行詰込から `<h2>` + `<ul>` 構造化に。
-      table でなく ul を選んだ理由 = 2-3 行の少数項目では table が overkill、ul が semantic で軽量 (= "日付 — 内容" の年表形式)。 %>
-  <div style="margin-top: 16px;">
-    <h2 class="sketch-h" style="margin-bottom: 8px;">改訂履歴</h2>
-    <ul class="sketch-small" style="color: var(--muted); margin: 0; padding-left: 1.2em; line-height: 1.6;">
-      <li>2026-05-05 — 初版公開</li>
-      <li>2026-05-05 — 事業者表示追加・消費者契約法対応</li>
-      <li>2026-05-06 — Android Health Connect 経由の取得情報を明記</li>
+      table でなく ul を選んだ理由 = 1 軸 (= 時系列のみ) なので何件あっても ul が筋、軸数 ≥ 2 で初めて table 検討
+      (= 「table 使いたい衝動は件数でなく軸数で殺す」、Issue #178 本文に判断ルール追記済)。
+      他セクションと整合させるため「10. 改訂履歴」 として番号付き昇格 + sketch-box 包み。 %>
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">10. 改訂履歴</h2>
+    <ul class="sketch-small" style="color: var(--ink-2); margin: 0; padding-left: 1.2em; line-height: 1.6;">
+      <li><strong>2026-05-05</strong> — 初版公開</li>
+      <li><strong>2026-05-05</strong> — 事業者表示追加・消費者契約法対応</li>
+      <li><strong>2026-05-06</strong> — Android Health Connect 経由の取得情報を明記</li>
     </ul>
   </div>
 

--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -98,8 +98,15 @@
     </p>
   </div>
 
-  <p class="sketch-small" style="color: var(--muted); margin-top: 8px;">
-    改訂履歴: 2026-05-05 初版公開 / 2026-05-05 事業者表示追加・消費者契約法対応 / 2026-05-06 Android Health Connect 経由の取得情報を明記
-  </p>
+  <%# 改訂履歴セクション (= Issue #91): 1 行詰込から `<h2>` + `<ul>` 構造化に。
+      table でなく ul を選んだ理由 = 2-3 行の少数項目では table が overkill、ul が semantic で軽量 (= "日付 — 内容" の年表形式)。 %>
+  <div style="margin-top: 16px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">改訂履歴</h2>
+    <ul class="sketch-small" style="color: var(--muted); margin: 0; padding-left: 1.2em; line-height: 1.6;">
+      <li>2026-05-05 — 初版公開</li>
+      <li>2026-05-05 — 事業者表示追加・消費者契約法対応</li>
+      <li>2026-05-06 — Android Health Connect 経由の取得情報を明記</li>
+    </ul>
+  </div>
 
 </div>

--- a/app/views/legal/terms.html.erb
+++ b/app/views/legal/terms.html.erb
@@ -68,8 +68,14 @@
     </p>
   </div>
 
-  <p class="sketch-small" style="color: var(--muted); margin-top: 8px;">
-    改訂履歴: 2026-05-05 初版公開 / 2026-05-05 事業者表示追加・消費者契約法対応
-  </p>
+  <%# 改訂履歴セクション (= Issue #91): 1 行詰込から `<h2>` + `<ul>` 構造化に。
+      table でなく ul を選んだ理由 = 2-3 行の少数項目では table が overkill、ul が semantic で軽量 (= "日付 — 内容" の年表形式)。 %>
+  <div style="margin-top: 16px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">改訂履歴</h2>
+    <ul class="sketch-small" style="color: var(--muted); margin: 0; padding-left: 1.2em; line-height: 1.6;">
+      <li>2026-05-05 — 初版公開</li>
+      <li>2026-05-05 — 事業者表示追加・消費者契約法対応</li>
+    </ul>
+  </div>
 
 </div>

--- a/app/views/legal/terms.html.erb
+++ b/app/views/legal/terms.html.erb
@@ -69,12 +69,14 @@
   </div>
 
   <%# 改訂履歴セクション (= Issue #91): 1 行詰込から `<h2>` + `<ul>` 構造化に。
-      table でなく ul を選んだ理由 = 2-3 行の少数項目では table が overkill、ul が semantic で軽量 (= "日付 — 内容" の年表形式)。 %>
-  <div style="margin-top: 16px;">
-    <h2 class="sketch-h" style="margin-bottom: 8px;">改訂履歴</h2>
-    <ul class="sketch-small" style="color: var(--muted); margin: 0; padding-left: 1.2em; line-height: 1.6;">
-      <li>2026-05-05 — 初版公開</li>
-      <li>2026-05-05 — 事業者表示追加・消費者契約法対応</li>
+      table でなく ul を選んだ理由 = 1 軸 (= 時系列のみ) なので何件あっても ul が筋、軸数 ≥ 2 で初めて table 検討
+      (= 「table 使いたい衝動は件数でなく軸数で殺す」、Issue #178 本文に判断ルール追記済)。
+      他セクションと整合させるため「8. 改訂履歴」 として番号付き昇格 + sketch-box 包み。 %>
+  <div class="sketch-box" style="margin-bottom: 20px;">
+    <h2 class="sketch-h" style="margin-bottom: 8px;">8. 改訂履歴</h2>
+    <ul class="sketch-small" style="color: var(--ink-2); margin: 0; padding-left: 1.2em; line-height: 1.6;">
+      <li><strong>2026-05-05</strong> — 初版公開</li>
+      <li><strong>2026-05-05</strong> — 事業者表示追加・消費者契約法対応</li>
     </ul>
   </div>
 


### PR DESCRIPTION
closes #91

## Summary

PR #38 の design-reviewer 指摘 (= 「将来更新が重なると 1 行に詰め込まれて読み飛ばされる」) を解消。改訂履歴を **`<h2>` + `<ul>` 年表形式** に構造化。

## Before / After

### Before (= 1 行詰込)
\`\`\`erb
<p class="sketch-small" style="color: var(--muted); margin-top: 8px;">
  改訂履歴: 2026-05-05 初版公開 / 2026-05-05 事業者表示追加・消費者契約法対応 / 2026-05-06 Android Health Connect 経由の取得情報を明記
</p>
\`\`\`

### After (= 構造化、privacy 例)
\`\`\`erb
<div style="margin-top: 16px;">
  <h2 class="sketch-h" style="margin-bottom: 8px;">改訂履歴</h2>
  <ul class="sketch-small" style="color: var(--muted); margin: 0; padding-left: 1.2em; line-height: 1.6;">
    <li>2026-05-05 — 初版公開</li>
    <li>2026-05-05 — 事業者表示追加・消費者契約法対応</li>
    <li>2026-05-06 — Android Health Connect 経由の取得情報を明記</li>
  </ul>
</div>
\`\`\`

## 設計判断 (= table vs ul)

| 案 | 評価 |
|---|---|
| `<table class="sketch-table">` (= Issue 提案) | ⭐⭐ thead / tbody の semantic は強いが、`sketch-table` クラス未定義 + 2-3 行で overkill |
| **`<ul>` + 「日付 — 内容」 年表形式 (= 採用)** | ⭐⭐⭐ semantic + 軽量、em-dash で視覚分離、10 件超えたら table 検討 |
| 現状維持 (= 1 行詰込) | ⭐ 1 行で読み飛ばされる、design-reviewer 指摘そのまま |

## 影響範囲

- \`app/views/legal/privacy.html.erb\` (= +9/-3 行)
- \`app/views/legal/terms.html.erb\` (= +9/-3 行)
- 既存 spec: 無修正で全 PASS

## レビュー方針 (= 軽量 Issue)

本 PR は **軽量 Issue** (= 2 ファイル / +18/-6 行 / view 構造化のみ) のため、3 者並列レビュー🟡🟢 全件本 PR 内吸収予定。

## Test plan

- [x] \`bundle exec rspec spec/requests/legal_spec.rb\` → 19 examples 0 failures
- [ ] レビュアー: ul 採用の判断 (= table overkill) が後輩教材として読めるか確認
- [ ] レビュアー: em-dash「—」 の視覚分離効果が日付 / 内容で機能しているか確認
- [ ] レビュアー: `sketch-h` + `sketch-small` の組合せが既存 legal ページの他セクション (= 7. 第三者提供 / 8. 利用者の権利 等) と整合しているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)