### PR TITLE
fix(android): colors.xml の XML コメント仕様違反 (--) を解消 (#126 hotfix 2)

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- weight_dialy ブランドカラー (= sketchy theme との一貫性、Web 版 CSS 変数 --paper と完全に同色)。
-         splash screen 背景に使用、Capacitor デフォルトの「Android ロボット + 水色背景」を置き換える (= Issue #128)。 -->
+    <!-- weight_dialy ブランドカラー (= sketchy theme との一貫性、Web 版 CSS 変数 paper と完全に同色)。
+         splash screen 背景に使用、Capacitor デフォルトの「Android ロボット + 水色背景」を置き換える (= Issue #128)。
+         注: XML コメント仕様で "double dash" 文字列は禁止のため CSS の "--" プレフィックスは記述から除外している。 -->
     <color name="colorSplashBackground">#fbf8f1</color>
 </resources>


### PR DESCRIPTION
## Summary
- 親 PR #305 (= GitHub Actions workflow) + PR #307 (= Node 22 hotfix) を経た Actions run 25718399622 が **2 回目の失敗**
- 失敗 step: \`Build debug APK\` (= Gradle \`mergeDebugResources\`)
- エラー: \`colors.xml:3:69: Error: The string "--" is not permitted within comments.\`
- 原因: XML 仕様 (= W3C XML 1.0 §2.5) で XML コメント内の double dash 禁止
- 元コメント文中の Web 版 CSS 変数 \`--paper\` 記述が引っかかっていた
- 修正: コメント文を \`paper\` 単独表記 + 補足注記で仕様回避 (= 1 行修正)

## なぜ AGP 8.13.0 で初検出か
- 子 6 (#125) の実機 / エミュレータビルド (Android Studio 内 AAPT) では警告止まりだった可能性
- GitHub Actions ubuntu-latest + AGP 8.13.0 の AAPT2 が strict mode で linter 厳格化
- 同種事故防止のため、本 PR マージ後に \`bin/setup\` 等で XML linter を hooks 化する検討は v1.1+ で

## Test plan
- [ ] マージ後、\`v0.1.0-test\` タグを削除 → 再 push
- [ ] Actions Build debug APK ステップが完走する
- [ ] Release に APK が添付される

## 関連
- PR #305 (= 親、workflow)
- PR #307 (= Node 22 hotfix)
- Issue #126 (= 子 7、v1.0 リリースの最後のピース)
- Issue #128 (= Splash 背景に colorSplashBackground を使う元起票)

🤖 Generated with [Claude Code](https://claude.com/claude-code)