### PR TITLE
docs: day-14-2 に PR #321 (= Issue #320) 反映 + 教訓 8 確立

### DIFF
--- a/docs/dev-log/day-14-2.md
+++ b/docs/dev-log/day-14-2.md
@@ -1,10 +1,12 @@
-# Day 14-2 開発ログ (2026-05-12 午後、v1.0 Android 配布完走 (= 親 #40 + 子 7 #126 + polish 2 件 #144 + #145) + Actions 4 回失敗 + 撤退ライン 3 段設計運用)
+# Day 14-2 開発ログ (2026-05-12 午後 + 夜の追加 + v1.1 改修フェーズ初 PR、v1.0 Android 配布完走 (= 親 #40 + 子 7 #126 + polish 2 件 #144 + #145) + Actions 4 回失敗 + 撤退ライン 3 段設計運用 + #314 + #317 + #320 session 永続化)
 
 day-14 (= 朝の「v1.1 軽量 3 連完走」 = #176 + #175 + #190) 完了後、**状況急変**: スクール運営から「**本日 20:00 開始の閉会式で本アプリに言及予定**」 の通達 (= 局長連絡)。後回しにしていた Android sideload 経路 (= 親 Issue #40 子 7 #126) を当日中に整備する必要発生。撤退ライン 3 段 (= 17:00 / 18:30 / 19:30) + マスト/ベター/任意の切り分けで進行 → **19:50 デッドラインに対し 17:00 直前で APK 完成 (= 2h50m バッファ)**、19:00 までに全マスト + ベター + 任意 #145 まで全完走。
 
 **Day 14-2 達成サマリ (= 本体 = 午後 v1.0 配布完走)**: 7 PR マージ (= #305 + #306 + #307 + #308 + #309 + #310 + #311 連番) + 4 Issue close (= #126 + #144 + #145 + 親 #40 v1.0 完走宣言) + GitHub Actions Android APK ビルドパイプライン新設 + フォント local 同梱 (= 142 KiB woff2 × 4 + preload 2 件) + Settings UI Capacitor 出し分け + **Actions 経路で計 4 件の躓き (= push 前予防 1 + 実発火 3 回失敗)** → 4 回目 Actions 発火 (= v0.1.0-test) で成功 (= 教訓 5 件確立、4a + 4b 分割で計 6 サブ教訓) + 撤退ライン 3 段設計が機械的に機能 (= 1 段目 17:00 で APK 確定、2 段目 / 3 段目には到達せず)。
 
-**Day 14-2 夜の追加 (= 19:00 以降)**: + 4 PR マージ (= #313 polish + #315 Issue #314 完走 + 本 dev-log PR #316 + #318 README §12 分離) + 3 Issue close (= #124 旧 WorkManager + #314 即日完走 + #317 README §12 分離) + 2 Issue 起票 (= #314 + #317、即日起票即日完走パターン 2 例目連発) + 教訓 6 (= Kotlin 越境 vs JS 完結) + 教訓 7 (= 同セッション完走型の境界外) 追加。**合計: 11 PR / 7 Issue close / 2 起票 / 教訓 7 件**。
+**Day 14-2 夜の追加 (= 19:00 以降)**: + 4 PR マージ (= #313 polish + #315 Issue #314 完走 + 本 dev-log PR #316 + #318 README §12 分離) + 3 Issue close (= #124 旧 WorkManager + #314 即日完走 + #317 README §12 分離) + 2 Issue 起票 (= #314 + #317、即日起票即日完走パターン 2 例目連発) + 教訓 6 (= Kotlin 越境 vs JS 完結) + 教訓 7 (= 同セッション完走型の境界外) 追加。
+
+**Day 14-2 v1.1 改修フェーズ初 PR の追加 (= 21:00 以降)**: + 1 PR マージ (= #321 session cookie 永続化 = Issue #320 完走) + 1 Issue close (= #320、即日完走 = 境界外パターン **3 例目連続観測** で教訓 7 の memory 化トリガー成立) + 1 Issue 起票 (= #320、判断ログ形式 Issue 3 例目) + 教訓 8 (= 3 者レビュー指摘の一次資料検証却下) 追加。**合計: 12 PR / 8 Issue close / 3 起票 / 教訓 8 件**。
 
 ---
 
@@ -58,6 +60,20 @@ day-14 (= 朝の「v1.1 軽量 3 連完走」 = #176 + #175 + #190) 完了後、
 - **#314** (= v1.1 軽量代替案 = 旧 #124 派生) — 17:00 頃起票 → PR #315 で同セッション内完走。スコープ厳守の例外として軽量代替案を即日着手・即日完走の希少パターン (= 同セッション内 Issue 起票 → 同セッション完走、自己完結型カテゴリ「境界外」 ケース、教訓 7 で詳述)
 - **#317** (= v1.1 README §12 を docs/ へ分離 + リンク化 + ブラッシュアップ) — 17:27 頃起票 → PR #318 で同セッション内完走。教訓 7 境界外カテゴリ **2 例目連続観測** (= 1 セッション内 2 件発生は珍しい、軽量 docs 系の即日完走しやすさが要因か = 3 例目以降の観測で memory 化判断)
 
+#### v1.1 改修フェーズ初 PR の追加 (= 21:00 以降、1 本)
+
+| PR | Issue | 内容 |
+|---|---|---|
+| #321 | #320 | feat(auth): session cookie に `expire_after: 2.weeks` を設定。`config/initializers/session_store.rb` 新規 (= same_site:lax 選択理由 + 期間 WHY + 将来 Devise 風 Remember me 並立指針をコメント明記、教材性)。`spec/requests/sessions_spec.rb` に Set-Cookie の Max-Age/Expires regression spec 1 例追加 (= 27 examples)。**1.1 改修フェーズ初の PR + 判断ログ形式 Issue 3 例目** (= Day 8 #161 / Day 9 #228 に続く)。+28 行 / 2 ファイル |
+
+#### v1.1 改修フェーズ初 close (= 1 件、境界外パターン 3 例目連続観測)
+
+- **#320** (= session cookie expire_after 設定) — PR #321 で本日完走 (= 21:00 起票 → 同セッション完走)。**教訓 7「境界外」 カテゴリ 3 例目連続観測** (= #314 + #317 に続く 3 例目)、3 例観測ルール到達で memory `feedback_self_proposal_relativization.md` への新サブカテゴリ「同セッション完走型」 正式反映トリガー成立 (= 後日別 PR で実施)
+
+#### v1.1 改修フェーズ初 起票 (= 1 件、判断ログ形式 3 例目)
+
+- **#320** (= session cookie expire_after 設定) — 21:00 頃起票 → PR #321 で同セッション完走。判断ログ形式 (= 背景 / 原因 / 採用案 A / 不採用案 B [= Devise 風 Remember me] + C [= Google refresh token] / 期間根拠 / 影響範囲 / Test plan の 7 セクション) は memory `feedback_issue_as_decision_log` の **3 例目テンプレ確立** (= Day 8 #161 / Day 9 #228 に続く)
+
 ---
 
 ## 🔥 トラブル (= Actions 経路で計 4 件の躓き = push 前予防 1 + Actions 実発火失敗 3)
@@ -75,7 +91,7 @@ day-14 (= 朝の「v1.1 軽量 3 連完走」 = #176 + #175 + #190) 完了後、
 
 ---
 
-## 🧠 教訓ハイライト (= 7 件確立、4a/4b 分割で計 8 サブ教訓)
+## 🧠 教訓ハイライト (= 8 件確立、4a/4b 分割で計 9 サブ教訓)
 
 ### 教訓 1: Capacitor CLI 8.x の Node >= 22 要件 = `package.json` `engines` 事前確認
 
@@ -144,18 +160,39 @@ memory `feedback_self_proposal_relativization.md` の自己完結型カテゴリ
 - 同セッション完走パターンは「同セッション完走型」 として別途観測 (= 学び 36 系統の新サブカテゴリ候補)、3 例目以降で定義明文化検討
 - memory `feedback_self_proposal_relativization.md` への即反映は保留、別途検討用に dev-log に記録のみ
 
+**※ 本日内 3 例目連続観測達成**: 教訓 7 確立後、同 dev-log 内で **#320 が 3 例目** = 「3 例目以降の観測で memory 化判断」 条件達成。次回別 PR で memory `feedback_self_proposal_relativization.md` への「同セッション完走型」 新サブカテゴリ正式反映を実施 (= Issue=仮説 / PR=確定 ルールを meta レベルでも適用)。
+
+### 教訓 8: 3 者並列レビュー指摘は鵜呑みにせず一次資料で検証する (= 🟡 軽微 1 件却下例)
+
+PR #321 の code-reviewer レビューで `same_site: :lax` が OAuth POST callback で cookie を落とすリスクとして ⚠️ Should fix 指摘あり。表面上は「`SameSite=Lax` 仕様 → cross-site POST で cookie 落ちる」 という一般則として正しい。
+
+**却下根拠 (= 一次資料検証)**:
+- `config/routes.rb` 17 行目: `get "/auth/:provider/callback"` → callback は **GET ルート**、トップレベル GET ナビゲーション
+- `same_site: :lax` 仕様: トップレベル GET ナビゲーションでは cookie は送られる
+- `OmniAuth.config.allowed_request_methods = [:post]` は **request phase** (= 自サイトへの同サイト POST) の CSRF 対策であり **callback phase とは別軸**
+- → code-reviewer は「OAuth callback = POST」 と一般則で当てはめたが、本アプリの実装は GET callback (= Rails / OmniAuth デフォルト) のため `:lax` で正常動作
+
+**なぜ大事か**: 3 者レビュー指摘の自動採用は「指摘内容が一般則として正しいが本コードベースには当てはまらない」 ケースで誤修正を生む。**一次資料 (= routes / config / 仕様書) で実態を確認 → 採用 / 却下を判断する** ルートを通すことが、レビュー × 学習教材性の核心。
+
+**運用への落とし込み**:
+- 却下した指摘は **コード内コメントで根拠を残す** (= 同じ指摘の繰り返し予防 + 後輩教材性、memory `feedback_code_as_communication` の応用)
+- PR description に「検証して却下した経緯」 を明記 (= レビュアー再指摘の予防 + 教材性アーカイブ)
+- 採用 / 却下の判断軸: ① 指摘の一般則の正しさ ≠ 本コードベースでの該当性、② 一次資料 (= routes / config / 関連 spec) で実態を確認、③ Chromium 緩和ルール等の「将来仕様変更」 リスクは検証して受容可否を明示判断
+
+**1 例目観測**: 1.1 改修フェーズ初 PR で確立 (= MVP フェーズではスピード優先で全採用 / 全却下の二項択一になりがちだったが、1.1 では「指摘の根拠を一次資料で検証 → 判断」 のサイクルを通せる余裕がある)。3 例目以降で memory `feedback_review_finding_verification.md` 等の正式 memory 化検討。
+
 ---
 
 ## 📊 統計
 
-- マージ PR: **11 本** (= 本体 #305→#311 連番 7 本 + 夜の追加 #313 + #315 + 本 dev-log PR #316 + #318)
-- close Issue: **7 件** (= 本体 #126 + #144 + #145 + 親 #40 + 夜の追加 #124 + #314 + #317)
-- 起票 Issue: **2 件** (= #314 + #317、即日起票即日完走、境界外パターン連続 2 例目)
+- マージ PR: **12 本** (= 本体 #305→#311 連番 7 本 + 夜の追加 #313 + #315 + 本 dev-log PR #316 + #318 + **v1.1 改修初 #321**)
+- close Issue: **8 件** (= 本体 #126 + #144 + #145 + 親 #40 + 夜の追加 #124 + #314 + #317 + **v1.1 改修初 #320**)
+- 起票 Issue: **3 件** (= #314 + #317 + **#320**、即日起票即日完走、境界外パターン **3 例目連続観測**)
 - Actions 試行回数: **5 回 + push 前予防 1 件** (= push 前予防 1 + 実発火失敗 3 + v0.1.0-test 成功 1 + v0.1.0 本番成功 1)
-- spec: 未確認 (= CI lint / scan_ruby / scan_js は全 PR で pass)
-- rubocop: 未確認 (= 同上)
-- 教訓: **7 件** (= Node 要件 + XML strict + メタ循環 + 自己完結 6 例目 + 撤退ライン機械化 + Kotlin 越境 vs JS 完結 + 即日完走パターン境界外)
-- open Issue 純減: **-5 件** (= 7 close - 2 起票、累計 Issue 数を 13 件まで圧縮)
+- spec: **27 examples** (= PR #321 で sessions_spec.rb に Set-Cookie 属性 regression 1 例追加、CI lint / scan_ruby / scan_js は全 PR で pass)
+- rubocop: 0 offenses (= PR #321 で新規 + 編集ファイルに対し実行確認)
+- 教訓: **8 件** (= Node 要件 + XML strict + メタ循環 + 自己完結 6 例目 + 撤退ライン機械化 + Kotlin 越境 vs JS 完結 + 即日完走パターン境界外 + **3 者レビュー指摘の一次資料検証却下**)
+- open Issue 純減: **-5 件** (= 8 close - 3 起票、累計 Issue 数を 13 件まで圧縮、変化なし)
 - 着手時刻: 15:30、Actions 成功時刻: 17:03 (= 撤退ライン 17:00 から +3 分、余裕)、夜の追加完走: 19:00 想定 (= 撤退ライン 19:30 から -30 分、デッドライン 19:50 から -50 分)
 
 ---
@@ -181,3 +218,5 @@ memory `feedback_self_proposal_relativization.md` の自己完結型カテゴリ
 - **自己完結型カテゴリと即日完走パターンの分離**: Issue 起票日 < PR マージ日 (= 1 セッション境界またぐ) を自己完結型の必須条件にする。同セッション完走は別カテゴリ「同セッション完走型」 として別途観測、定義固定先行
 - **api-researcher を「事前調査の 1 クッション」 に組み込む**: 外部 SDK / ライブラリの「未対応かもしれない機能」 を Issue 本文で楽観前提に書く前に、api-researcher で公式 repo + Issues を確認する 1 クッション。Issue #124 → #314 転換は本パターンの効力実証 (= 着手前 30 分の調査で 2-3 日の地雷を回避)
 - **軽量 docs PR でも 3 者並列レビュー指摘吸収を 1 PR で完結**: PR #318 で 🔴 + 🟡 全 4 件を追加コミット 1 個で吸収 (= memory `feedback_light_issue_one_pr_completion.md` × `feedback_always_three_reviewers.md` の組み合わせ実証)。軽量 PR でも 3 者レビュー手抜きせず、指摘は別 Issue に逃さず本 PR で吸収する原則を再確認
+- **3 者レビュー指摘は一次資料検証 → 採用 / 却下判断**: 指摘の一般則の正しさ ≠ 本コードベースでの該当性。routes / config / spec を一次資料として確認、却下時はコード内コメントで根拠を残す (= 教訓 8、PR #321 の `same_site: :lax` 検証却下が 1 例目)。MVP フェーズの「全採用 / 全却下の二項択一」 から 1.1 改修フェーズの「指摘の根拠を一次資料で検証 → 判断」 のサイクルへ
+- **同セッション完走型カテゴリの memory 化トリガー成立**: 教訓 7 で「3 例目以降の観測で memory 化判断」 と書いた条件達成 (= #314 + #317 + #320 の 3 例目連続観測)、memory `feedback_self_proposal_relativization.md` への新サブカテゴリ「同セッション完走型」 正式反映を次回別 PR で実施 (= Issue=仮説 / PR=確定 を meta レベルでも適用)


### PR DESCRIPTION
## Summary
- PR #321 (= feat(auth) session cookie expire_after / Issue #320 完走 / 1.1 改修フェーズ初 PR) を day-14-2.md に反映
- 新セクション「v1.1 改修フェーズ初 PR の追加」 + 教訓 8「3 者レビュー指摘は一次資料検証 → 採用 / 却下判断」 (= same_site:lax 検証却下 1 例目) 追加
- 数字 3 箇所同期更新 (= リード文 / セクションヘッダ / 統計)

## 主な追記内容
- **タイトル拡張** (line 1): `+ 夜の追加 + v1.1 改修フェーズ初 PR` を追加、`#320 session 永続化` を末尾に
- **新セクションリード** (line 9): `Day 14-2 v1.1 改修フェーズ初 PR の追加 (= 21:00 以降)` 段落 + 合計値 (12 PR / 8 close / 3 起票 / 教訓 8 件)
- **新セクション本文** (line 63-75): `#### v1.1 改修フェーズ初 PR の追加` 3 サブ見出し (= PR / close / 起票)
- **教訓 8** (line 165-): `3 者並列レビュー指摘は鵜呑みにせず一次資料で検証する`、PR #321 の same_site:lax 検証却下を 1 例目として記録
- **教訓 7 への追記** (line 163): 同 dev-log 内 3 例目連続観測達成 = memory 化トリガー成立を明記
- **統計更新** (line 188-195): 12 / 8 / 3 / 8 件 + spec 27 examples + rubocop 0 offenses
- **How to apply 追加 2 行** (line 221-222): 教訓 8 運用 + 教訓 7 memory 化トリガー成立

## Test plan
- [x] 数字 3 箇所同期 (= grep 確認、line 9 / 188-189 / 194)
- [x] 教訓 8 が 1 例目として明示 + 3 例観測ルール記載
- [x] 後輩教材性 (= 「却下した指摘もコード内コメントで根拠を残す」 運用が読み取れる)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
