### PR TITLE
polish: HC Webhook POST UX 改善 (#138)

### DIFF
--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -8,9 +8,10 @@ const HEALTH_READ_TYPES = ["steps", "distance", "flightsClimbed"]
 // HTTP status 別の日本語フォールバック (Issue #138)。
 // カジュアル層に「HTTP 422」 「Unauthorized」 が伝わらないため、想定 status 6 種に日本語を当てる。
 // 想定外 status (= 404 / 429 等) は呼び出し側で `HTTP ${status}` に fallback。
+// 401 のみ recoveryButton で「設定ページでトークン再生成」 への動線を提供 (= キーワード「トークン再生成」 を文言・ボタン文言・誘導先で統一)。
 const STATUS_MESSAGES = {
-  401: "ログインし直してください (= token が無効です)",
-  413: "データサイズが大きすぎます",
+  401: "トークンが無効です。設定ページでトークンを再生成してください",
+  413: "送信データが多すぎます。しばらく待ってから再試行してください",
   422: "データの形式に問題があります",
   500: "サーバー側のエラーです。しばらく待ってから再試行してください",
   502: "サーバーが応答しません。ネットワーク接続を確認してください",
@@ -237,6 +238,7 @@ export default class extends Controller {
       this.showStatus("⚠️ データ未取得です。再読込してください")
       return
     }
+    // pre-flight ガード: token 未設定はセッション中断時の異常系で通常起きない (= recoveryButton は出さず文言のみで OK、Issue #138 範囲外)。
     if (!this.webhookTokenValue) {
       this.showStatus("⚠️ webhook token 未設定 (= ログインし直してください)")
       return
@@ -244,6 +246,10 @@ export default class extends Controller {
 
     this.showStatus("📡 送信中...")
     this.syncButtonTarget.disabled = true
+    // 直前の sync で 401 となり recoveryButton が表示されたままの場合に備えて非表示に戻す (= UX バグ防止、code-reviewer ⚠️ 由来)。
+    if (this.hasRecoveryButtonTarget) {
+      this.recoveryButtonTarget.style.display = "none"
+    }
 
     try {
       const data = this.lastFetchedData
@@ -280,8 +286,8 @@ export default class extends Controller {
           ? `❌ ${friendlyMessage}`
           : `❌ 送信失敗 (HTTP ${response.status}): ${bodyMessage}`
         this.showStatus(display)
-        // 401 (= token 無効) のときのみ Settings 誘導ボタンを表示。
-        // 他 status は文言のみで運用 (= 復帰導線が status ごとに異なるため Issue #138 では 401 のみ実装)。
+        // 401 (= token 無効) のときのみ Settings 誘導ボタンを表示 (= 復帰導線が一意に決まる status のため)。
+        // 他 status (= 5xx の retry 系等) の復帰導線は本 PR スコープ外、必要になったら別 Issue で recoveryButton を 2 mode 化検討。
         if (response.status === 401 && this.hasRecoveryButtonTarget) {
           this.recoveryButtonTarget.style.display = ""
         }

--- a/app/javascript/controllers/native_health_controller.js
+++ b/app/javascript/controllers/native_health_controller.js
@@ -5,8 +5,20 @@ import { Controller } from "@hotwired/stimulus"
 // 旧コードでは "floorsClimbed" と書かれており permission チェックで "Unsupported data type" エラーになっていた (2026-05-06 実機検証で発覚)。
 const HEALTH_READ_TYPES = ["steps", "distance", "flightsClimbed"]
 
+// HTTP status 別の日本語フォールバック (Issue #138)。
+// カジュアル層に「HTTP 422」 「Unauthorized」 が伝わらないため、想定 status 6 種に日本語を当てる。
+// 想定外 status (= 404 / 429 等) は呼び出し側で `HTTP ${status}` に fallback。
+const STATUS_MESSAGES = {
+  401: "ログインし直してください (= token が無効です)",
+  413: "データサイズが大きすぎます",
+  422: "データの形式に問題があります",
+  500: "サーバー側のエラーです。しばらく待ってから再試行してください",
+  502: "サーバーが応答しません。ネットワーク接続を確認してください",
+  503: "サーバーが混み合っています。しばらく待ってから再試行してください"
+}
+
 export default class extends Controller {
-  static targets = ["status", "requestButton", "syncButton"]
+  static targets = ["status", "requestButton", "syncButton", "recoveryButton"]
   static values = { webhookToken: String }
 
   connect() {
@@ -259,9 +271,20 @@ export default class extends Controller {
         const errorBody = await response.text()
         // サーバーは {error: "..."} JSON で 4xx を返す設計、JSON parse 成功時は error を抜粋。
         // パース失敗時は生 body の先頭 80 字でフォールバック。
-        let message = errorBody.slice(0, 80)
-        try { message = JSON.parse(errorBody).error ?? message } catch (_) {}
-        this.showStatus(`❌ 送信失敗 (HTTP ${response.status}): ${message}`)
+        let bodyMessage = errorBody.slice(0, 80)
+        try { bodyMessage = JSON.parse(errorBody).error ?? bodyMessage } catch (_) {}
+        // HTTP status 別の日本語フォールバック (Issue #138)。STATUS_MESSAGES にあれば優先、
+        // なければ従来通り `HTTP ${status}: ${body 抜粋}` で開発者 dogfood 互換。
+        const friendlyMessage = STATUS_MESSAGES[response.status]
+        const display = friendlyMessage
+          ? `❌ ${friendlyMessage}`
+          : `❌ 送信失敗 (HTTP ${response.status}): ${bodyMessage}`
+        this.showStatus(display)
+        // 401 (= token 無効) のときのみ Settings 誘導ボタンを表示。
+        // 他 status は文言のみで運用 (= 復帰導線が status ごとに異なるため Issue #138 では 401 のみ実装)。
+        if (response.status === 401 && this.hasRecoveryButtonTarget) {
+          this.recoveryButtonTarget.style.display = ""
+        }
         return
       }
 
@@ -279,6 +302,16 @@ export default class extends Controller {
       this.showStatus(`❌ 送信エラー: ${this.errorMessage(error)}`)
     } finally {
       this.syncButtonTarget.disabled = false
+    }
+  }
+
+  // 401 検出時に表示される Settings 誘導ボタンの遷移ハンドラ (Issue #138)。
+  // Turbo がロード済なら Turbo.visit、そうでなければ window.location で /settings へ遷移。
+  openSettings() {
+    if (typeof Turbo !== "undefined") {
+      Turbo.visit("/settings")
+    } else {
+      window.location.assign("/settings")
     }
   }
 }

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -141,12 +141,13 @@
     </button>
 
     <%# Issue #138: Webhook POST が 401 (= token 無効) で失敗したときのみ JS 側で表示。
-        他 status は文言のみで運用 (= 復帰導線が status ごとに異なるため 401 のみ Settings 誘導)。 %>
+        他 status の復帰導線は本 PR スコープ外、必要になったら別 Issue で recoveryButton を 2 mode 化検討。
+        ボタン文言は STATUS_MESSAGES の 401 文言と「トークン再生成」 キーワードで揃える。 %>
     <button data-action="click->native-health#openSettings"
             data-native-health-target="recoveryButton"
             class="sketch-btn"
-            style="display: none; margin-top: 8px;">
-      設定ページを開く →
+            style="display: none; margin-top: 12px;">
+      設定ページでトークンを再生成 →
     </button>
   </div>
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -139,6 +139,15 @@
             style="display: none;">
       📡 同期する
     </button>
+
+    <%# Issue #138: Webhook POST が 401 (= token 無効) で失敗したときのみ JS 側で表示。
+        他 status は文言のみで運用 (= 復帰導線が status ごとに異なるため 401 のみ Settings 誘導)。 %>
+    <button data-action="click->native-health#openSettings"
+            data-native-health-target="recoveryButton"
+            class="sketch-btn"
+            style="display: none; margin-top: 8px;">
+      設定ページを開く →
+    </button>
   </div>
 
   <%# 危険ゾーン: トークン再生成 %>

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Settings", type: :request do
         # 絵文字あり/なし両対応で本アサーションはそのまま通過する。
         expect(response.body).to include("Android Health Connect 連携")
         expect(response.body).to include('data-controller="native-health"')
-        # PR #138: 401 失敗時の Settings 誘導ボタンが Stimulus target として登録されている。
+        # Issue #138: 401 失敗時の Settings 誘導ボタンが Stimulus target として登録されている。
         expect(response.body).to include('data-native-health-target="recoveryButton"')
       end
 

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -114,6 +114,8 @@ RSpec.describe "Settings", type: :request do
         # 絵文字あり/なし両対応で本アサーションはそのまま通過する。
         expect(response.body).to include("Android Health Connect 連携")
         expect(response.body).to include('data-controller="native-health"')
+        # PR #138: 401 失敗時の Settings 誘導ボタンが Stimulus target として登録されている。
+        expect(response.body).to include('data-native-health-target="recoveryButton"')
       end
 
       it "Web 版では display: none で初期表示する (= Capacitor 検知時のみ表示に切り替わる)" do


### PR DESCRIPTION
## Summary

Issue #138 (= PR #137 strategic + design レビュー由来 v1.1 polish 候補) の **案 C 採用** = HTTP status 別日本語フォールバック + 401 専用 Settings 誘導 UI を統合 + **3 者並列レビュー指摘 7 件全件本 PR 内吸収** (= 軽量 Issue 1 PR ルール 11 例目)。

- **STATUS_MESSAGES 定数追加** (= module スコープ): 想定 status 6 種 (= 401 / 413 / 422 / 500 / 502 / 503) の日本語文言を 1 箇所に集約、レビュー反映で「トークン再生成」 キーワード統一 + 413 再試行案内追加
- **401 検出時の Settings 誘導ボタン** (= Stimulus `recoveryButton` target + `openSettings()` アクション): token 無効時に「設定ページでトークンを再生成 →」 ボタンを表示、認知ギャップ解消
- **sync 再実行時の recoveryButton リセット**: code-reviewer ⚠️ 指摘の UX バグ防止
- **想定外 status は従来通り fallback** (= `❌ 送信失敗 (HTTP X): body`、開発者 dogfood 互換維持)

## 副局長判断

- 案 A (= 文言のみ) と案 B (= 401 誘導のみ) を検討、Issue 推奨の **案 C 統合** を採用
- Settings 誘導の実装方式は **Stimulus target 追加** (= 責務分離 + Stimulus 慣習)
- 案 Y (= recoveryButton 2 mode 化、5xx で retry) は **Issue #273 起票で吸収** (= スコープ拡大回避、polish ループ送り)

## 3 者並列レビュー結果 (= /review-three Command 通算 7 回目)

- 🔍 code-reviewer: 🟡 Needs minor fix (= ⚠️ 1 件 = リセット漏れ + 💡 4 件)
- 🎯 strategic-reviewer: 🟡 = **学び 36 自走発火 1 件目発生** (= 「他 status は文言のみ」 を PR description / js comment / view comment の 3 箇所で同文反復 = 言い切り強度高で発火) → 案 Y 別 Issue #273 起票で吸収、本 PR は js / view の言い切りトーンダウンで対応
- 🎨 design-reviewer: 🟢 デモで出せる + 軽微 4 件 + デモ向上提案 2 件 (= 別 Issue 候補)

→ Blocker 0 件 / 軽微 3 件 / 提案 4 件 (= 本 PR 内吸収、デモ向上 2 件は別 Issue 候補)、**全件本 PR 内吸収** = **軽量 Issue 1 PR ルール 11 例目**

## 学び 36 仮説への重要観測 (= Production polish PR 発火 1 件目)

Day 11-3 で確立した新仮説「自己提唱の言い切りを含む PR で発火」 への **Production polish PR 発火 1 件目候補**:

- 旧仮説「ドッグフーディング有無」 では Production polish PR は発火しないはずだった (= PR #268 / #270 で発火なし観測)
- しかし PR #272 で **「3 箇所同文反復言い切り」** で発火 = 新仮説を支持するデータ
- サブパターン候補: **「3 箇所以上の同文反復 = 発火確率上昇」**

memory `feedback_self_proposal_relativization.md` 更新時の観測データとして記録 (= Day 12+ 別 Issue 起票候補)。

## Test plan

- [x] settings_spec の `data-native-health-target="recoveryButton"` assertion + 既存 50 examples 0 failures
- [x] フル spec 607 examples 0 failures
- [x] rubocop 0 offenses
- [x] JS 構文チェック (= node -c) PASS
- [x] 旧文言 grep: `❌ 送信失敗 (HTTP X)` は意図的 fallback 経路で 1 件残置 (= 想定外 status 用、line 281)
- [ ] **実機 Capacitor or ngrok 経由での 401 動作確認は本 PR スコープ外** (= JS controller の 401 ハンドリングは spec 不可、Day 12+ で実機検証)

## 関連

- Issue #138 (= 親、PR #137 strategic + design レビュー由来)
- **Issue #273 (= 案 Y 別 Issue、recoveryButton 2 mode 化)**
- PR #137 (= Issue #123 手動同期ボタン MVP)
- 親 Issue #40 (= Capacitor + Health Connect 連携)
- memory `feedback_self_proposal_relativization.md` (= 学び 36 新仮説 + サブパターン候補の観測対象、Day 12+ 更新候補)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)