### PR TITLE
fix: SOLID_QUEUE_IN_PUMA=false に変更して SolidQueue 4 プロセスを停止 (#284)

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,7 +35,10 @@ port ENV.fetch("PORT", 3000)
 plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+# 値比較 (== "true") で OFF を表現可能にする (= Rails デフォルトの `if ENV[...]` は値で
+# OFF を表現できない罠を回避、`"false"` / `""` / `"0"` すべて truthy で plugin がロードされる)。
+# 経緯: Issue #284 で `SOLID_QUEUE_IN_PUMA="false"` で停止できないことが判明、本判定式に修正。
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] == "true"
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.

--- a/render.yaml
+++ b/render.yaml
@@ -39,10 +39,27 @@ services:
       #       = max 12 で、Free Postgres の 97 接続上限に余裕で収まる。
       - key: WEB_CONCURRENCY
         value: "0"
-      # Solid Queue を Puma プロセス内に同居させる (= 別 worker service を契約しない、Free Tier 制約)。
-      # config/puma.rb の `plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]` を有効化する。
+      # [5/10 OOM 対策 #281 follow-up] SolidQueue Worker 群を停止 (= 4 プロセス分のメモリ削減)。
+      #
+      # 動機: Issue #281 の棚卸し調査で weight_dialy は SolidQueue を実質未使用と判明。
+      # 原因: app/jobs/ 独自 Job ゼロ + perform_later/perform_now/deliver_later 呼び出し 0 件
+      #       + recurring.yml は SolidQueue 自身の自己掃除 job 1 件のみ
+      #       (= 4 プロセス常駐が「掃除すべき空テーブルを掃除する」 ためだけの過剰起動)。
+      # 解決: "false" に変更して config/puma.rb の `plugin :solid_queue` を無効化し、
+      #       SolidQueue 内部プロセス群 (Supervisor / Worker / Dispatcher / Scheduler) の
+      #       4 プロセス常駐を停止。puma.rb 側の判定式は `== "true"` 値比較に修正済 (= Issue #284
+      #       で「if ENV["X"] は truthy 判定で値による OFF が効かない」 罠回避)。
+      # 安全: queue_adapter = :solid_queue は production.rb で残置するため、将来 enqueue が混入
+      #       した場合は DB に滞留 (= worker がいないので処理されない) して検知可能。
+      #       現状 enqueue ゼロのため、停止する自己掃除 job (= clear_solid_queue_finished_jobs)
+      #       にも掃除対象がなく実害なし。
+      # 復活: 将来 Job 機能が必要になったら以下 3 ステップ:
+      #       (1) 本値を "true" に戻して再デプロイ
+      #       (2) `SolidQueue::Job.count` で滞留 job を確認 (= 混入分が積まれていれば初回掃除負荷)
+      #       (3) `bin/rails db:migrate` で SolidQueue 関連の追加 migration がないか確認
+      #       (= gem / migration / db テーブルは残置なので「ENV 1 行で完結」 が基本)。
       - key: SOLID_QUEUE_IN_PUMA
-        value: "true"
+        value: "false"
 
 databases:
   - name: weight-dialy-db


### PR DESCRIPTION
## Summary

- 5/10 OOM 対策 #281 follow-up (= PR #283 Puma single mode 化に続く OOM 物理プロセス削減 第 2 弾)
- Issue #281 棚卸し調査の結論「weight_dialy は SolidQueue を実質未使用」 を受けた実装
- `render.yaml` の `SOLID_QUEUE_IN_PUMA` を `"true"` → `"false"` に変更
- `config/puma.rb:38` の判定式を `if ENV["X"] == "true"` 値比較に修正 (= **3 者並列レビュー Blocker 反映**)
- SolidQueue 内部プロセス群 (Supervisor / Worker / Dispatcher / Scheduler) の 4 プロセス常駐を停止

## OOM 対応 Issue 群の位置付け (= PR #283 と対の関係)

| Issue | 種別 | 状態 |
|---|---|---|
| #280 (PR #283) | 警告系 (= Puma single mode) | ✅ マージ済 |
| #281 → #284 (本 PR) | 棚卸し調査系 → A 案実装 (= SolidQueue 4 プロセス停止) | **本 PR で対応** |
| #282 | 仕様調査系 (= Anthropic API 400) | 別 PR で対応予定 |

PR #283 + 本 PR で **OOM 対策の物理プロセス削減が完結**。Render Metrics で 2 段階のメモリ削減効果が個別観測可能。

## 3 者並列レビュー指摘の反映

**🚨 Blocker: 1 件** (= code + strategic 同根) **→ 修正完了**

3 者レビューで **`if ENV["SOLID_QUEUE_IN_PUMA"]` は文字列 `"false"` でも truthy で plugin がロードされ続ける = SolidQueue が止まらない致命的バグ** が発覚。`config/puma.rb:38` を `== "true"` 値比較に修正することで「ENV 値による ON/OFF 制御」 を可能にした (= devcontainer で truthy 挙動を実検証済)。

→ 本 PR は **2 ファイル変更** (= render.yaml + config/puma.rb)。当初想定の「ENV 1 行変更だけ」 から拡張、Blocker 修正のため不可避。

**🟡 軽微: 4 件 → 全件吸収**

- [design 提案 1] WEB_CONCURRENCY コメントとフォーマット完全一致 (= 5 段構造: 動機 → 原因 → 解決 → 安全 → 復活)
- [design 提案 2] Supervisor / Worker / Dispatcher / Scheduler に「= SolidQueue 内部プロセス群」 1 行説明追加
- [code 💡] 安全 ブロックに自己掃除 job 停止への言及追加 (= 現状 enqueue ゼロのため実害なし)
- [strategic 論点 2] 復活手順を「ENV 1 行で完結」 言い切りから 3 ステップに展開

**🟢 提案: 1 件 → 別 Issue 候補として残置**

- [strategic 学び] memory 化候補 `feedback_env_truthiness_pitfall.md` (= `if ENV["X"]` 罠) は本 PR スコープ外、別 Issue 起票候補

詳細はコミットメッセージに記載。**軽量 Issue 1 PR ルール 14 例目連続達成** (= Day 12-1 13 例から +1)。

## 補足: SolidQueue 停止で壊れる箇所がないことの確認 (= strategic 論点 3 評価済)

| 確認項目 | 結果 |
|---|---|
| `app/jobs/` 独自 Job クラス | ゼロ (= application_job.rb のみ) |
| `perform_later` / `perform_now` 呼び出し | 0 件 |
| `deliver_later` (ActionMailer) 呼び出し | 0 件 |
| ActionCable broadcast | 利用なし |
| `solid_cable` adapter | SolidQueue とは独立 (= cable 用 DB polling、worker 不要) |

→ SolidQueue 停止で機能影響ゼロ。

## Test plan

### マージ前

- [x] `git diff` で意図通りの差分確認 (= +24 / -4、2 ファイル)
- [x] 3 者並列レビュー実施 + Blocker 1 件修正 + 軽微 4 件全件吸収
- [x] devcontainer で `if ENV["X"] == "true"` 値比較動作確認 (= strategic-reviewer 実証)

### マージ後 (= 本番デプロイ後)

- [ ] Render の自動デプロイ完了を確認
- [ ] Puma 起動ログに `SolidQueue-1.4.0 Started Supervisor/Worker/Dispatcher/Scheduler` が **出ていない** ことを確認
- [ ] Render Metrics でメモリベースラインがさらに下がる (= PR #283 の Puma single mode 化に上乗せ) ことを観測
- [ ] アプリ動作に異常がないことを確認 (= 主要画面表示 + OAuth ログイン)
- [ ] 24 時間以内に OOM クラッシュ再発がないことを確認

## 関連

- Issue #284 (= Closes)
- Issue #281 (= 親調査 Issue、本 PR で完了)
- Issue #280 / PR #283 (= 同 OOM 対策、Puma single mode 化)
- Issue #282 (= Anthropic API 400 修正、別 PR で対応予定)
- `config/puma.rb:38` (= Blocker 修正対象)
- `config/environments/production.rb:53` (= queue_adapter 残置箇所)
- `config/recurring.yml` (= 自己掃除 job、本 PR で停止)
- memory 化候補: `feedback_env_truthiness_pitfall.md` (= 別 Issue 起票候補)
- memory `feedback_always_three_reviewers.md` (= 3 者並列レビュー実施)
- memory `feedback_light_issue_one_pr_completion.md` (= 軽量 Issue 1 PR ルール 14 例目)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
