### PR TITLE
feat(ops): OneTimeLoginToken GC ジョブ + auto_login Cache-Control 整備 (#176)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -33,7 +33,7 @@ class SessionsController < ApplicationController
   # Capacitor WebView 側の入口。custom scheme で受け取った one-time token を消費し、WebView cookie storage に session を確立する。
   # token は単独で完結し外部から漏れても 30 秒 + 1 回限りで失効するが、念のため reset_session で session fixation を排除。
   def auto_login
-    response.headers["Cache-Control"] = "no-store" # Turbo Drive prefetch 予防 (= 将来 link_to が増えた時に token を意図せず消費されないように)
+    response.cache_control[:no_store] = true # Turbo Drive prefetch 予防 (= 将来 link_to が増えた時に token を意図せず消費されないように)
     token = OneTimeLoginToken.consume!(token: params[:token].to_s)
     if token.nil?
       Rails.logger.warn("auto_login rejected: invalid/expired/used token")

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -33,6 +33,7 @@ class SessionsController < ApplicationController
   # Capacitor WebView 側の入口。custom scheme で受け取った one-time token を消費し、WebView cookie storage に session を確立する。
   # token は単独で完結し外部から漏れても 30 秒 + 1 回限りで失効するが、念のため reset_session で session fixation を排除。
   def auto_login
+    response.headers["Cache-Control"] = "no-store" # Turbo Drive prefetch 予防 (= 将来 link_to が増えた時に token を意図せず消費されないように)
     token = OneTimeLoginToken.consume!(token: params[:token].to_s)
     if token.nil?
       Rails.logger.warn("auto_login rejected: invalid/expired/used token")

--- a/app/jobs/cleanup_one_time_login_tokens_job.rb
+++ b/app/jobs/cleanup_one_time_login_tokens_job.rb
@@ -1,0 +1,9 @@
+class CleanupOneTimeLoginTokensJob < ApplicationJob
+  queue_as :default
+
+  # TTL は 30s だが record は残る (= consume! が delete でなく used_at 更新のため)。
+  # expires_at < 1.day.ago 一本で未使用 / 使用済問わず保持不要を網羅できる。
+  def perform
+    OneTimeLoginToken.where("expires_at < ?", 1.day.ago).delete_all
+  end
+end

--- a/app/jobs/cleanup_one_time_login_tokens_job.rb
+++ b/app/jobs/cleanup_one_time_login_tokens_job.rb
@@ -3,6 +3,7 @@ class CleanupOneTimeLoginTokensJob < ApplicationJob
 
   # TTL は 30s だが record は残る (= consume! が delete でなく used_at 更新のため)。
   # expires_at < 1.day.ago 一本で未使用 / 使用済問わず保持不要を網羅できる。
+  # (Issue #176 では expired_or_used scope 案だったが、TTL 30s なら expires_at 一本で網羅できるため単純化)
   def perform
     OneTimeLoginToken.where("expires_at < ?", 1.day.ago).delete_all
   end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  cleanup_one_time_login_tokens:
+    class: CleanupOneTimeLoginTokensJob
+    schedule: every day at 4am

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -15,4 +15,4 @@ production:
     schedule: every hour at minute 12
   cleanup_one_time_login_tokens:
     class: CleanupOneTimeLoginTokensJob
-    schedule: every day at 4am
+    schedule: at 4am every day

--- a/db/migrate/20260512015038_add_index_to_one_time_login_tokens_expires_at.rb
+++ b/db/migrate/20260512015038_add_index_to_one_time_login_tokens_expires_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToOneTimeLoginTokensExpiresAt < ActiveRecord::Migration[8.1]
+  def change
+    add_index :one_time_login_tokens, :expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_212134) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_12_015038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_212134) do
     t.datetime "updated_at", null: false
     t.datetime "used_at"
     t.bigint "user_id", null: false
+    t.index ["expires_at"], name: "index_one_time_login_tokens_on_expires_at"
     t.index ["token"], name: "index_one_time_login_tokens_on_token", unique: true
     t.index ["user_id"], name: "index_one_time_login_tokens_on_user_id"
   end

--- a/spec/jobs/cleanup_one_time_login_tokens_job_spec.rb
+++ b/spec/jobs/cleanup_one_time_login_tokens_job_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe CleanupOneTimeLoginTokensJob, type: :job do
+  subject(:job) { described_class.new }
+
+  # GC 閾値: expires_at < 1.day.ago のレコードを削除する。
+  # 未使用 / 使用済みは問わない (= 期限が 1 日以上前なら保持不要)。
+
+  describe "#perform" do
+    let(:user) { create(:user) }
+
+    context "when expires_at is older than 1 day ago (= GC 対象)" do
+      let!(:stale_unused) do
+        # expires_at を 1.day.ago より古く設定: 未使用トークン
+        create(:one_time_login_token, user: user, expires_at: 1.day.ago - 1.second)
+      end
+
+      let!(:stale_used) do
+        # expires_at を 1.day.ago より古く設定: 使用済みトークン
+        create(:one_time_login_token, :used, user: user, expires_at: 1.day.ago - 1.second)
+      end
+
+      it "deletes stale unused tokens" do
+        job.perform
+        expect(OneTimeLoginToken.exists?(stale_unused.id)).to be(false)
+      end
+
+      it "deletes stale used tokens" do
+        job.perform
+        expect(OneTimeLoginToken.exists?(stale_used.id)).to be(false)
+      end
+
+      it "reduces the total count by the number of stale records" do
+        expect { job.perform }.to change(OneTimeLoginToken, :count).by(-2)
+      end
+    end
+
+    context "when expires_at is exactly at the boundary (= 1.day.ago より新しい側)" do
+      let!(:boundary_token) do
+        # expires_at が 1.day.ago + 1.second = 閾値より新しいため残る
+        create(:one_time_login_token, user: user, expires_at: 1.day.ago + 1.second)
+      end
+
+      it "does not delete the token just inside the boundary" do
+        job.perform
+        expect(OneTimeLoginToken.exists?(boundary_token.id)).to be(true)
+      end
+    end
+
+    context "when expires_at is in the future (= まだ有効なトークン)" do
+      let!(:live_token) { create(:one_time_login_token, user: user) }
+
+      it "does not delete the live token" do
+        job.perform
+        expect(OneTimeLoginToken.exists?(live_token.id)).to be(true)
+      end
+
+      it "does not change the total count" do
+        expect { job.perform }.not_to change(OneTimeLoginToken, :count)
+      end
+    end
+
+    context "when stale and live tokens coexist" do
+      let!(:stale_token) do
+        create(:one_time_login_token, user: user, expires_at: 1.day.ago - 1.second)
+      end
+
+      let!(:live_token) { create(:one_time_login_token, user: user) }
+
+      it "deletes only the stale token and keeps the live one" do
+        job.perform
+        expect(OneTimeLoginToken.exists?(stale_token.id)).to be(false)
+        expect(OneTimeLoginToken.exists?(live_token.id)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/jobs/cleanup_one_time_login_tokens_job_spec.rb
+++ b/spec/jobs/cleanup_one_time_login_tokens_job_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 RSpec.describe CleanupOneTimeLoginTokensJob, type: :job do
-  subject(:job) { described_class.new }
+  let(:job) { described_class.new }
 
   # GC 閾値: expires_at < 1.day.ago のレコードを削除する。
   # 未使用 / 使用済みは問わない (= 期限が 1 日以上前なら保持不要)。
 
   describe "#perform" do
+    around { |example| freeze_time { example.run } }
     let(:user) { create(:user) }
 
     context "when expires_at is older than 1 day ago (= GC 対象)" do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -154,6 +154,8 @@ RSpec.describe "Sessions", type: :request do
         expect(flash[:notice]).to eq("ログインしました")
       end
 
+      # auto_login は成功時 302 redirect を返すため、302 自体のキャッシュ防止ではなく
+      # 「万一ブラウザが URL をキャッシュした場合の token 消費予防」 が意図。
       it "sets Cache-Control: no-store to prevent token URL caching" do
         get auto_login_path(token: token_record.token)
         expect(response.headers["Cache-Control"]).to eq("no-store")

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -153,6 +153,11 @@ RSpec.describe "Sessions", type: :request do
         get auto_login_path(token: token_record.token)
         expect(flash[:notice]).to eq("ログインしました")
       end
+
+      it "sets Cache-Control: no-store to prevent token URL caching" do
+        get auto_login_path(token: token_record.token)
+        expect(response.headers["Cache-Control"]).to eq("no-store")
+      end
     end
 
     context "with an expired token" do


### PR DESCRIPTION
## Summary

Issue #176 (= Phase 3 OAuth ブリッジで導入した `OneTimeLoginToken` の運用整備) を実装。

- **A.** `CleanupOneTimeLoginTokensJob` 新設。`expires_at < 1.day.ago` のレコードを `delete_all` で GC。`config/recurring.yml` に `every day at 4am` で登録。
- **B.** `SessionsController#auto_login` に `Cache-Control: no-store` を 1 行追加。Turbo Drive prefetch で意図せず token を消費されるリスクを予防。

## 実装判断

- **削除条件を `expires_at < 1.day.ago` 一本に絞った理由**: TTL は 30 秒だが `consume!` は `update_all(used_at:)` で record を残す設計。`expires_at < 1.day.ago` は「未使用 / 使用済」 を問わず保持不要を網羅できる (= used でも unused でも、expires_at が 1 日以上前 = TTL の 2880 倍 経過済なら GC して問題なし)。Issue 本文の `expired_or_used.where(created_at < 1.day.ago)` より単純化。
- **猶予を TTL でなく 1 日 にした理由**: デバッグ・監査ログと突き合わせる時の余裕を確保。TTL 直後に消すと「auto_login 失敗した時にレコード追えない」状況になりうる。

## Test plan

- [x] `bundle exec rspec spec/jobs spec/requests/sessions_spec.rb` → 33 examples, 0 failures
- [x] `bundle exec rubocop` → 84 files inspected, no offenses
- [ ] (任意) 本番 Solid Queue で `cleanup_one_time_login_tokens` が登録されているか確認 (= Render デプロイ後ログ確認)

## レビュー観点

- **TZ**: `every day at 4am` はサーバ TZ 依存。Render は UTC 想定。`config/application.rb` の `config.time_zone = "Tokyo"` でも Solid Queue recurring は内部的に UTC で評価されるはず。気になるなら明示 `every day at 4am UTC` への変更を検討。
- **`expires_at < 1.day.ago` の境界**: Issue 本文より単純化した代償として「未使用で expires_at 直後」も TTL 30s 経過後は GC 対象。実害は無いが意図共有。
- **Cache-Control: no-store**: `expires_now` (= `no-cache, private`) との使い分けは「キャッシュ非保存」を厳格に伝えるため `no-store` 採用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)