### PR TITLE
polish: Settings の HC セクション UI 微調整 (#134)

### DIFF
--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -91,7 +91,7 @@
       かつ既存の native-health セクション (下記) が JS で代替表示される。UX ループ解消が目的。 %>
   <% if @show_android_app_promo %>
     <div class="sketch-box" style="margin-bottom: 24px;">
-      <h2 class="sketch-h" style="margin-bottom: 8px;">📱 Android Health Connect 連携</h2>
+      <h2 class="sketch-h" style="margin-bottom: 8px;">Android Health Connect 連携</h2>
       <p class="sketch-body-text" style="margin-bottom: 12px;">
         お手元の Android スマホから Health Connect 経由で歩数 / 距離 / 階段を自動同期できます。
         同期されたデータは Web 版にログインしてダッシュボードで閲覧できます。
@@ -108,7 +108,7 @@
        data-native-health-webhook-token-value="<%= current_user.webhook_token %>"
        class="sketch-box"
        style="display: none; margin-bottom: 24px;">
-    <h2 class="sketch-h" style="margin-bottom: 8px;">📱 Android Health Connect 連携</h2>
+    <h2 class="sketch-h" style="margin-bottom: 8px;">Android Health Connect 連携</h2>
     <p class="sketch-small" style="margin-bottom: 12px;">
       Android アプリ版で Health Connect から歩数 / 距離 / 階段を取得 → サーバーへ自動同期します。
     </p>
@@ -128,7 +128,7 @@
             data-native-health-target="requestButton"
             class="sketch-btn"
             style="display: none; margin-right: 8px;">
-      権限を許可する
+      歩数を取得する
     </button>
     <button data-action="click->native-health#sync"
             data-native-health-target="syncButton"

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -87,6 +87,9 @@
     </p>
   <% end %>
 
+  <%# 見出し命名ルール (= Issue #134 由来、本ファイル全 sketch-h に適用):
+      装飾絵文字なし (= ポリシー / Step 1 / Step 2 / トークン再生成と揃える)。
+      機能絵文字 (= 📡 同期する / 🎉 完了 / ⚠️ 警告) は意味付きアイコンとして残置可。 %>
   <%# Web 版 Android user 向け案内 (Issue #184)。Capacitor 検知時はサーバ側で web_android? = false になり非表示、
       かつ既存の native-health セクション (下記) が JS で代替表示される。UX ループ解消が目的。 %>
   <% if @show_android_app_promo %>
@@ -110,7 +113,7 @@
        style="display: none; margin-bottom: 24px;">
     <h2 class="sketch-h" style="margin-bottom: 8px;">Android Health Connect 連携</h2>
     <p class="sketch-small" style="margin-bottom: 12px;">
-      Android アプリ版で Health Connect から歩数 / 距離 / 階段を取得 → サーバーへ自動同期します。
+      Android アプリ版で Health Connect 経由で歩数 / 距離 / 階段を自動同期します。
     </p>
 
     <%# Issue #218: 同期前事前ガイダンス。Health Connect 自体にデータが届いていないと同期成功 (= 200 OK)
@@ -128,7 +131,7 @@
             data-native-health-target="requestButton"
             class="sketch-btn"
             style="display: none; margin-right: 8px;">
-      歩数を取得する
+      歩数を取得する →
     </button>
     <button data-action="click->native-health#sync"
             data-native-health-target="syncButton"

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "Settings", type: :request do
         end
 
         it "「インストール手順を準備中」セクションを表示する (= Web Android user 向け新セクション、Issue #184)" do
-          # 新セクションのタイトル (= 「📱 Android Health Connect 連携」) は既存の Capacitor 検知時セクションと
+          # 新セクションのタイトル (= 「Android Health Connect 連携」) は既存の Capacitor 検知時セクションと
           # 同一文字列のため、新セクション固有の本文「インストール手順を準備中」で識別する。
           expect(response.body).to include("インストール手順を準備中")
         end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -110,6 +110,8 @@ RSpec.describe "Settings", type: :request do
       end
 
       it "Android Health Connect 連携セクションを含む (= Stimulus controller 経由でレンダリング)" do
+        # PR #270 で見出しから絵文字 📱 を削除したが、`include` は部分文字列マッチのため、
+        # 絵文字あり/なし両対応で本アサーションはそのまま通過する。
         expect(response.body).to include("Android Health Connect 連携")
         expect(response.body).to include('data-controller="native-health"')
       end


### PR DESCRIPTION
## Summary

Issue #134 (= PR #133 design-reviewer 「v1.1 で OK」 指摘 2 件) を完走、Settings の Health Connect セクションの UI を微調整 + 3 者レビュー指摘 5 件を本 PR で全件吸収。

- **ボタン文言**: `権限を許可する` → `歩数を取得する →` (= 行動寄りでアプリコンセプト「日常の歩きを拾う」 と一致 + design 提案 1 で動作矢印追加)
- **見出し絵文字 📱 削除**: 他セクション (= ポリシー / Step 1 / Step 2 / トークン再生成) と無装飾で揃える、機能絵文字 (= 📡 同期する) との対比が際立つ
- **見出し命名ルール永続コメント追加**: view 直上に「装飾絵文字なし / 機能絵文字残置可」 を 1 行明文化 (= strategic 論点 2、後続セクション追加時の判断基準として教材化)
- **コピー揺らぎ統一**: line 113 を line 96 と「Health Connect 経由で〜自動同期」 で揃える (= design 提案 2)
- **spec コメント追従 + 補足**: 学び 29 (= 値変更とコメント追従) + code Nit (= include マッチ意図明示)

## 副局長判断

- 提案 1 (= ボタン文言): Issue 提案の「歩数を取得する」 を採用 (= HC は歩数 / 距離 / 階段を取得するが「歩数」 が代表値として馴染みやすい、副局長視点でも妥当 → 自分の提唱を相対化せず確定、自己完結型 6 例目候補に該当せず = 学び 36 不発火)
- 提案 2 (= 絵文字削除): Issue 本文「任意判断」 だが他セクション一貫性で削除推奨、局長 A 案採用

## 3 者並列レビュー結果 (= /review-three Command 起動、第 5 回通算)

- 🔍 code-reviewer: ✅ Approve + 💡 Nit 1 件 (= spec line 112 コメント補足)
- 🎯 strategic-reviewer: 🟢 進めてよい + 論点 3 件 + 学びポイント (= ボタン文言は実装網羅性ではなくコンセプト整合性で選ぶ)
- 🎨 design-reviewer: 🟢 デモで出せる + 提案 2 件 (= ボタン矢印 / コピー揺らぎ統一)

→ Blocker 0 件 / 軽微 0 件 / 提案 5 件、**全件本 PR 内吸収** (= 軽量 Issue 1 PR ルール 9 例目)

## 副次効果

- spec assertion (= `"Android Health Connect 連携"` 絵文字なしマッチ) は無修正で PASS、絵文字あり/なし両対応の判定意図を spec コメントで永続化
- spec line 296 のコメント `「📱 Android Health Connect 連携」` は学び 29 (= 値変更とコメント追従) で同 PR 内追従済

## 学び 36 観測 (= 仮説への追加データ)

day-11.md / day-11-2.md の仮説「ドッグフーディング非伴 PR では学び 36 (= 外部レビューによる再相対化) 発火しない」 への観測 2 例目候補:

- 本 PR は polish PR (= ドッグフーディング非伴)
- 副局長視点で論点 1 (= ボタン文言) を再評価したが A 案維持 = 学び 36 **不発火確認**
- 仮説支持データ 1 件追加、3 例目観測時に再構築候補

## Test plan

- [x] settings_spec の `"Android Health Connect 連携"` assertion 維持 + ボタン文言修正済 (50 examples 0 failures)
- [x] フル spec 607 examples 0 failures
- [x] rubocop 0 offenses
- [x] 旧文言 grep ヒット 0 件確認 (`grep -rnE "📱 Android Health Connect|権限を許可" app spec config` で 0 件)
  - 注: grep 範囲は **app / spec / config に限定**、`docs/` `memory/` `.claude/` は履歴保全のため対象外 (= 学び 28 = 歴史的記録は当時の状態を述べる文脈なので未編集、strategic 論点 3 反映)

## 関連

- Issue #134
- PR #133 (= Issue #121 Health Connect 動的パーミッションフロー、design-reviewer 指摘由来)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)