### PR TITLE
polish: 食品換算カードを 2 行構成 + 絵文字ハイライト化 (#236)

### DIFF
--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -304,7 +304,16 @@
     <div class="sketch-label">🔥 消費</div>
     <div class="sketch-hh">+<%= today_kcal %> <span class="sketch-small">kcal</span></div>
     <% if food_equivalent %>
-      <div class="sketch-small sketch-food-equivalent">≒ <%= food_equivalent[:emoji] %> <%= food_equivalent[:name] %> <%= food_equivalent[:count] %> <%= food_equivalent[:unit] %>ぶん</div>
+      <%# Issue #236: 食品換算カードを 2 行構成 + 絵文字ハイライト化 (= プロジェクタ大画面 3 秒テストでのインパクト向上)。
+          階層: 大 = +X kcal (sketch-hh) / 中 = 絵文字 (sketch-h) / 小 = 食品名 + 数量 (sketch-small)。
+          常時適用 (= フォールバック判定は service 改修が必要、別 Issue 規模)。
+          line-height: 1.0 で絵文字行の縦余白を詰めて 3 階層バランス確保。 %>
+      <div class="sketch-h sketch-food-equivalent" style="text-align: center; margin-top: 6px; line-height: 1.0;">
+        <%= food_equivalent[:emoji] %>
+      </div>
+      <div class="sketch-small sketch-food-equivalent" style="text-align: center;">
+        ≒ <%= food_equivalent[:name] %> <%= food_equivalent[:count] %> <%= food_equivalent[:unit] %>ぶん
+      </div>
     <% else %>
       <div class="sketch-small">今日のプラスα</div>
     <% end %>

--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -307,15 +307,17 @@
       <%# Issue #236: 食品換算カードを 2 行構成 + 絵文字ハイライト化 (= プロジェクタ大画面 3 秒テストでのインパクト向上)。
           階層: 大 = +X kcal (sketch-hh) / 中 = 絵文字 (sketch-h) / 小 = 食品名 + 数量 (sketch-small)。
           常時適用 (= フォールバック判定は service 改修が必要、別 Issue 規模)。
-          line-height: 1.0 で絵文字行の縦余白を詰めて 3 階層バランス確保。 %>
-      <div class="sketch-h sketch-food-equivalent" style="text-align: center; margin-top: 6px; line-height: 1.0;">
+          絵文字行に sketch-food-equivalent (= white-space: nowrap + overflow: hidden + ellipsis) は付けない:
+          このクラスは旧 1 行構成で長い食品名の折り返し防止用、絵文字 1 文字には不要かつ clip リスク
+          (= code-reviewer 指摘)。文言行のみ sketch-food-equivalent を保持。 %>
+      <div class="sketch-h" style="text-align: center; margin-top: 6px;">
         <%= food_equivalent[:emoji] %>
       </div>
       <div class="sketch-small sketch-food-equivalent" style="text-align: center;">
         ≒ <%= food_equivalent[:name] %> <%= food_equivalent[:count] %> <%= food_equivalent[:unit] %>ぶん
       </div>
     <% else %>
-      <div class="sketch-small">今日のプラスα</div>
+      <div class="sketch-small">今日はまだ記録なし</div>
     <% end %>
   </div>
 


### PR DESCRIPTION
closes #236

## Summary

Issue #236 (= プロジェクタ大画面でのインパクト向上、PR #232 design-reviewer 提案由来) の 2 行構成提案を採用。**常時適用** で実装 (= フォールバック判定は service 改修が必要で別 Issue 規模)。

## 階層設計 (= 3 階層バランス)

| 階層 | 要素 | クラス | 役割 |
|---|---|---|---|
| **大** | +X kcal | sketch-hh | 消費カード主要数値、最大強調 |
| **中** | 🍫 (絵文字) | sketch-h (= 新規追加) | 視覚アクセント、3 秒テストでの認識性 ↑ |
| **小** | ≒ 板チョコ 5 枚ぶん | sketch-small | 食品名 + 数量、補足情報 |

## 設計判断 (= Issue 内検討事項への対応)

| 検討事項 | 採否 | 理由 |
|---|---|---|
| 絵文字を `sketch-hh` で単独表示 (= Issue 案) | ❌ | +X kcal の sketch-hh と二重強調で焦点分散、`sketch-h` に格下げで階層差確保 |
| 常時適用 (= 採用) | ✅ | service 改修不要、軽量 1 PR で完結 |
| フォールバック時のみ適用 | ❌ | count cap 値判定は service 内部状態、view から判定不可、別 Issue / 別 PR 規模 |

## Before / After

### Before (= 1 行構成)
```erb
<div class="sketch-small sketch-food-equivalent">
  ≒ 🍫 板チョコ 5 枚ぶん
</div>
```

### After (= 2 行構成、3 階層バランス)
```erb
<div class="sketch-h sketch-food-equivalent" style="text-align: center; margin-top: 6px; line-height: 1.0;">
  🍫
</div>
<div class="sketch-small sketch-food-equivalent" style="text-align: center;">
  ≒ 板チョコ 5 枚ぶん
</div>
```

## 影響範囲

- \`app/views/home/_dashboard.html.erb\` (= +9 / -1 行、ERB コメント込み)
- 既存 spec: 無修正で全 PASS

## レビュー方針 (= 軽量 Issue)

本 PR は **軽量 Issue** (= 1 ファイル / +9 行 / view 構造変更のみ) のため、3 者並列レビュー🟡🟢 全件本 PR 内吸収予定。

## Test plan

- [x] \`bundle exec rspec spec/requests/home_spec.rb\` → 44 examples 0 failures
- [ ] レビュアー: 3 階層バランス (= sketch-hh / sketch-h / sketch-small) が読みやすいか確認
- [ ] レビュアー: 「常時適用」 vs 「フォールバック時のみ」 の判断 (= service 改修回避、軽量 1 PR で完結) が妥当か確認
- [ ] レビュアー: モバイル幅 (= 375px) で 2 行構成が破綻しないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)