### PR TITLE
feat(ui): navbar に safe-area-inset 補正を追加 (#190)

### DIFF
--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -27,7 +27,7 @@
      navbar 高さを変更した際に参照箇所を一括更新できる (= Issue #174 B)。
      基準値 64px = padding 8px×2 + ボタン約 46px + border-bottom 2px (= Issue #49 slim 化後の実測値)。
      iPhone PWA 端末では env(safe-area-inset-top) が 8px を超える分だけ追加で拡大 (= Issue #190)。 */
-  --navbar-height: calc(64px + max(0px, env(safe-area-inset-top) - 8px));
+  --navbar-height: calc(64px + max(0px, env(safe-area-inset-top, 0px) - 8px));
 }
 
 /* body 全体を紙質背景に。layout から bg-base-200 は外す前提。
@@ -56,8 +56,10 @@ body {
   display: flex; align-items: center; justify-content: space-between;
   /* iPhone PWA / Dynamic Island 端末で padding-top を env(safe-area-inset-top) に拡大、ノッチ侵入回避 (= Issue #190)。
      Android Chrome / Desktop は env = 0px のため max(8px, 0px) = 8px で従来挙動維持。
+     env(..., 0px) 第 2 引数は古い Chrome (< 69) / IE 等の未サポート環境向け fallback。
+     padding-bottom 8px は固定 (= 画面下端の safe-area-inset-bottom は navbar の下端には発生しない)。
      --navbar-height も連動して env 値ぶん拡大するため、flash toast の top-offset も追従する。 */
-  padding: max(8px, env(safe-area-inset-top)) 20px 8px; gap: 12px;
+  padding: max(8px, env(safe-area-inset-top, 0px)) 20px 8px; gap: 12px;
   border-bottom: 2px solid var(--ink);
   background: var(--paper);
   position: sticky; top: 0; z-index: 30;

--- a/app/assets/stylesheets/sketchy.css
+++ b/app/assets/stylesheets/sketchy.css
@@ -25,8 +25,9 @@
   /* navbar 高さ参照変数。navbar 自体の高さは padding/content で決まり、この変数に引きずられない。
      参照側 (flash toast の top-offset 等) が --navbar-height を使うことで、
      navbar 高さを変更した際に参照箇所を一括更新できる (= Issue #174 B)。
-     現在値 64px = padding 8px×2 + ボタン約 46px + border-bottom 2px (= Issue #49 slim 化後の実測値)。 */
-  --navbar-height: 64px;
+     基準値 64px = padding 8px×2 + ボタン約 46px + border-bottom 2px (= Issue #49 slim 化後の実測値)。
+     iPhone PWA 端末では env(safe-area-inset-top) が 8px を超える分だけ追加で拡大 (= Issue #190)。 */
+  --navbar-height: calc(64px + max(0px, env(safe-area-inset-top) - 8px));
 }
 
 /* body 全体を紙質背景に。layout から bg-base-200 は外す前提。
@@ -53,7 +54,10 @@ body {
    sticky 重なり時の視認性確保のためそのまま維持。 */
 .sketch-navbar {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 8px 20px; gap: 12px;
+  /* iPhone PWA / Dynamic Island 端末で padding-top を env(safe-area-inset-top) に拡大、ノッチ侵入回避 (= Issue #190)。
+     Android Chrome / Desktop は env = 0px のため max(8px, 0px) = 8px で従来挙動維持。
+     --navbar-height も連動して env 値ぶん拡大するため、flash toast の top-offset も追従する。 */
+  padding: max(8px, env(safe-area-inset-top)) 20px 8px; gap: 12px;
   border-bottom: 2px solid var(--ink);
   background: var(--paper);
   position: sticky; top: 0; z-index: 30;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,7 +82,7 @@
     </header>
 
     <%# flash はトースト風に画面上部 fixed で重ねる (document flow から外れるため、表示/非表示で下のコンテンツがズレない)。
-        top offset は CSS 変数 --navbar-height (= 64px) + 余白 16px で計算 (= Issue #174 B)。
+        top offset は CSS 変数 --navbar-height (= 基準 64px、iPhone PWA は env(safe-area-inset-top) 連動で拡大) + 余白 16px で計算 (= Issue #174 B / #190)。
         --navbar-height は :root で定義済み (sketchy.css)。参照側のみ変数を使い、navbar 自体の高さは
         padding/content/border で決まる (= slim 化挙動を壊さないため変数を navbar 本体には適用しない)。
         FOUC 対策: 初期 opacity-0 + Stimulus connect() で fade-in。JS 無効フォールバックは <head> の <noscript><style> 参照。


### PR DESCRIPTION
## Summary

Issue #190 (= v1.1: viewport-fit=cover を活かす safe-area-inset 補正) を実装。iPhone PWA / Dynamic Island 端末でノッチ侵入による navbar 上辺欠けを回避。

- `.sketch-navbar` の `padding-top` を `max(8px, env(safe-area-inset-top, 0px))` に拡大 (= padding-right/bottom/left は維持、bottom は固定で safe-area-inset-bottom は navbar 下端には発生しない)
- `:root --navbar-height` を `calc(64px + max(0px, env(safe-area-inset-top, 0px) - 8px))` に変更 → flash toast の `top-[calc(var(--navbar-height)+16px)]` が連動して下に追従

Closes #190

## メタ教訓: 「meta タグ宣言 + CSS env() 補正」 は 2 PR で 1 機能パターン

PR #189 (= `viewport-fit=cover` 宣言) + 本 PR (= CSS env() 補正) で **初めて 1 機能完成**。meta タグだけだと「動いた気がするが効いてない」 状態になり、CSS 側ペアリングを忘れると code-reviewer 指摘で後追い補正 (= 本 PR の構造、Issue #190 起票経路) になる。今後 `theme-color` / `apple-mobile-web-app-capable` 等の類似 meta 追加時は、宣言と CSS 補正を同一 PR で出すと Issue 起票の往復が 1 回減る。

## 副作用判断

| 環境 | `env(safe-area-inset-top, 0px)` | 挙動 |
|---|---|---|
| iPhone 11+ Safari PWA | ~44px | padding-top 44px、navbar 約 100px、toast も連動 ✓ |
| iPhone Dynamic Island PWA | ~59px | padding-top 59px、navbar 約 115px、toast 連動 ✓ |
| Android Chrome | 0px | `max(8px, 0px) = 8px` → 現状維持 ✓ |
| Desktop | 0px | 現状維持 ✓ |
| 古い Chrome (< 69) / IE | env 未対応 | 第 2 引数 `0px` で fallback → 現状維持 ✓ |

## 実装判断

- **`max(8px, env(safe-area-inset-top, 0px))`**: env が 0px の Android/Desktop では 8px に着地して既存挙動を完全維持。env が 8px 超 (= iPhone ノッチ端末) のときのみ拡大。第 2 引数 `0px` で古いブラウザ向け fallback
- **`--navbar-height` の calc**: padding-top 増分のみ追加 (`max(0px, env(...) - 8px)`) で、Android/Desktop では基準値 64px 維持
- **コメント整合性**: `app/views/layouts/application.html.erb:85` の `--navbar-height (= 64px)` 表記も実態 (= 動的 calc、ノッチ端末で拡大) に合わせ更新

## Test plan

- [x] `bundle exec rspec` → 615 examples, 0 failures (= CSS / ERB コメントのみで spec 影響なし)
- [ ] **(実機検証必須、局長側)** iPhone 11+ Safari の Home Screen 追加 → navbar 上辺が欠けない
- [ ] **(実機検証)** iPhone PWA で flash toast の表示位置が navbar 下端 +16px に追従
- [ ] **(実機検証)** Android Chrome / Desktop で navbar 高さに変化なし (= 従来挙動維持)
- [ ] **(実機検証推奨、design-reviewer 由来)** Dynamic Island 端末 (iPhone 14 Pro+) でタイトル文字 (Caveat 32px) の視覚バランス確認

## マージ後タスク (= 別 Issue / Issue コメント)

- [ ] Issue #190 にコメントで「navbar が唯一の sticky 要素なので本 PR で完結」 判断ログ追記 (= memory `feedback_issue_as_decision_log.md` の運用)
- [ ] settings モーダル / `_welcome_modal` の safe-area-inset 補正を別 Issue 起票 (= v1.2、design-reviewer 提案 1)

## 関連

- PR #189 (= viewport-fit=cover 宣言、本 Issue の起源)
- PR #173 (= navbar sticky 化、本問題の前提)
- PR #187 (= --navbar-height CSS 変数化)
- memory `feedback_issue_as_decision_log.md` (= マージ後判断ログ運用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)