### PR TITLE
polish: 食品換算表示のトーンを「if 条件」 → 「過去肯定」 に再構成 (#235)

### DIFF
--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -195,8 +195,12 @@
         <h3 class="sketch-h" style="flex: 1; margin: 0;"><%= advice.headline %></h3>
       </div>
       <% if advice.items.any? %>
+        <%# Issue #235: 「+X kcal **なら**…」 (= if 条件、未来への口実化リスク = 「これから食べていい」 と読み替えられる) を、
+            「**今日 +X kcal 動いた** ぶん、たとえば…」 (= 過去肯定 + 換算例示) に再構成。
+            3 ステップ思想 ① 「罪悪感を減らす」 = 過去への肯定 (= 「これだけ動いた」) を強調、
+            未来への口実化 (= 「ご褒美感」) を排除。 %>
         <div class="sketch-small">
-          きょうのプラスα消費 <strong>+<%= today_kcal %> kcal</strong> なら…
+          今日 <strong>+<%= today_kcal %> kcal</strong> 動いたぶん、たとえば…
         </div>
         <ul style="margin: 8px 0 0 16px; padding: 0; list-style: disc;">
           <% advice.items.each do |item| %>

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -198,9 +198,11 @@
         <%# Issue #235: 「+X kcal **なら**…」 (= if 条件、未来への口実化リスク = 「これから食べていい」 と読み替えられる) を、
             「**今日 +X kcal 動いた** ぶん、たとえば…」 (= 過去肯定 + 換算例示) に再構成。
             3 ステップ思想 ① 「罪悪感を減らす」 = 過去への肯定 (= 「これだけ動いた」) を強調、
-            未来への口実化 (= 「ご褒美感」) を排除。 %>
+            未来への口実化 (= 「ご褒美感」) を排除。
+            「動いた」 に sketch-hl-yellow ハイライトで 2 点強調 (= +X kcal strong + 動いた yellow = 「数字 = 量」 + 「動詞 = 事実」)、
+            プロジェクタ大画面 3 秒テストでの達成カード認識性向上 (= design-reviewer 提案)。 %>
         <div class="sketch-small">
-          今日 <strong>+<%= today_kcal %> kcal</strong> 動いたぶん、たとえば…
+          今日 <strong>+<%= today_kcal %> kcal</strong> <span class="sketch-hl-yellow">動いた</span>ぶん、たとえば…
         </div>
         <ul style="margin: 8px 0 0 16px; padding: 0; list-style: disc;">
           <% advice.items.each do |item| %>


### PR DESCRIPTION
closes #235

## Summary

Issue #235 (= 唐揚げ等の高頻度ヒット食品でご褒美化リスクを下げるコピー検討) の **案 B (= 「過去への肯定」 トーン)** を採用、3 ステップ思想 ① 「罪悪感を減らす」 と整合。

## Before / After

| 旧 (= if 条件) | 新 (= 過去肯定) |
|---|---|
| きょうのプラスα消費 **+400 kcal なら**… | **今日 +400 kcal 動いた** ぶん、**たとえば**… |
| 「なら」 = if 条件 → **「これから食べていい」 と読み替えるリスク** | 「動いた」 = 過去動詞 + 「たとえば」 = 換算例示 → **過去への肯定** |

## 3 ステップ思想 ① との整合

- ✅ 想定: 「これだけ動いた = 過去の食事を相殺できた」 という **過去への肯定**
- ❌ リスク: 「これだけ動いた = これから食べていい」 という **未来への口実化** (= ご褒美化リスク)

特に **唐揚げ 80 kcal/個** は 400 kcal 程度で 5 個 cap に達しやすく seed ヒット確率が他食品比で高いため、**コピーレベルでの予防** が効く (= データ変更なしで実現)。

## 採否検討 (= Issue #235 内 5 案)

| 案 | 内容 | 採否 |
|---|---|---|
| A | 食品マスタから唐揚げ除外 | ❌ 大、発表会受け食品揃え変更、v1.1 議論 |
| **B** | **文言を「過去への肯定」 に振り切る (= 採用)** | ✅ コピー変更のみで完結、ROI 最高 |
| C | 唐揚げ kcal を上げてヒット頻度低下 | ❌ データ調整 + spec 変更必要、35 分超過リスク |
| D | フォールバック専用コピー流用 | ❌ ロジック分岐追加、中量 |
| E | 現状維持 | ❌ リスク内在し続ける |

## 影響範囲

- \`app/views/home/_dashboard.html.erb\` (= +6 行 / -3 行、ERB コメント込み)
- 既存 spec: **無修正で全 PASS**

## レビュー方針 (= 軽量 Issue)

本 PR は **軽量 Issue** (= 1 ファイル / +6 行 / コピー変更のみ) のため、3 者並列レビュー🟡🟢 全件本 PR 内吸収予定。

## Test plan

- [x] \`bundle exec rspec spec/requests/home_spec.rb\` → 44 examples 0 failures
- [ ] レビュアー: 「動いたぶん、たとえば…」 が 3 ステップ思想 ① と整合しているか確認
- [ ] レビュアー: 「ぶん」 (= 量を示す古風な表現) がカジュアル層に伝わるか確認
- [ ] レビュアー: ERB コメントで「過去肯定 vs 未来口実化」 の判断軸が後輩教材として読めるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)