### PR TITLE
polish(ai): エラーログを完全 body 出力に修正 + webhooks_controller 同パターン同時駆除 (#288)

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -17,16 +17,21 @@ class WebhooksController < ActionController::API
     record_delivery!(status: "success", accepted_count: accepted)
     render json: { accepted: accepted }, status: :ok
   rescue JSON::ParserError => e
-    Rails.logger.warn("[WebhooksController] JSON parse error: #{e.message.truncate(120)}")
+    # truncate(2000): 真因即発見のための余裕値。詳細根拠は #288 / app/services/calorie_advice_service.rb 参照。
+    Rails.logger.warn("[WebhooksController] JSON parse error: #{e.message.truncate(2000)}")
     record_delivery!(status: "invalid", accepted_count: 0, error_message: I18n.t("webhook.errors.json_parse_error"))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   rescue WebhookHealthDataIngestService::InvalidPayload => e
+    # truncate(120): 本箇所は DB の WebhookDelivery#error_message column に保存する用途
+    # (= ログ出力でなく管理画面表示用) のため、ログ用 truncate(2000) ルール (= #288) は非適用。
+    # column のサイズ制約 + 表示行長を考慮した既存値を維持。
     record_delivery!(status: "invalid", accepted_count: 0, error_message: e.message.truncate(120))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   rescue ActiveRecord::RecordInvalid => e
     # 個々のレコードのバリデーション違反 (負数 / 不正な日付等) を 500 ではなく 422 + 監査ログで返す。
     # rails-implementer の意図 (全体失敗方式) を実装まで貫徹するため。
-    Rails.logger.warn("[WebhooksController] RecordInvalid: #{e.message.truncate(120)}")
+    # truncate(2000): 真因即発見のための余裕値。詳細根拠は #288 / app/services/calorie_advice_service.rb 参照。
+    Rails.logger.warn("[WebhooksController] RecordInvalid: #{e.message.truncate(2000)}")
     record_delivery!(status: "invalid", accepted_count: 0, error_message: I18n.t("webhook.errors.record_invalid"))
     render json: { error: "Invalid payload" }, status: :unprocessable_content
   end

--- a/app/services/calorie_advice_service.rb
+++ b/app/services/calorie_advice_service.rb
@@ -88,7 +88,25 @@ class CalorieAdviceService
   rescue StandardError => e
     # API failure / timeout / rate limit / JSON parse error すべて広く受けてフォールバック。
     # 細粒度の制御 (= 例外別の retry 等) は polish フェーズで Issue 化して別途。
-    Rails.logger.warn("[CalorieAdviceService] AI failed (#{e.class}: #{e.message.truncate(120)}), falling back to static")
+    #
+    # [#288 truncate 上限を 2000 に引き上げ]
+    # 旧 truncate(120) は短すぎて真因が `invalid_request_erro...` で切れて見えず
+    # (= Issue #282 で truncate(120) で切れた実際のログ出力)、API クレジット枯渇時の
+    # "Your credit balance is too low..." を見逃して原因特定が遅れた教訓を反映。
+    #
+    # 値選定根拠 (= 2000 バイト):
+    # e.message は anthropic gem の APIStatusError#initialize で `{url:, status:, body:}.to_s`
+    # として展開される (= JSON 文字列ではなく Hash の to_s、errors.rb:159 参照)。url 約 40
+    # バイト + status 3 バイト + body 通常 200-500 バイト (= Issue #282 のログ実測 約 280
+    # バイト) = 合計 250-550 バイト程度。2000 はその 4 倍弱の余裕を持ちつつ、1 行ログとして
+    # grep / less で読める経験則の上限内。巨大 body が返ってきた場合 (= 想定外) のログ
+    # 肥大化ガードも兼ねる。
+    #
+    # セキュリティ注意:
+    # Anthropic API の body は通常エラー文 (`{type: "error", error: {type, message}}`) で
+    # API key や PII を含まない仕様。ただし gem アップグレード時は anthropic gem の
+    # errors.rb#initialize の body 展開ロジックを再確認すること (= 認証情報混入リスク)。
+    Rails.logger.warn("[CalorieAdviceService] AI failed (#{e.class}: #{e.message.truncate(2000)}), falling back to static")
     static_items = Static.call(estimated_kcal)
     Result.new(headline: HEADLINE, items: static_items, button_label: BUTTON_LABEL, ai_used: false)
   end


### PR DESCRIPTION
## Summary

- Issue #282 (= Anthropic API クレジット枯渇真因が `truncate(120)` で切れて発見が遅れた教訓) を受けた改善
- `CalorieAdviceService` + `WebhooksController` の rescue 節 ログ出力で `e.message.truncate(120)` → `truncate(2000)` に拡大
- 真因即発見を可能にし、将来の API エラー (= rate limit / model deprecation / credit / spec change) の調査効率向上
- **strategic-reviewer の grep 指摘で同パターン全件駆除に拡張** (= memory `feedback_grep_zero_after_fix.md` の polish PR 適用)

## 同パターン駆除の判定 (= L24 は除外)

webhooks_controller.rb で grep ヒット 3 箇所のうち、**性質が違う 1 箇所は意図的に除外**:

| 行 | 経路 | 用途 | 対応 |
|---|---|---|---|
| L20 | `JSON::ParserError` | **Rails.logger.warn** (= ログ用) | `truncate(2000)` 修正 ✅ |
| L24 | `WebhookHealthDataIngestService::InvalidPayload` | **DB の `WebhookDelivery#error_message` column 保存用** (= 管理画面表示用) | **意図的残置 + コメント根拠明示** |
| L29 | `ActiveRecord::RecordInvalid` | **Rails.logger.warn** (= ログ用) | `truncate(2000)` 修正 ✅ |

→ ログ用 `truncate(120)` は **grep 0 件達成** (= memory `feedback_grep_zero_after_fix.md` 達成)。

## 3 者並列レビュー指摘の反映

**🚨 Blocker: 0 件**

**🟡 軽微: 6 件 → 全件吸収**

- [strategic 論点 1] webhooks_controller 同パターン全件駆除 (= **B 案採用、本 PR 内拡張**)
- [code ⚠️] セキュリティ注意コメント追加 (= API キー漏洩リスク + gem upgrade 時再確認)
- [code 💡] 数値根拠精度修正 (= `Hash の to_s として展開`、url + status + body 合計バイト数で説明)
- [strategic 論点 2] 2000 値選定軸 1 行追加 (= grep / less で読める経験則の上限内)
- [design 1] 「200-500 バイト」 出所明示 (= `Issue #282 のログ実測 約 280 バイト`)
- [design 2] 段落区切り `[#288 ...]` 小見出し風 (= render.yaml `[5/10 OOM 対策 #280]` フォーマット軽量版)
- [design 3] `invalid_request_erro...` 省略表記補足 (= `Issue #282 で truncate(120) で切れた実際のログ出力`)

**🟢 提案: 1 件 → 別 Issue 候補として残置**

- memory `feedback_grep_zero_after_fix.md` の polish PR 適用拡張 (= 別 Issue 起票候補、本 PR スコープ外)

詳細はコミットメッセージに記載。**軽量 Issue 1 PR ルール 15 例目連続達成** (= Day 12-1 14 例から +1)。

## Test plan

### マージ前

- [x] `git diff` で意図通りの差分確認 (= +26 / -3、2 ファイル)
- [x] **grep 確認**: ログ用 `e.message.truncate(120)` は 0 件 (= 同パターン全駆除達成)
  ```
  $ grep -rn "truncate(120)" app/
  app/controllers/webhooks_controller.rb:25:    # truncate(120): 本箇所は DB の WebhookDelivery#error_message column...
  app/controllers/webhooks_controller.rb:28:    record_delivery!(status: "invalid", accepted_count: 0, error_message: e.message.truncate(120))
  app/services/calorie_advice_service.rb:93-94: # コメント内の歴史的言及 (= 「旧 truncate(120) は短すぎ」)
  ```
  → 残存 L28 は DB 用で意図的残置 (= 性質が違うため非適用)、L93-94 は歴史的言及のコメント (= コード非該当)
- [x] 3 者並列レビュー実施 + 指摘 6 件全件吸収
- [x] 既存 spec への影響確認 (= `calorie_advice_service_spec.rb:241` の `/AI failed.*falling back to static/` 正規表現マッチは維持される)

### マージ後

- [ ] 本番デプロイ後、次回 API エラー発生時にログで body 完全出力されることを確認
- [ ] (将来) AI クレジット枯渇等のエラーで `Your credit balance is too low` 等の真因が即読めることを観測

## 関連

- Issue #288 (= Closes)
- Issue #282 (= 起源、クレジット枯渇真因発覚時の教訓)
- Issue #289 (= 並走の改善 Issue、クレジット監視設計)
- `app/services/calorie_advice_service.rb`
- `app/controllers/webhooks_controller.rb`
- memory `feedback_grep_zero_after_fix.md` (= 同名パターン全駆除ルール、本 PR で polish PR への適用拡張を実演)
- memory `feedback_always_three_reviewers.md` (= 3 者並列レビュー実施)
- memory `feedback_light_issue_one_pr_completion.md` (= 軽量 Issue 1 PR ルール 15 例目)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
