### PR TITLE
fix(ci): Node 20 → 22 (Capacitor CLI 8.x の必須要件) (#126 hotfix)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
+      - name: Set up Node.js (= Capacitor CLI 8.x requires Node >= 22)
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install npm dependencies (= Capacitor / @capgo plugins)


### PR DESCRIPTION
## Summary
- PR #305 マージ後の v0.1.0-test ビルド (= run 25718197893) が `npx cap sync android` ステップで失敗:
  ```
  [fatal] The Capacitor CLI requires NodeJS >=22.0.0
  Please install the latest LTS version.
  ```
- Capacitor 8.x 系は **Node >= 22 必須** (= 公式リリースノートで明示)
- setup-node の `node-version: 20` → `22` へ 1 行修正

## 設計判断
- 影響範囲: workflow yaml のみ (= Rails コード / Android プロジェクトに影響なし)
- Node 22 は LTS、ubuntu-latest runner で安定動作
- 撤退ライン: 17:00 まで残 1h+、本 hotfix → タグ削除 → 再 push で 16:30 までに動作確認完了想定

## Test plan
- [ ] マージ後、`v0.1.0-test` タグを削除 → 再 push
- [ ] Actions Sync Capacitor Android ステップが通過する
- [ ] Build debug APK ステップが完走する
- [ ] Release に APK が添付される

## 関連
- PR #305 (= 親、本 hotfix の対象 workflow を入れた PR)
- Issue #126 (= 子 7、v1.0 リリースの最後のピース)
- Issue #40 (= 親 Issue、Capacitor + Health Connect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)