### PR TITLE
polish: ゲストバナーに SNS 内蔵ブラウザ OAuth 詰まり案内を追加 (#143)

### DIFF
--- a/app/views/home/_banner_guest.html.erb
+++ b/app/views/home/_banner_guest.html.erb
@@ -8,9 +8,11 @@
       </p>
       <%# Issue #143: SNS 内蔵ブラウザ (LINE / X (Twitter) / Instagram 等) では Google OAuth callback が
           外部ブラウザへ戻れず認証フローが破綻する (= PR #142 で `; wv)` bypass を通すが OAuth は詰まる対策)。
-          QR / SNS シェア由来の流入を救うため、外部ブラウザへの誘導を案内。 %>
-      <p class="sketch-small" style="margin-top: 4px;">
-        ※ LINE / X (Twitter) / Instagram 等の <strong>SNS 内蔵ブラウザ</strong> ではログインできません。<strong>Safari / Chrome</strong> でお開きください。
+          QR / SNS シェア由来の流入を救うため、外部ブラウザへの誘導を案内。
+          コピーは **肯定形先置き** (= 「Safari/Chrome で使える」 を先) で 3 ステップ思想 ① 「罪悪感を減らす / できる前提」 トーンに整合。
+          color: var(--muted) で sketch-banner-text (ink-2) との階層差を確保 (= 補足情報の視覚識別)。 %>
+      <p class="sketch-small" style="margin-top: 4px; color: var(--muted);">
+        <strong>Safari / Chrome</strong> からアクセスすると Google ログインが使えます。LINE や X 等の内蔵ブラウザはご注意ください。
       </p>
     </div>
   </div>

--- a/app/views/home/_banner_guest.html.erb
+++ b/app/views/home/_banner_guest.html.erb
@@ -6,6 +6,12 @@
       <p class="sketch-banner-text">
         これは<strong>サンプルデータ</strong>です。Google でログインすると、自分の歩数データを記録できます。
       </p>
+      <%# Issue #143: SNS 内蔵ブラウザ (LINE / X (Twitter) / Instagram 等) では Google OAuth callback が
+          外部ブラウザへ戻れず認証フローが破綻する (= PR #142 で `; wv)` bypass を通すが OAuth は詰まる対策)。
+          QR / SNS シェア由来の流入を救うため、外部ブラウザへの誘導を案内。 %>
+      <p class="sketch-small" style="margin-top: 4px;">
+        ※ LINE / X (Twitter) / Instagram 等の <strong>SNS 内蔵ブラウザ</strong> ではログインできません。<strong>Safari / Chrome</strong> でお開きください。
+      </p>
     </div>
   </div>
   <div class="sketch-banner-action"


### PR DESCRIPTION
closes #143

## Summary

PR #142 の design-reviewer 指摘 (= 「\`; wv)\` bypass で LINE 等の内蔵ブラウザはアクセス通るが Google OAuth callback で詰まる」) を解消。ゲストバナーに **SNS 内蔵ブラウザ警告 + 外部ブラウザ誘導** を sketch-small 注記で 1 行追加。

## 実装 (= 案 A、Issue #143 推奨案)

\`_banner_guest.html.erb\` の \`sketch-banner-text\` 直後に sketch-small 注記を追加:

\`\`\`erb
<p class="sketch-small" style="margin-top: 4px;">
  ※ LINE / X (Twitter) / Instagram 等の <strong>SNS 内蔵ブラウザ</strong> ではログインできません。<strong>Safari / Chrome</strong> でお開きください。
</p>
\`\`\`

## 設計判断 (= 3 案検討)

| 案 | 内容 | 採否 | 理由 |
|---|---|---|---|
| **A (採用)** | 全ゲスト向け常時表示 (= 1 行追加) | ✅ | 1 行で完結、保守コストなし |
| B | UA 判定 + 専用バナー | ❌ | 中量、UA 判定ロジック保守コストあり |
| C | \`; wv)\` bypass 削除 | ❌ | overrideUserAgent が壊れた時の保険喪失リスク |

## 文言の設計

- **strong 強調**: 「SNS 内蔵ブラウザ」 (= 問題の主体) + 「Safari / Chrome」 (= 解決策の主体)
- 「※」 接頭辞: 既存パターン (= privacy 改訂履歴の sketch-small + ※) と整合
- カジュアル層に伝わる固有名詞 (= LINE / X (Twitter) / Instagram) を例示

## 影響範囲

- \`app/views/home/_banner_guest.html.erb\` (= +6 行、注記コメント込み)
- 既存 spec: banner partial の主要テキストは無修正、回帰なし

## レビュー方針 (= 軽量 Issue)

本 PR は **軽量 Issue** (= 1 ファイル / +6 行 / view 文言追加のみ) のため、3 者並列レビュー🟡🟢 全件本 PR 内吸収予定。

## Test plan

- [x] \`bundle exec rspec spec/requests/home_spec.rb\` → 既存挙動保持
- [ ] レビュアー: 全ゲスト向け常時表示 (= 案 A) の判断が UX 上妥当か確認 (= 関係ない外部ブラウザユーザーへのノイズ vs 流入救済の ROI)
- [ ] レビュアー: 文言 + strong 強調がカジュアル層に伝わるか確認
- [ ] レビュアー: sketch-small + margin-top: 4px の配置が sketch-banner-body 内で破綻していないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)