### PR TITLE
feat(settings): Capacitor 検知時に Health Connect セクションを最上部へ (#144)

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -13,6 +13,7 @@ class SettingsController < ApplicationController
                                       .order(received_at: :desc)
                                       .limit(WEBHOOK_HISTORY_LIMIT)
     @show_android_app_promo = PlatformDetectorService.web_android?(request)
+    @is_capacitor = PlatformDetectorService.capacitor?(request)
   end
 
   def regenerate_token

--- a/app/services/platform_detector_service.rb
+++ b/app/services/platform_detector_service.rb
@@ -17,4 +17,10 @@ class PlatformDetectorService
     ua = request.user_agent.to_s
     ua.match?(/Android/) && !ua.match?(/WeightDialyCapacitor/)
   end
+
+  # Capacitor アプリ起動の判定 (= overrideUserAgent に "WeightDialyCapacitor" 付与済)。
+  # Issue #144 (= Settings の Health Connect セクションを Capacitor 時のみ最上部に出し分け) で使用。
+  def self.capacitor?(request)
+    request.user_agent.to_s.match?(/WeightDialyCapacitor/)
+  end
 end

--- a/app/views/settings/_health_connect_section.html.erb
+++ b/app/views/settings/_health_connect_section.html.erb
@@ -1,0 +1,49 @@
+<%# Health Connect 連携 (Android のみ、Capacitor 検知で動的表示。Web 版では非表示のまま)。
+    Issue #144 で本 partial を抽出 → Capacitor 検知時は settings/show.html.erb 冒頭に、
+    非 Capacitor (= Web 版 / iOS) では従来位置 (= ポリシーリンクの直前) に出し分ける。 %>
+<div data-controller="native-health"
+     data-native-health-webhook-token-value="<%= current_user.webhook_token %>"
+     class="sketch-box"
+     style="display: none; margin-bottom: 24px;">
+  <h2 class="sketch-h" style="margin-bottom: 8px;">Android Health Connect 連携</h2>
+  <p class="sketch-small" style="margin-bottom: 12px;">
+    Android アプリ版で Health Connect 経由で歩数 / 距離 / 階段を自動同期します。
+  </p>
+
+  <%# Issue #218: 同期前事前ガイダンス。Health Connect 自体にデータが届いていないと同期成功 (= 200 OK)
+      でも 0 歩で保存される事故 (= 局長実体験由来、PR #206 で同期後警告と二段構え) を未然に防ぐ。
+      sketch-note クラス (= sketchy.css、border-left + paper-2 背景) で「補足」 視覚明示。 %>
+  <p class="sketch-small sketch-note" style="margin-bottom: 12px;">
+    ※ 歩数アプリ (<strong>Google Fit</strong> や <strong>Samsung Health</strong> など) から Health Connect へデータが渡る設定になっているとスムーズに同期できます。
+    0 歩のままの場合は、Health Connect アプリの「<strong>データとアクセス</strong>」 で書き込み設定をご確認ください。
+  </p>
+
+  <p data-native-health-target="status" class="sketch-body-text" style="margin-bottom: 16px;">
+    確認中...
+  </p>
+  <button data-action="click->native-health#requestPermission"
+          data-native-health-target="requestButton"
+          class="sketch-btn"
+          style="display: none; margin-right: 8px;">
+    歩数を取得する →
+  </button>
+  <button data-action="click->native-health#sync"
+          data-native-health-target="syncButton"
+          class="sketch-btn"
+          style="display: none;">
+    📡 同期する
+  </button>
+
+  <%# Issue #273 で 2 mode 化 (settings / retry)。401 → settings 誘導、5xx → retry。
+      **本 PR は 2 mode で確定 (= 3 種類目 mode は v1.2 以降の検討)**。
+      初期値は data-mode="settings" (= 401 用)、JS 側が retry 時に textContent + data-mode を上書きする (= 文言 SSOT は JS の RECOVERY_LABELS、本 HTML は SSR 用ダミー)。
+      連打抑制: sync() 冒頭の display:none 戻し処理で 1 クリック目に消えるため、recoveryButton 自体の disabled 制御は不要。
+      2 回目以降の連続失敗は JS 側 retryCount + RETRY_THRESHOLD で本ボタンを非表示に切り替える (= Issue #276)。 %>
+  <button data-action="click->native-health#recoveryAction"
+          data-native-health-target="recoveryButton"
+          data-mode="settings"
+          class="sketch-btn"
+          style="display: none; margin-top: 12px;">
+    設定ページでトークンを再生成 →
+  </button>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -10,6 +10,13 @@
     iPhone は Apple Shortcuts、Android は Health Connect から、毎日の歩数を自動で取り込みます。
   </p>
 
+  <%# Capacitor アプリ時のみ Health Connect セクションを最上部に出す (Issue #144、design レビュー指摘:
+      Apple Shortcuts Step 1-3 全スクロール後にやっと Health Connect 到達するもたつき解消)。
+      非 Capacitor (= Web 版 / iOS) では従来位置 (= ポリシーリンク前) で render される (= 下記)。 %>
+  <% if @is_capacitor %>
+    <%= render "health_connect_section" %>
+  <% end %>
+
   <%# Step 1: Webhook トークン %>
   <p class="sketch-label" style="margin-bottom: 6px;">Step 1</p>
   <div class="sketch-box" style="margin-bottom: 20px;">
@@ -106,53 +113,11 @@
     </div>
   <% end %>
 
-  <%# Health Connect 連携 (Android のみ、Capacitor 検知で動的表示。Web 版では非表示のまま) %>
-  <div data-controller="native-health"
-       data-native-health-webhook-token-value="<%= current_user.webhook_token %>"
-       class="sketch-box"
-       style="display: none; margin-bottom: 24px;">
-    <h2 class="sketch-h" style="margin-bottom: 8px;">Android Health Connect 連携</h2>
-    <p class="sketch-small" style="margin-bottom: 12px;">
-      Android アプリ版で Health Connect 経由で歩数 / 距離 / 階段を自動同期します。
-    </p>
-
-    <%# Issue #218: 同期前事前ガイダンス。Health Connect 自体にデータが届いていないと同期成功 (= 200 OK)
-        でも 0 歩で保存される事故 (= 局長実体験由来、PR #206 で同期後警告と二段構え) を未然に防ぐ。
-        sketch-note クラス (= sketchy.css、border-left + paper-2 背景) で「補足」 視覚明示。 %>
-    <p class="sketch-small sketch-note" style="margin-bottom: 12px;">
-      ※ 歩数アプリ (<strong>Google Fit</strong> や <strong>Samsung Health</strong> など) から Health Connect へデータが渡る設定になっているとスムーズに同期できます。
-      0 歩のままの場合は、Health Connect アプリの「<strong>データとアクセス</strong>」 で書き込み設定をご確認ください。
-    </p>
-
-    <p data-native-health-target="status" class="sketch-body-text" style="margin-bottom: 16px;">
-      確認中...
-    </p>
-    <button data-action="click->native-health#requestPermission"
-            data-native-health-target="requestButton"
-            class="sketch-btn"
-            style="display: none; margin-right: 8px;">
-      歩数を取得する →
-    </button>
-    <button data-action="click->native-health#sync"
-            data-native-health-target="syncButton"
-            class="sketch-btn"
-            style="display: none;">
-      📡 同期する
-    </button>
-
-    <%# Issue #273 で 2 mode 化 (settings / retry)。401 → settings 誘導、5xx → retry。
-        **本 PR は 2 mode で確定 (= 3 種類目 mode は v1.2 以降の検討)**。
-        初期値は data-mode="settings" (= 401 用)、JS 側が retry 時に textContent + data-mode を上書きする (= 文言 SSOT は JS の RECOVERY_LABELS、本 HTML は SSR 用ダミー)。
-        連打抑制: sync() 冒頭の display:none 戻し処理で 1 クリック目に消えるため、recoveryButton 自体の disabled 制御は不要。
-        2 回目以降の連続失敗は JS 側 retryCount + RETRY_THRESHOLD で本ボタンを非表示に切り替える (= Issue #276)。 %>
-    <button data-action="click->native-health#recoveryAction"
-            data-native-health-target="recoveryButton"
-            data-mode="settings"
-            class="sketch-btn"
-            style="display: none; margin-top: 12px;">
-      設定ページでトークンを再生成 →
-    </button>
-  </div>
+  <%# 非 Capacitor 時のみ最下段に表示 (Capacitor 時は冒頭で render 済、Issue #144)。
+      partial 抽出元の旧コード (= 109-155 行に inline 配置) は app/views/settings/_health_connect_section.html.erb に移行。 %>
+  <% unless @is_capacitor %>
+    <%= render "health_connect_section" %>
+  <% end %>
 
   <%# 危険ゾーン: トークン再生成 %>
   <div class="sketch-box sketch-box-danger-soft" style="margin-bottom: 24px;">


### PR DESCRIPTION
## Summary
- Issue #144 (= design レビュー指摘) 解消
- Capacitor アプリで Settings 開いた時、Apple Shortcuts Step 1-3 全スクロール後にやっと Health Connect セクション → デモもたつき
- 解決: Capacitor 検知時のみ Health Connect セクションを最上部 (リード文の直後) に出し分け、Web 版 / iOS は従来位置 (= ポリシーリンクの前) で維持

## 実装内容
1. **PlatformDetectorService に `.capacitor?(request)` 新規追加**
   - 既存 `.web_android?` と対称パターン
   - UA に \`WeightDialyCapacitor\` 含むかで判定 (= overrideUserAgent 付与済)
2. **SettingsController#show で `@is_capacitor` フラグセット**
3. **`app/views/settings/_health_connect_section.html.erb` partial 抽出**
   - 元の 109-155 行 (= inline 配置) を partial 化
   - DRY 原則: 同 markup を 2 か所に書かない
4. **`settings/show.html.erb` で出し分け**
   - 冒頭 (リード文の直後): \`<% if @is_capacitor %><%= render ... %><% end %>\`
   - 従来位置: \`<% unless @is_capacitor %><%= render ... %><% end %>\`

## 設計判断

### なぜ `capacitor?` を Service に置く (= helper でなく)
- 既存 `web_android?` が PlatformDetectorService にある = 検知ロジックの集約場所として確立済
- helper だと view 専用、controller / job からも呼べる Service が筋良い
- 学習教材として `web_android?` と並べて見せる価値

### なぜ partial 抽出 (= CSS order でなく)
- CSS Flexbox の order 指定は構造変更コスト大 + 既存 `sketch-box` スタイルとの整合性懸念
- partial 化なら markup を 1 ファイルに集約、order 切替は erb の条件分岐 1 行で済む
- DRY 違反回避 + 後輩教材として「partial 抽出 + render の出し分け」 サンプル

## Test plan
- [ ] Web 版 (Chrome / Safari) で Settings 開く → Health Connect セクション = 従来通り最下段付近
- [ ] Capacitor アプリで Settings 開く → Health Connect セクション = リード文の直後 (最上部)
- [ ] iOS / iPhone で Settings 開く → Capacitor 以外なので Health Connect セクション = 従来通り
- [ ] partial 抽出による既存表示への副作用なし (= JS `native-health` controller の動作確認)
- [ ] `@show_android_app_promo` (= Issue #184) の表示は別ロジックで影響なし

## 関連
- Issue #144 (= 本 PR で完走)
- Issue #184 (= 既存 `@show_android_app_promo`、同じ出し分けパターン)
- PR #142 (= Capacitor overrideUserAgent + wv 二重防衛、`WeightDialyCapacitor` UA の起源)

🤖 Generated with [Claude Code](https://claude.com/claude-code)