### PR TITLE
feat(auth): session cookie に expire_after: 2.weeks を設定 (#320)

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,14 @@
+# expire_after: 2 週間 = 通勤通学カジュアル層 (= 週末しか開かない / 月 1-2 ペース利用者) を想定。
+# 詳細根拠 = Issue #320。将来 Devise 風 "Remember me" cookie を追加する際は、本値を短縮 (or 撤去)
+# し、長期化は Remember me cookie 側で管理する方針 (= 「チェック有 = 長期 / 無 = ブラウザセッション」
+# の選択 UI が一般的なため、cookie_store 自体を一律長期にしておくと並立で破綻する)。
+#
+# same_site: :lax = Google OAuth callback は GET ルート (= routes.rb の auth_callback path) のため
+# トップレベル GET ナビゲーションとして cookie が送られる。OmniAuth の allowed_request_methods = [:post]
+# は request phase (= 自サイトへの同サイト POST) の CSRF 対策であり callback phase とは別軸。
+# 仮に callback が POST だった場合は same_site: :none + secure: true への変更が必要だった。
+Rails.application.config.session_store :cookie_store,
+  key: "_weight_dialy_session",
+  expire_after: 2.weeks,
+  secure: Rails.env.production?,
+  same_site: :lax

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe "Sessions", type: :request do
     end
   end
 
+  describe "Set-Cookie ヘッダの属性 (= session_store.rb の expire_after 反映確認)" do
+    # Rails の session_store 設定 (= config/initializers/session_store.rb) が
+    # 実際に Set-Cookie ヘッダに反映されることを担保する regression spec。
+    # 将来 expire_after が誤って削除された場合に検知する (= Issue #320 由来)。
+    before { mock_google_oauth2(uid: "uid_1", email: "a@example.com", name: "A") }
+
+    it "issues a persistent cookie with Max-Age or Expires (= ブラウザセッション cookie でないことを確認)" do
+      get auth_callback_path(provider: "google_oauth2")
+      set_cookie = response.headers["Set-Cookie"]
+      expect(set_cookie).to include("_weight_dialy_session")
+      expect(set_cookie).to match(/max-age=|expires=/i)
+    end
+  end
+
   describe "DELETE /logout" do
     # session を直接 set するために logged-in 状態を作る
     let(:user) { create(:user) }


### PR DESCRIPTION
## Summary
- Capacitor Android アプリで「アプリを閉じるとすぐログアウト」 する UX 課題を解決
- 原因 = Rails 8 default の cookie session store が `expire_after` 未指定 → session cookie が「ブラウザセッション cookie」 扱い → Android System WebView がアプリ終了で破棄
- 対応 = `expire_after: 2.weeks` + `secure: production?` + `same_site: :lax` を明示

Closes #320

## 変更内容
- `config/initializers/session_store.rb` 新規追加 (= 4 行 + 教材コメント 9 行)
- `spec/requests/sessions_spec.rb` に regression spec 1 例追加 (= Set-Cookie に Max-Age/Expires が乗ることを確認)

## 3 者並列レビュー結果

`/review-three` を起動済。判定別の対応:

### 🚨 Blocker: 0 件

### 🟡 軽微 → 対応または却下を判断

- **[code] `same_site: :lax` が OAuth POST callback で cookie 落とすリスク**
  → **検証して却下**。`routes.rb` 17 行目で callback は `get "/auth/:provider/callback"` (= GET ルート)、トップレベル GET ナビゲーションのため `:lax` で cookie は送られる。`OmniAuth.allowed_request_methods = [:post]` は request phase の制約であり callback phase とは別軸。検証結果を session_store.rb のコメントに残し再指摘を予防。
- **[code] Set-Cookie 属性アサート spec 追加**
  → **採用**。`sessions_spec.rb` に 1 example 追加、将来 `expire_after` が誤削除されたら検知。

### 🟢 提案 → 対応

- **[strategic] `expire_after: 2.weeks` の WHY コメント**
  → **採用**。「通勤通学カジュアル層想定 + Issue #320 参照」 をファイルコメントに記載。
- **[strategic] 将来 B 案 (= Devise 風 Remember me) 並立時の方針**
  → **採用**。「本値を短縮 → Remember me cookie 側で長期化管理」 をファイルコメントに記載。
- **[strategic] curl での Set-Cookie 確認を Test plan に追加**
  → **採用** (= 下記 Test plan)。
- **[design] navbar の logout 動線 polish**
  → **却下** (= 本 PR スコープ外、別 Issue 検討対象)。

## Test plan
- [x] `bundle exec rspec spec/requests/sessions_spec.rb` 全 pass (= 27 例、新規 1 + 既存 26)
- [x] `bundle exec rubocop` clean
- [ ] Render 本番デプロイ後、curl で Set-Cookie の `Max-Age` 値確認:
  ```bash
  curl -sI https://weight-dialy.onrender.com/ | grep -i set-cookie
  # 期待: Max-Age=1209600 (= 14 日 = 2 週間) が _weight_dialy_session 行に含まれる
  ```
- [ ] Android アプリで Google ログイン → アプリ閉じる → 開き直してログイン状態維持を確認
- [ ] 既存 OAuth フロー (= Web 経由 + Capacitor 経由 = one-time token bridge) が引き続き動作することを確認

## 影響範囲
- **既存ログイン中ユーザー**: 影響なし (= 新規ログイン以降に適用)
- **既存セッション**: 古い session cookie はブラウザセッション扱いのまま、新規発行から expire_after 反映
- **本番 DB**: migration なし、ロールバック = ファイル削除のみ

## 関連
- 1.1 改修フェーズ初の PR (= memory `project_phase_1_1_refactoring`)
- 判断ログ形式 Issue (= memory `feedback_issue_as_decision_log`、Day 8 #161 / Day 9 #228 に続く 3 例目)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
