### PR TITLE
docs: day-9-3 開発ログ新規作成 (= PR #260 + 学び 35)

### DIFF
--- a/docs/dev-log/day-9-3.md
+++ b/docs/dev-log/day-9-3.md
@@ -1,0 +1,146 @@
+# Day 9-3 開発ログ (2026-05-07 18:00 以降、Claude tooling 第一群 4 連発の 1 番目完走 + 確認スピン運用パターン確立)
+
+> **Day 9 構成**: 午前 (= [day-9-1.md](day-9-1.md)) → 午後 ~18:00 (= [day-9-2.md](day-9-2.md)) → **18:00 以降 (= 本ファイル day-9-3.md)**
+
+午前 + 午後 (= [day-9-1.md](day-9-1.md) + [day-9-2.md](day-9-2.md)) で **MVP 後 polish 初日のベストプラクティス reference 日** を完成させた後の **18:00 以降セッション** (= セッション 9)。Day 9-2 振り返りで言語化した **Claude tooling 第一群 4 連発** (= memory `project_claude_tooling_roadmap.md`) のうち **1 番目 (= Issue #256 `/plan-issue` ハイブリッド化)** を完走。
+
+**Day 9-3 達成サマリ**: **1 PR (= #260) マージ + 1 Issue (= #256) close + memory `feedback_self_proposal_relativization.md` 4 例目達成 (= 1 PR で 2 件埋め込み) + ハイブリッド構成 (= Slash Command `/plan-issue` 軽量版 + Skill `propose-issue` 提案型) 完成 + 第一群 4 連発の 1 番目完走 (= 残 3 件 = #257 → #259 → #258) + 学び 35 確立 (= 確認スピン運用パターン)**
+
+**Day 9-3 総括**: **9 日間蓄積した memory 運用ルールを Skill / Command で機械化する第一群 4 連発の口火を切った日**。6 日前 (= Day 2) のハイブリッド構成予言 (= memory `project_plan_issue_skill_consideration.md`) を **9 日越しに実装確定** することで、「実演後判断」 ルール (= 過剰実装を避け、実運用後に判断する) の reference になった。
+
+## 戦略テーマ (= セッション 9)
+
+**Claude tooling 9 日間運用の機械化** (= memory 蓄積を Skill / Command / Hook で自動化する第一群 4 連発の 1 番目)
+
+memory `project_claude_tooling_roadmap.md` の **3 回観測ルール** で発火確定した第一群 4 件 (= #256 / #257 / #259 / #258) を **判断保留の長さ + ROI 順** で着手。本セッションは 1 番目 = `/plan-issue` ハイブリッド化 (= 6 日前の Day 2 から保留) を完走、第一群の口火を切った。
+
+---
+
+## 🎯 Day 9-3 (= 18:00 以降) の目標
+
+1. Issue #256 (= `/plan-issue` ハイブリッド化) を完走 (= 第一群 4 連発の 1 番目)
+2. memory `project_plan_issue_skill_consideration.md` のハイブリッド構成予言 (= 6 日前 Day 2) を実装で確定
+3. Skill / Command の使い分け軸を実装で言語化 (= Day 9-3 の教材性、後輩スクール生への 1 行で渡せる reference)
+
+---
+
+## 🏆 達成したこと (= PR #260 マージ + Issue #256 close + ハイブリッド構成完成 + 学び 35 確立)
+
+### マージ済み PR (= 1 本)
+
+| PR | Issue | 内容 |
+|---|---|---|
+| #260 | #256 (= 第一群 4 連発の 1 番目、6 日前 Day 2 保留 → 9 日後死蔵観察 → 軽量化リライト + Skill 化) | chore(claude): /plan-issue 軽量化 + Skill propose-issue 新設 (= ハイブリッド構成完成)。Slash Command `/plan-issue` 軽量化 (= **191 → 135 行**、Backlog セクション約 60 行削除 + Step 統合 + 条件付き発火 3 箇所 = Step 3 keyword 抽出時のみ / Step 4 複雑度高時のみ / Step 5 自明なら省略可) + Skill `propose-issue` 新設 (= 提案型、即起動禁止の二段構え、4 発火シーン定義 = 次タスク言及 / 派生 Issue / polish ネタ / dev-log 未着手項目化)。**1 PR で「自分の提唱を相対化する」 メタパターン 2 件埋め込み** (= 格下げ 1: Skill 名 `plan-issue` → `propose-issue` (= Claude Code 公式仕様「同名なら Skill が優先発火」 と矛盾、二段構え不成立を回避) + 格下げ 2: 発火シーン 5 → 4 (= memory 化検討シーンを発火対象外に格下げ、Issue 化と memory 化は判断軸が違うため `feedback_*.md` 新規作成が筋)) → memory `feedback_self_proposal_relativization.md` **4 例目達成**。3 者並列レビュー指摘 8 件 (= code 3 + design 3 + strategic 2) を本 PR 内吸収 (= 軽量 Issue 1 PR ルール **4 例目**)。影響 2 ファイル (= `.claude/commands/plan-issue.md` rewrite 74% + `.claude/skills/propose-issue/SKILL.md` 新規)、Rails コード変更ゼロ |
+
+### close した Issue (= 1 件)
+
+- **#256** (= `/plan-issue` 軽量化 + Skill 提案型ハイブリッド化、Day 9-2 振り返りで起票 → 同日 18:00 以降で着手) — PR #260 で close、第一群 4 連発の **1 番目完走**。memory `project_plan_issue_skill_consideration.md` の **6 日前の予言** (= Day 2 起源、ハイブリッド構成案) を 9 日越しに実装確定。
+
+---
+
+## 🧠 教訓ハイライト (= 1 件、本日 18:00 以降確立)
+
+### 学び 35: 未知の仕様が絡む実装は確認スピン 1 周で先手を取る — 「同名で揃える」 を仕様矛盾で格下げした実例
+
+PR #260 実装中の発見。Issue #256 本文では Skill 名 `plan-issue` (= Slash Command と同名) で揃える方針だったが、`.claude/skills/plan-issue/SKILL.md` 新設 **直前** に claude-code-guide エージェントで公式仕様確認 → 「**Custom commands have been merged into skills、同名なら Skill が優先発火**」 を確認 → 二段構え (= Skill 提案 → ユーザー Yes → Command 起動) が成立しないと判明 → Skill 名を `propose-issue` に格下げして実装続行。
+
+#### 「先手で潰す」 の運用パターン
+
+実装着手前に **公式仕様 / フレームワーク慣習** を確認することで、実装後の手戻りを未然に防ぐ。今回の場合:
+
+- **悪手 (= 確認スピンなし)**: 同名で実装 → push → 動作確認 → 衝突発見 → 命名やり直し → 再 push → 再動作確認 = **2 周 + コミット粒度悪化** (= 「迷走の歴史」 が git log に残る)
+- **良手 (= 確認スピン 1 周)**: 同名前提で実装着手 → 30 秒の確認スピン → 衝突発見 → 命名変更 → 1 周で完了 (= 学び 35 適用、PR #260 実例)
+
+→ 「**未知の仕様が絡む時は実装前に api-researcher / claude-code-guide で確認スピン 1 周入れる**」 が weight_dialy 教材性の運用パターン。
+
+#### 確認スピンを入れる目安 (= 副局長判断軸)
+
+- **絶対入れる**: 公式仕様 / 公開 API / 命名衝突可能性 / DB スキーマ / 後から変えにくい決定が含まれる
+- **入れた方がよい**: フレームワーク慣習が曖昧、複数の方針が混在している、既存コードに先例がない
+- **不要**: 既存パターンの踏襲のみ、Markdown / docs 編集のみ、内部コードの軽微修正
+
+#### 学び 34 (= 判断の前提が変わったら判断を更新する) との関係
+
+学び 34 は **「コメントを判断履歴に書き換える」 = 後追い更新** の運用、本学び 35 は **「実装前の確認スピンで先手」 = 事前更新** の運用。両者は **時間軸の前後で相補的** に機能する:
+
+| 軸 | 学び 34 | 学び 35 |
+|---|---|---|
+| タイミング | 実装後 (= 判断更新時) | 実装前 (= 着手前) |
+| 対象 | コードコメント | 命名 / 仕様判断 |
+| 動機 | 嘘コメント防止 | 手戻り防止 |
+| memory 紐付け | `feedback_issue_as_decision_log.md` (= 判断ログ系) | `feedback_self_proposal_relativization.md` (= 自案格下げ系) |
+
+How to apply:
+- **公式 API / フレームワーク仕様 / 公開 API / 命名衝突可能性 / DB スキーマ など「後から変えにくい決定」 が含まれる実装** は、**実装前に確認スピン 1 周** (= api-researcher / claude-code-guide) を入れる
+- 確認スピン結果、Issue 起票時の方針と矛盾が出たら、**memory `feedback_self_proposal_relativization.md` の運用** で格下げして PR description「自分の提唱を相対化した点」 セクションに記録 (= 教材性確保、後輩への 1 行で渡せる)
+- 「**確認スピン 30 秒** で 1 周分の手戻り (= 数時間級) を救える」 が運用 ROI の核心
+
+---
+
+## 📊 統計 (= 18:00 以降、Day 9-3 分のみ)
+
+- マージした PR: **1 本** (= #260、第一群 1 番目完走)
+- close した Issue: **1 件** (= #256)
+- 起票した Issue: **0 件** (= Day 9-2 で第一群 4 件起票済、本セッションで新規起票なし)
+- spec: **607 examples** (= 変化なし、本 PR は Markdown のみで Rails コード変更ゼロ)
+- rubocop: **0 offenses** (= 変化なし)
+- 教訓: **1 件** (= 学び 35)
+- セッション時間: **1 セッション** (= セッション 9 = Claude tooling 第一群 1 番目)
+
+### Day 9 全体総括 (= day-9-1 + day-9-2 + day-9-3 統合視点)
+
+| 指標 | 午前 (day-9-1) | 午後 (day-9-2) | 18:00 以降 (day-9-3) | **Day 9 合計** |
+|---|---|---|---|---|
+| マージ PR | 6 本 | 6 本 | 1 本 | **13 本** |
+| close Issue | 4 件 | 6 件 | 1 件 | **11 件** |
+| 起票 Issue | 6 件 | 0 件 | 0 件 | **6 件** |
+| 教訓 (学び) | 7 件 (27〜33) | 1 件 (34) | 1 件 (35) | **9 件** |
+| memory 新規 | 0 件 | 1 件 (= `feedback_self_proposal_relativization.md`) | 0 件 (= 4 例目埋め込みのみ、新規化なし) | **1 件 (Day 9 全体で)** |
+| spec | 557 → 585 (+28) | 585 → 607 (+22) | 607 (変化なし) | **+50** |
+| セッション | 6 | 2 | 1 | **9** |
+| ダッシュボード更地化 | Tier 2 全 3 件 | Tier 3 全 1 件 | (= 該当なし、Claude tooling 系列) | **Tier 2 + Tier 3 全更地化** |
+| Claude tooling 第一群 4 連発 | (= 起票 4 件) | (= 起票直後) | **1/4 完走** | **1/4 (残 3 件 = #257 → #259 → #258)** |
+
+→ **Day 9 = MVP 後 polish 初日 + Claude tooling 機械化初日のダブル reference 日** として完成。Day 10 以降の polish 日 / 機械化日のテンプレ価値を持つ。
+
+---
+
+## 🎯 残タスク (= Day 10 以降 / 第一群 4 連発)
+
+### 第一群 4 連発の残 3 件 (= 本セッション後の着手予定、判断保留の長さ + ROI 順)
+
+- [ ] **#257** (= `/dev-log-merge` Skill 自動、ROI 最大、次セッション着手候補) — 毎 PR 発火する 4 つの手作業のうち最頻度
+- [ ] **#259** (= `/review-three` Command 明示、3 者並列レビュー起動標準化)
+- [ ] **#258** (= `/mode` Command 明示、4 モード宣言時の再開地点提示)
+
+### 後続持ち越し (= 第一群完走後の別 Issue で起票予定)
+
+- [ ] **`.claude/README.md` Skill / Command 体系整備** (= strategic-reviewer 推奨 A、第一群 4 件完走時 = #258 マージ後 に起票、4 件の実装で確定した使い分け軸を一気に書き起こす方が情報量が多い)
+
+### Tier 1 大物 (= Day 10 以降の北極星、day-9-2 から継承)
+
+- [ ] Phase 3 三重防衛 / Capacitor OAuth ブリッジ / daisyUI 全置換 のいずれか 1 件選択 (= モード宣言時に局長判断)
+
+### 中期 (= v1.0 / v1.1)
+
+- [ ] 子 5b (= WorkManager 自動同期、~3-5h)
+- [ ] 子 7 (= APK ビルド + sideload 手順、~1h)
+- [ ] Day 9 セッション 3 由来 v1.1 polish Issue 残 1 件: **#234** (= 食品換算カードに帳消し系コピー)
+
+### 学習トラック
+
+- [ ] Lesson 7 (= クラスメソッド `def self.xxx` or if 文 or 継承 `<` 候補)
+
+---
+
+## How to apply (= Day 9-3 由来、適用済みの操作手順)
+
+- **未知の仕様が絡む実装は確認スピン 1 周で先手を取る** (= 学び 35 核心): 公式 API / フレームワーク仕様 / 命名衝突可能性 / 後から変えにくい決定が含まれる場合、api-researcher / claude-code-guide で 30 秒の確認スピンを **実装前** に入れる。手戻り 1 周分 (= 数時間級) を救える運用 ROI
+- **「自分の提唱を相対化する」 1 PR 2 件埋め込み運用**: 大きめ PR で複数の格下げ判断が発生する場合、PR description「自分の提唱を相対化した点」 セクションに **格下げ 1 / 2 / ...** を分けて記録 (= memory `feedback_self_proposal_relativization.md` 4 例目で実証、PR #260)
+- **第一群 4 連発の着手順**: **判断保留の長さ + ROI 順** で着手 (= 6 日前から保留が最も長い #256 を最初に解消、次は ROI 最大の #257)。memory `project_claude_tooling_roadmap.md` 厳守
+- **6 日前の予言を 9 日越しに実装確定する運用**: 「実演後判断」 ルール (= memory `project_plan_issue_skill_consideration.md`) で過剰実装を避け、実運用 9 日後に死蔵観察を経て判断確定。**「使うかも」 で先回り実装しない** が weight_dialy の最強原則
+
+---
+
+> **→ 戻る: [day-9-2.md](day-9-2.md)** (= 午後の部、polish 連続着手 + memory 確定)
+> **→ 戻る: [day-9-1.md](day-9-1.md)** (= 午前の部、Tier 2 全更地化)


### PR DESCRIPTION
## Summary

- Day 9-3 (= 2026-05-07 18:00 以降セッション 9) の開発ログを新規作成
- PR #260 (= #256 close、Claude tooling 第一群 4 連発の 1 番目完走) を反映
- 学び 35 (= 未知の仕様が絡む実装は確認スピン 1 周で先手を取る) を確立記録
- Day 9 全体総括テーブルを 3 セッション統合視点で更新 (= 13 PR / 11 Issue close / 9 学び / 9 セッション)

## 内容

- 戦略テーマ: Claude tooling 9 日間運用の機械化 (= 第一群 4 連発の 1 番目)
- 達成: PR #260 マージ + Issue #256 close + ハイブリッド構成 (= Slash Command 軽量版 + Skill 提案型) 完成 + memory `feedback_self_proposal_relativization.md` 4 例目 (= 1 PR 2 件埋め込み)
- 教訓: 学び 35 確認スピン運用パターン (= 学び 34「判断の前提が変わったら判断を更新する」 と時間軸前後で相補的)
- 残タスク: 第一群 4 連発の残 3 件 (= #257 → #259 → #258) + `.claude/README.md` 体系整備 (= 第一群完走後)

## Test plan

- [ ] dev-log フォーマットが既存 day-9-1 / day-9-2 と整合
- [ ] memory `feedback_dev_log_after_merge.md` (= マージ直後 dev-log 更新) ルール準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)