### PR TITLE
ci(android): GitHub Actions で debug APK ビルド + Release 添付 (#126 子 7)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install npm dependencies (= Capacitor / @capgo plugins)
         run: npm ci
 
+      - name: Sync Capacitor Android (= node_modules → android/ プロジェクト同期、capacitor.settings.gradle が解決可能になる)
+        run: npx cap sync android
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -74,12 +77,14 @@ jobs:
           body: |
             ## weight_dialy ${{ steps.tag.outputs.name }} — Android sideload APK
 
-            ⚠️ **debug 署名 + sideload 配布**。Google Play 経由ではないため、初回インストール時は「不明なアプリのインストール」許可が必要です。
+            ⚠️ **debug 署名 + sideload 配布**。Google Play 経由ではないため、初回インストール時は「提供元不明のアプリ」許可ダイアログ + Play Protect 警告が出ます。
+
+            > **インストールが難しい / Android 以外の方**: [Web 版](https://weight-dialy.onrender.com) からも全機能をお試しいただけます。
 
             ### インストール手順
-            1. 下の Assets から `weight-dialy-${{ steps.tag.outputs.name }}-debug.apk` をダウンロード
-            2. 端末の 設定 → アプリと通知 → 特別なアプリアクセス → 「不明なアプリのインストール」で利用ブラウザに許可
-            3. APK タップ → インストール (= Play Protect の「未確認のアプリ」警告は「許可」)
+            1. 下の Assets から `weight-dialy-${{ steps.tag.outputs.name }}-debug.apk` をダウンロード (例: `weight-dialy-v0.1.0-debug.apk`)
+            2. ダウンロードした APK をタップ → 「このアプリの提供元を許可しますか?」ダイアログが出たら **「許可」** をタップ (= ダイアログが出ない機種は 設定 → アプリ → 特別なアプリアクセス → 提供元不明のアプリ → 利用したブラウザを許可)
+            3. インストール → Play Protect の「未確認のアプリ」警告は **「許可」** をタップ (= debug 署名のため正常、スクール公開用の dogfood 版です)
             4. 初回起動 → Health Connect の権限ダイアログを許可
             5. アプリ内 Settings から Webhook トークンを設定 (= [Web 版](https://weight-dialy.onrender.com) で取得)
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,86 @@
+name: Android Release APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag (e.g., v0.1.0-test)'
+        required: true
+        default: 'v0.1.0-test'
+
+jobs:
+  build:
+    name: Build debug APK and attach to Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install npm dependencies (= Capacitor / @capgo plugins)
+        run: npm ci
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        working-directory: android
+        run: chmod +x ./gradlew
+
+      - name: Build debug APK
+        working-directory: android
+        run: ./gradlew assembleDebug --no-daemon --stacktrace
+
+      - name: Resolve tag name
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rename APK with tag suffix
+        run: |
+          mkdir -p artifacts
+          cp android/app/build/outputs/apk/debug/app-debug.apk \
+             "artifacts/weight-dialy-${{ steps.tag.outputs.name }}-debug.apk"
+
+      - name: Create or update GitHub Release with APK
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: weight_dialy ${{ steps.tag.outputs.name }}
+          generate_release_notes: true
+          files: artifacts/weight-dialy-${{ steps.tag.outputs.name }}-debug.apk
+          fail_on_unmatched_files: true
+          body: |
+            ## weight_dialy ${{ steps.tag.outputs.name }} — Android sideload APK
+
+            ⚠️ **debug 署名 + sideload 配布**。Google Play 経由ではないため、初回インストール時は「不明なアプリのインストール」許可が必要です。
+
+            ### インストール手順
+            1. 下の Assets から `weight-dialy-${{ steps.tag.outputs.name }}-debug.apk` をダウンロード
+            2. 端末の 設定 → アプリと通知 → 特別なアプリアクセス → 「不明なアプリのインストール」で利用ブラウザに許可
+            3. APK タップ → インストール (= Play Protect の「未確認のアプリ」警告は「許可」)
+            4. 初回起動 → Health Connect の権限ダイアログを許可
+            5. アプリ内 Settings から Webhook トークンを設定 (= [Web 版](https://weight-dialy.onrender.com) で取得)
+
+            詳細手順は README の Android sideload セクションを参照してください。


### PR DESCRIPTION
## Summary
- 親 Issue #40 子 7 (= Issue #126) を「GitHub Release 経由配布」で完走するための GitHub Actions ワークフロー追加
- `v*` タグ push または `workflow_dispatch` で起動 → debug APK をビルド → Release 自動作成 + APK 添付
- 別 PR で README sideload セクションを実物リンクに差し替え予定 (= 並行起動)

## 設計判断

### なぜ Actions 経路 (= 手動 Windows ビルドではない)
- 再現性 / 教材性 (= 後輩が PR 経由で APK 更新できる)
- ローカル WSL に JDK + Android SDK 未導入、Windows Android Studio 経由は端末固定リスク
- **撤退ライン**: 17:00 までに Actions 経路で APK が Release に乗らない場合は Windows Android Studio 手動ビルド + \`gh release create\` へフォールバック (= 子 6 で実証済)

### Node 20 + npm ci が必須な理由
- \`android/capacitor.settings.gradle\` が \`../node_modules/@capacitor/android/capacitor\` 等を参照
- \`@capgo/capacitor-health\` の Android プロジェクトも \`node_modules\` 配下にあり、npm install しないと Gradle で依存解決失敗

### JDK 21
- \`android/app/capacitor.build.gradle\` で \`sourceCompatibility VERSION_21\` / \`targetCompatibility VERSION_21\` 指定
- Capacitor 8 系 + AGP 8.13.0 + compileSdk 36 (Android 14) の組合せ

### debug 署名のまま配布
- Issue #126 確定: 「sideload + dogfood なら debug 署名で十分」 (= release 署名キーストア生成は v1.1 検討)
- Release body に Play Protect 警告 + 「不明なアプリのインストール」許可手順を明記

## Test plan
- [ ] PR マージ後、Actions タブから \`Android Release APK\` を **workflow_dispatch** で起動 (= \`v0.1.0-test\`)
- [ ] ビルド成功 → Releases ページに \`v0.1.0-test\` + \`weight-dialy-v0.1.0-test-debug.apk\` が表示される
- [ ] 動作確認後、v0.1.0-test Release は削除して本番 \`v0.1.0\` タグ push でやり直す (= 本番 Release は generate_release_notes でクリーンに)
- [ ] 17:00 までに緑にならない場合は撤退ライン適用 → Windows Android Studio 手動経路へ

## 関連
- 親 Issue #40 (= Capacitor + Health Connect で Android 完全対応)
- 子 7 Issue #126 (= APK ビルド + sideload 手順)
- 子 1-6 (#119-#123 + #125): 全 close 済 / 子 5b (#124): v1.1 切り離し方針

🤖 Generated with [Claude Code](https://claude.com/claude-code)