### PR TITLE
fix: Puma を single mode (workers=0) に変更してメモリオーバーヘッド削減 (#280)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -28,10 +28,17 @@ services:
         fromDatabase:
           name: weight-dialy-db
           property: connectionString
-      # Free Tier 512MB RAM では worker 1 が安全 (worker 2 + threads 3 = 6 スレッドで OOM リスク)。
-      # Connection pool 合計 (worker 1 × 4 database × 3 threads = 12) も Free Postgres の 97 接続上限内に収まる。
+      # [5/10 OOM 対策 #280] Puma を single mode (= workers=0) に変更。
+      #
+      # 動機: 5/10 09:12 JST に本番インスタンスが OOM (= Free Tier 512MB 超過) でクラッシュ。
+      # 原因: workers=1 の cluster mode は master + worker の二重起動になり、Puma 自身が
+      #       起動ログで single mode への切り替えを推奨していた (= 警告原文は Issue #280 参照)。
+      # 解決: workers=0 (single mode) で master プロセス分のメモリを削減、worker 1 つのみで起動。
+      # 安全: 並列性は threads (RAILS_MAX_THREADS=3、puma.rb のデフォルト) で維持されるため性能影響なし。
+      #       Connection pool 合計 = 1 process × 3 threads × 4 DB config (= primary/cache/queue/cable)
+      #       = max 12 で、Free Postgres の 97 接続上限に余裕で収まる。
       - key: WEB_CONCURRENCY
-        value: "1"
+        value: "0"
       # Solid Queue を Puma プロセス内に同居させる (= 別 worker service を契約しない、Free Tier 制約)。
       # config/puma.rb の `plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]` を有効化する。
       - key: SOLID_QUEUE_IN_PUMA


### PR DESCRIPTION
## Summary

- 5/10 09:12 JST の本番 Render OOM クラッシュ (= Issue #280) 対策
- `render.yaml` の `WEB_CONCURRENCY` を `"1"` → `"0"` に変更し、Puma を single mode 化
- Puma 自身が起動ログで推奨していた構成 (= "Consider running Puma in single-mode (workers = 0) in order to reduce memory overhead.")
- 並列性は threads (= RAILS_MAX_THREADS=3) で維持されるため性能影響なし

## OOM 対応 Issue 群の位置付け

本 PR は OOM 対策 3 部作の **第 1 弾 (= 確度高・スピード重視)**:

| Issue | 種別 | 状態 |
|---|---|---|
| #280 (本 PR) | 警告系 (= Puma 推奨設定への切替、確度高) | **本 PR で対応** |
| #281 | 棚卸し調査 (= SolidQueue Job 棚卸し、無料枠 Background Worker 不可判明) | 別 PR で対応中 |
| #282 | 仕様調査系 (= Anthropic API 400 BadRequest、モデル ID 仮説) | 別 PR で対応中 |

3 件まとめず分割した理由は確度の段階差。確度高の本 PR を先行マージしてベースラインメモリを下げ、OOM 再発確率を最速で下げる。

## 3 者並列レビュー指摘の反映

**🚨 Blocker: 0 件**
**🟡 軽微: 5 件 → 全件吸収**
**🟢 提案: 3 件 → 一部反映 + 一部 YAGNI 見送り**

詳細はコミットメッセージに記載。本 PR で全件解決。

## 補足: SolidQueue plugin との互換性 (= strategic 論点 3)

`config/puma.rb` の `plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]` は cluster mode / single mode どちらでも動作する設計 (= workers の値に非依存)。本変更で SolidQueue plugin の挙動は変わらない。

## Test plan

### マージ前

- [x] `git diff render.yaml` で意図通りの差分確認 (= +10 / -3)
- [x] 3 者並列レビュー実施 + 指摘 5 件全件吸収

### マージ後 (= 本番デプロイ後)

- [ ] Render の自動デプロイ完了を確認
- [ ] Puma 起動ログで `Detected running cluster mode with 1 worker` 警告が **消えている** ことを確認
- [ ] Puma 起動ログで `* Single mode` (= cluster mode 行ではない) で起動していることを確認
- [ ] Render Metrics でメモリベースラインが下がる (= master プロセス分 ~30-50MB 削減) ことを観測
- [ ] 24 時間以内に OOM クラッシュ再発がないことを確認

## 関連

- Issue #280 (= Closes)
- Issue #281 (= SolidQueue 調査、別 PR で対応中)
- Issue #282 (= Anthropic API 400 修正、別 PR で対応中)
- 5/10 09:12 OOM クラッシュ (= 起票・修正トリガ)
- memory `feedback_always_three_reviewers.md` (= 3 者並列レビュー実施)
- memory `feedback_light_issue_one_pr_completion.md` (= 軽微 5 件を別 Issue 起票せず本 PR で吸収)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
