### PR TITLE
docs: day-14-2 に PR #318 (= Issue #317) 反映

### DIFF
--- a/docs/dev-log/day-14-2.md
+++ b/docs/dev-log/day-14-2.md
@@ -4,7 +4,7 @@ day-14 (= 朝の「v1.1 軽量 3 連完走」 = #176 + #175 + #190) 完了後、
 
 **Day 14-2 達成サマリ (= 本体 = 午後 v1.0 配布完走)**: 7 PR マージ (= #305 + #306 + #307 + #308 + #309 + #310 + #311 連番) + 4 Issue close (= #126 + #144 + #145 + 親 #40 v1.0 完走宣言) + GitHub Actions Android APK ビルドパイプライン新設 + フォント local 同梱 (= 142 KiB woff2 × 4 + preload 2 件) + Settings UI Capacitor 出し分け + **Actions 経路で計 4 件の躓き (= push 前予防 1 + 実発火 3 回失敗)** → 4 回目 Actions 発火 (= v0.1.0-test) で成功 (= 教訓 5 件確立、4a + 4b 分割で計 6 サブ教訓) + 撤退ライン 3 段設計が機械的に機能 (= 1 段目 17:00 で APK 確定、2 段目 / 3 段目には到達せず)。
 
-**Day 14-2 夜の追加 (= 19:00 以降)**: + 3 PR マージ (= #313 polish + #315 Issue #314 完走 + 本 dev-log PR #316) + 2 Issue close (= #124 旧 WorkManager + #314 即日完走) + 1 Issue 起票 (= #314、即日起票即日完走で「同セッション完走型」 = 自己完結型カテゴリ境界外パターン) + 教訓 6 (= Kotlin 越境 vs JS 完結) + 教訓 7 (= 同セッション完走型の境界外) 追加。**合計: 10 PR / 6 Issue close / 1 起票 / 教訓 7 件**。
+**Day 14-2 夜の追加 (= 19:00 以降)**: + 4 PR マージ (= #313 polish + #315 Issue #314 完走 + 本 dev-log PR #316 + #318 README §12 分離) + 3 Issue close (= #124 旧 WorkManager + #314 即日完走 + #317 README §12 分離) + 2 Issue 起票 (= #314 + #317、即日起票即日完走パターン 2 例目連発) + 教訓 6 (= Kotlin 越境 vs JS 完結) + 教訓 7 (= 同セッション完走型の境界外) 追加。**合計: 11 PR / 7 Issue close / 2 起票 / 教訓 7 件**。
 
 ---
 
@@ -32,12 +32,13 @@ day-14 (= 朝の「v1.1 軽量 3 連完走」 = #176 + #175 + #190) 完了後、
 | #310 | (hotfix) | fix(android): colors.xml hotfix take 2 (= PR #308 の補足注記内 `"--"` 引用が**それ自体 XML 違反** で再失敗、メタ循環の罠)。1 行修正 |
 | #311 | #145 | feat(assets): フォント (Patrick Hand / Caveat / Kalam) を woff2 同梱で local 配信化 + Patrick Hand / Caveat preload 追加 (= design-reviewer 提案、第一印象向上)。+47/-6 行 + 142 KiB woff2 × 4 |
 
-#### 夜の追加マージ PR (= 19:00 以降の polish + v1.1 着手、2 本)
+#### 夜の追加マージ PR (= 19:00 以降の polish + v1.1 着手、3 本)
 
 | PR | Issue | 内容 |
 |---|---|---|
 | #313 | (polish) | fix(ci): Release body の What's Changed を「最新 5 PR」 に制限 (= 局長指摘で気付き)。`generate_release_notes: true` 削除 + 自前 `gh pr list --limit 5` step + body 注入 + Full Changelog リンク残置。permissions `pull-requests: read` + `env: PR_LIMIT: '5'` 抽出 + bullet 表記を author 省略で簡素化 (= 3 者レビュー反映)。v0.1.0 body は手動 `gh release edit` で先行救済済 |
 | #315 | #314 | feat(sync): App.addListener 自動同期 + 同期ボタン UI 改善 (= WorkManager 代替軽量実装)。`@capgo/capacitor-health` 未対応 + Kotlin 2-3 日工数判明 (= api-researcher 調査) を受け JS 完結軽量代替で完走。`shouldAutoSync` 複数 AND ガード / Stimulus disconnect で listener 解除 / sync() に isAutoSyncing 分岐で home 遷移抑止 / 24h 超 ⚠️ ヒント。+196/-3 行 / 4 ファイル |
+| #318 | #317 | docs: README §12 (= 約 130 行 Android アプリ版利用ガイド) を `docs/android-install.md` に分離 + リンク化。冒頭 note 重複削除 (= design PR #306 Suggestion 吸収) + 「不明な提供元のアプリ」 表記の Android バージョン差異対応 + 要点 3 bullets 追加 (= §11 デプロイ環境と同パターン) + リンクテキスト平易化 (= 3 者レビュー 🔴 + 🟡 を本 PR で全吸収、軽量 Issue 1 PR 完結ルール準拠)。+131/-128 行 |
 
 ### close した Issue (= 4 件)
 
@@ -46,14 +47,16 @@ day-14 (= 朝の「v1.1 軽量 3 連完走」 = #176 + #175 + #190) 完了後、
 - **#145** (= Capacitor 初回起動時 FOUT 対策) — PR #311 で解消、**案 A (フォント同梱) を前倒し採用 + 案 C (ウォームアップ) 撤回**
 - **#40** (= 親 Capacitor + Health Connect 完全対応) — **v1.0 完走宣言コメント + close**。子 1-5a + 6 + 7 全完了、子 5b (= #124 WorkManager 自動同期) は本体時点では open 継続 (= 夜の追加で派生 #314 に再分岐、詳細は下記 ####「夜の追加 close」)
 
-#### 夜の追加 close (= 2 件)
+#### 夜の追加 close (= 3 件)
 
 - **#124** (= 旧 WorkManager 元案、親 #40 子 5b 系統) — **スコープ見直し close**。api-researcher 調査で当初 3-5h → 2-3 日工数判明、派生 #314 へ継承
 - **#314** (= 派生軽量代替、JS 完結 App.addListener 自動同期 + 同期ボタン UI 改善) — PR #315 で本日完走、`Closes` 自動 close 未指定のため**本 dev-log PR マージ後に手動 `gh issue close 314`** で対応 (= 本 dev-log の整合性を取るため事後 close)
+- **#317** (= v1.1 README §12 を docs/ へ分離 + リンク化) — PR #318 で同セッション完走、即日起票即日完走パターン 2 例目 (= #314 に続く、教訓 7「境界外」 カテゴリの連続観測)
 
-### 起票した Issue (= 1 件、即日完走)
+### 起票した Issue (= 2 件、即日完走)
 
 - **#314** (= v1.1 軽量代替案 = 旧 #124 派生) — 17:00 頃起票 → PR #315 で同セッション内完走。スコープ厳守の例外として軽量代替案を即日着手・即日完走の希少パターン (= 同セッション内 Issue 起票 → 同セッション完走、自己完結型カテゴリ「境界外」 ケース、教訓 7 で詳述)
+- **#317** (= v1.1 README §12 を docs/ へ分離 + リンク化 + ブラッシュアップ) — 17:27 頃起票 → PR #318 で同セッション内完走。教訓 7 境界外カテゴリ **2 例目連続観測** (= 1 セッション内 2 件発生は珍しい、軽量 docs 系の即日完走しやすさが要因か = 3 例目以降の観測で memory 化判断)
 
 ---
 
@@ -145,14 +148,14 @@ memory `feedback_self_proposal_relativization.md` の自己完結型カテゴリ
 
 ## 📊 統計
 
-- マージ PR: **10 本** (= 本体 #305→#311 連番 7 本 + 夜の追加 #313 + #315 + 本 dev-log PR #316)
-- close Issue: **6 件** (= 本体 #126 + #144 + #145 + 親 #40 + 夜の追加 #124 + #314)
-- 起票 Issue: **1 件** (= #314、即日起票即日完走、境界外パターン)
+- マージ PR: **11 本** (= 本体 #305→#311 連番 7 本 + 夜の追加 #313 + #315 + 本 dev-log PR #316 + #318)
+- close Issue: **7 件** (= 本体 #126 + #144 + #145 + 親 #40 + 夜の追加 #124 + #314 + #317)
+- 起票 Issue: **2 件** (= #314 + #317、即日起票即日完走、境界外パターン連続 2 例目)
 - Actions 試行回数: **5 回 + push 前予防 1 件** (= push 前予防 1 + 実発火失敗 3 + v0.1.0-test 成功 1 + v0.1.0 本番成功 1)
 - spec: 未確認 (= CI lint / scan_ruby / scan_js は全 PR で pass)
 - rubocop: 未確認 (= 同上)
 - 教訓: **7 件** (= Node 要件 + XML strict + メタ循環 + 自己完結 6 例目 + 撤退ライン機械化 + Kotlin 越境 vs JS 完結 + 即日完走パターン境界外)
-- open Issue 純減: **-5 件** (= 6 close - 1 起票、累計 Issue 数を 13 件まで圧縮)
+- open Issue 純減: **-5 件** (= 7 close - 2 起票、累計 Issue 数を 13 件まで圧縮)
 - 着手時刻: 15:30、Actions 成功時刻: 17:03 (= 撤退ライン 17:00 から +3 分、余裕)、夜の追加完走: 19:00 想定 (= 撤退ライン 19:30 から -30 分、デッドライン 19:50 から -50 分)
 
 ---
@@ -177,3 +180,4 @@ memory `feedback_self_proposal_relativization.md` の自己完結型カテゴリ
 - **「Kotlin 越境 vs JS 完結」 の境界判断**: 「Native 領域に踏み込まないと不可能」 と思った機能でも、JS 完結の妥協案 (= 体験劣化を許容) が見つかるケースあり。Issue #124 (= 2-3 日) → #314 (= 4-7h) 転換が好例。境界線越え禁止ルールを時間制約に応用する発想
 - **自己完結型カテゴリと即日完走パターンの分離**: Issue 起票日 < PR マージ日 (= 1 セッション境界またぐ) を自己完結型の必須条件にする。同セッション完走は別カテゴリ「同セッション完走型」 として別途観測、定義固定先行
 - **api-researcher を「事前調査の 1 クッション」 に組み込む**: 外部 SDK / ライブラリの「未対応かもしれない機能」 を Issue 本文で楽観前提に書く前に、api-researcher で公式 repo + Issues を確認する 1 クッション。Issue #124 → #314 転換は本パターンの効力実証 (= 着手前 30 分の調査で 2-3 日の地雷を回避)
+- **軽量 docs PR でも 3 者並列レビュー指摘吸収を 1 PR で完結**: PR #318 で 🔴 + 🟡 全 4 件を追加コミット 1 個で吸収 (= memory `feedback_light_issue_one_pr_completion.md` × `feedback_always_three_reviewers.md` の組み合わせ実証)。軽量 PR でも 3 者レビュー手抜きせず、指摘は別 Issue に逃さず本 PR で吸収する原則を再確認


### PR DESCRIPTION
## Summary

- PR #318 (= Issue #317、README §12 を `docs/android-install.md` に分離 + リンク化) を `docs/dev-log/day-14-2.md` の夜の追加 3 段階目として反映
- 数字 3 箇所同期更新 (= リード文 / セクションヘッダ / 統計)
- How to apply 末尾に「軽量 docs PR でも 3 者並列レビュー指摘吸収を 1 PR で完結」 1 行追記

## 数字同期サマリ

| 箇所 | 旧 | 新 |
|---|---|---|
| 夜の追加リード | 3 PR / 2 close / 1 起票 | **4 PR / 3 close / 2 起票** |
| 合計 (リード末) | 10 PR / 6 close / 1 起票 / 教訓 7 | **11 PR / 7 close / 2 起票 / 教訓 7** |
| 夜の追加マージ PR ヘッダ | 2 本 | **3 本** |
| 夜の追加 close ヘッダ | 2 件 | **3 件** |
| 起票した Issue ヘッダ | 1 件、即日完走 | **2 件、即日完走** |
| 統計 マージ PR | 10 本 | **11 本** |
| 統計 close Issue | 6 件 | **7 件** |
| 統計 起票 Issue | 1 件 | **2 件** |
| 教訓 | 7 件 | 据え置き (= 7 件) |
| open Issue 純減 | -5 件 (= 6 - 1) | -5 件 (= 7 - 2) |

## Test plan

- [ ] 数字 3 箇所が同期している (= grep `11 PR`, `7 Issue close`, `2 起票`, `11 本`, `7 件`, `2 件` で全てヒット)
- [ ] 旧数字の取り残しなし (= grep `10 PR`, `6 close`, `1 起票` で 0 件、計算式注記を除く)
- [ ] PR table / close リスト / 起票リストに #318 / #317 が追加されている
- [ ] How to apply 末尾の 1 行が docs PR の文脈に整合している
- [ ] 後輩が読んで価値ある内容になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)