### PR TITLE
feat(i18n): settings 画面を ja.yml に抽出 (= 2 例目、規約弾力性テスト、#328)

### DIFF
--- a/app/views/settings/_health_connect_section.html.erb
+++ b/app/views/settings/_health_connect_section.html.erb
@@ -14,7 +14,7 @@
       でも 0 歩で保存される事故 (= 局長実体験由来、PR #206 で同期後警告と二段構え) を未然に防ぐ。
       sketch-note クラス (= sketchy.css、border-left + paper-2 背景) で「補足」 視覚明示。 %>
   <p class="sketch-small sketch-note" style="margin-bottom: 12px;">
-    <%= t('.pre_sync_note_html').html_safe %>
+    <%= t('.pre_sync_note_html') %>
   </p>
 
   <%# Issue #314: 最終同期時刻表示 (= 「最終同期: N 時間前」)。24h 以上未同期で data-warning="true"

--- a/app/views/settings/_health_connect_section.html.erb
+++ b/app/views/settings/_health_connect_section.html.erb
@@ -5,17 +5,16 @@
      data-native-health-webhook-token-value="<%= current_user.webhook_token %>"
      class="sketch-box"
      style="display: none; margin-bottom: 24px;">
-  <h2 class="sketch-h" style="margin-bottom: 8px;">Android Health Connect 連携</h2>
+  <h2 class="sketch-h" style="margin-bottom: 8px;"><%= t('.heading') %></h2>
   <p class="sketch-small" style="margin-bottom: 12px;">
-    Android アプリ版で Health Connect 経由で歩数 / 距離 / 階段を自動同期します。
+    <%= t('.description') %>
   </p>
 
   <%# Issue #218: 同期前事前ガイダンス。Health Connect 自体にデータが届いていないと同期成功 (= 200 OK)
       でも 0 歩で保存される事故 (= 局長実体験由来、PR #206 で同期後警告と二段構え) を未然に防ぐ。
       sketch-note クラス (= sketchy.css、border-left + paper-2 背景) で「補足」 視覚明示。 %>
   <p class="sketch-small sketch-note" style="margin-bottom: 12px;">
-    ※ 歩数アプリ (<strong>Google Fit</strong> や <strong>Samsung Health</strong> など) から Health Connect へデータが渡る設定になっているとスムーズに同期できます。
-    0 歩のままの場合は、Health Connect アプリの「<strong>データとアクセス</strong>」 で書き込み設定をご確認ください。
+    <%= t('.pre_sync_note_html').html_safe %>
   </p>
 
   <%# Issue #314: 最終同期時刻表示 (= 「最終同期: N 時間前」)。24h 以上未同期で data-warning="true"
@@ -24,23 +23,23 @@
      data-warning="false"
      class="sketch-small sketch-last-sync"
      style="margin-bottom: 8px;">
-    まだ同期されていません
+    <%= t('.not_synced_yet') %>
   </p>
 
   <p data-native-health-target="status" class="sketch-body-text" style="margin-bottom: 16px;">
-    確認中...
+    <%= t('.checking') %>
   </p>
   <button data-action="click->native-health#requestPermission"
           data-native-health-target="requestButton"
           class="sketch-btn"
           style="display: none; margin-right: 8px;">
-    歩数を取得する →
+    <%= t('.request_permission_button') %>
   </button>
   <button data-action="click->native-health#sync"
           data-native-health-target="syncButton"
           class="sketch-btn"
           style="display: none;">
-    📡 同期する
+    <%= t('.sync_button') %>
   </button>
 
   <%# Issue #273 で 2 mode 化 (settings / retry)。401 → settings 誘導、5xx → retry。
@@ -53,6 +52,6 @@
           data-mode="settings"
           class="sketch-btn"
           style="display: none; margin-top: 12px;">
-    設定ページでトークンを再生成 →
+    <%= t('.recovery_button') %>
   </button>
 </div>

--- a/app/views/settings/_webhook_delivery_history.html.erb
+++ b/app/views/settings/_webhook_delivery_history.html.erb
@@ -1,7 +1,7 @@
 <%# 送信ログ (直近 5 件)。Apple Shortcuts のクライアントは Webhook 422 を「ネットワーク切れ」と
     誤表示するため (Day 3-3 既知バグ)、ここでログを見せて自己解決を助ける。 %>
 <p class="sketch-label" style="margin-bottom: 6px;">
-  <%= t('.label_html', limit: SettingsController::WEBHOOK_HISTORY_LIMIT).html_safe %>
+  <%= t('.label', limit: SettingsController::WEBHOOK_HISTORY_LIMIT) %>
 </p>
 <div class="sketch-box" style="margin-bottom: 24px;">
   <% if @webhook_deliveries.empty? %>
@@ -12,7 +12,7 @@
     <%# Issue #58: セクション冒頭に最終送信時刻を 1 行で表示 (= 直近状態が即座に把握できる)。
         @webhook_deliveries は received_at desc 順で取得済みなので first が最新。 %>
     <p class="sketch-small" style="margin: 0 0 10px; color: var(--ink-2);">
-      <%= t('.last_sent_html', time_ago: time_ago_in_words(@webhook_deliveries.first.received_at)).html_safe %>
+      <%= t('.last_sent_html', time_ago: time_ago_in_words(@webhook_deliveries.first.received_at)) %>
     </p>
     <ul class="sketch-webhook-history">
       <% @webhook_deliveries.each do |delivery| %>
@@ -22,7 +22,7 @@
           </span>
           <span class="sketch-webhook-history-time"
                 title="<%= delivery.received_at.strftime("%Y-%m-%d %H:%M JST") %>">
-            <%= time_ago_in_words(delivery.received_at) %><%= t('.time_ago_suffix') %>
+            <%= time_ago_in_words(delivery.received_at) %><%= t('.time_unit_ago') %>
           </span>
           <% count = webhook_record_count_for_display(delivery) %>
           <% if count %>

--- a/app/views/settings/_webhook_delivery_history.html.erb
+++ b/app/views/settings/_webhook_delivery_history.html.erb
@@ -1,16 +1,18 @@
 <%# 送信ログ (直近 5 件)。Apple Shortcuts のクライアントは Webhook 422 を「ネットワーク切れ」と
     誤表示するため (Day 3-3 既知バグ)、ここでログを見せて自己解決を助ける。 %>
-<p class="sketch-label" style="margin-bottom: 6px;">Shortcut からの送信ログ (直近 <%= SettingsController::WEBHOOK_HISTORY_LIMIT %> 件)</p>
+<p class="sketch-label" style="margin-bottom: 6px;">
+  <%= t('.label_html', limit: SettingsController::WEBHOOK_HISTORY_LIMIT).html_safe %>
+</p>
 <div class="sketch-box" style="margin-bottom: 24px;">
   <% if @webhook_deliveries.empty? %>
     <p class="sketch-body-text" style="margin: 0;">
-      まだ Shortcut からの送信はありません。Step 3 のボタンからインストールしてください。
+      <%= t('.empty_state') %>
     </p>
   <% else %>
     <%# Issue #58: セクション冒頭に最終送信時刻を 1 行で表示 (= 直近状態が即座に把握できる)。
         @webhook_deliveries は received_at desc 順で取得済みなので first が最新。 %>
     <p class="sketch-small" style="margin: 0 0 10px; color: var(--ink-2);">
-      最終送信: <strong><%= time_ago_in_words(@webhook_deliveries.first.received_at) %>前</strong>
+      <%= t('.last_sent_html', time_ago: time_ago_in_words(@webhook_deliveries.first.received_at)).html_safe %>
     </p>
     <ul class="sketch-webhook-history">
       <% @webhook_deliveries.each do |delivery| %>
@@ -20,11 +22,11 @@
           </span>
           <span class="sketch-webhook-history-time"
                 title="<%= delivery.received_at.strftime("%Y-%m-%d %H:%M JST") %>">
-            <%= time_ago_in_words(delivery.received_at) %>前
+            <%= time_ago_in_words(delivery.received_at) %><%= t('.time_ago_suffix') %>
           </span>
           <% count = webhook_record_count_for_display(delivery) %>
           <% if count %>
-            <span class="sketch-webhook-history-count"><%= count %> 件</span>
+            <span class="sketch-webhook-history-count"><%= count %> <%= t('.count_unit') %></span>
           <% end %>
           <% if delivery.error_message.present? %>
             <p class="sketch-webhook-history-error">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,13 +1,13 @@
-<% content_for :title, "設定 — weight daily." %>
+<% content_for :title, t('.title') %>
 
 <div class="sketch-page-narrow" style="max-width: 36rem;">
 
   <%# ヘッダー (= データ連携の入口、iPhone Shortcuts / Android Health Connect 両方を内包する。
        元は「Apple Shortcuts 連携」固定だったが、Android Chrome 評価者が「自分には関係ない設定ページ」と
        感じる UX 課題が公開前 design レビューで判明 → 中立タイトルに変更し、リード文で対応端末を明示。) %>
-  <h1 class="sketch-hh" style="margin-bottom: 6px;">データ連携の設定</h1>
+  <h1 class="sketch-hh" style="margin-bottom: 6px;"><%= t('.h1') %></h1>
   <p class="sketch-body-text" style="margin-bottom: 24px;">
-    iPhone は Apple Shortcuts、Android は Health Connect から、毎日の歩数を自動で取り込みます。
+    <%= t('.lead') %>
   </p>
 
   <%# Capacitor アプリ時のみ Health Connect セクションを最上部に出す (Issue #144、design レビュー指摘:
@@ -18,9 +18,9 @@
   <% end %>
 
   <%# Step 1: Webhook トークン %>
-  <p class="sketch-label" style="margin-bottom: 6px;">Step 1</p>
+  <p class="sketch-label" style="margin-bottom: 6px;"><%= t('.step1.label') %></p>
   <div class="sketch-box" style="margin-bottom: 20px;">
-    <p class="sketch-label" style="margin-bottom: 8px;">あなた専用のトークン（秘密にしてください）</p>
+    <p class="sketch-label" style="margin-bottom: 8px;"><%= t('.step1.token_caption') %></p>
 
     <div data-controller="copy" data-copy-text-value="<%= @webhook_token %>">
       <code style="display: block; font-size: 20px; word-break: break-all; background: var(--paper-2); border: 1px solid var(--ink); border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; font-family: monospace; line-height: 1.4;">
@@ -30,15 +30,15 @@
               class="sketch-btn sketch-btn-primary"
               data-copy-target="button"
               data-action="click->copy#copy">
-        コピー
+        <%= t('.copy_button') %>
       </button>
     </div>
   </div>
 
   <%# Step 2: エンドポイント URL %>
-  <p class="sketch-label" style="margin-bottom: 6px;">Step 2</p>
+  <p class="sketch-label" style="margin-bottom: 6px;"><%= t('.step2.label') %></p>
   <div class="sketch-box" style="margin-bottom: 20px;">
-    <p class="sketch-label" style="margin-bottom: 8px;">iPhone のショートカットアプリで使う URL</p>
+    <p class="sketch-label" style="margin-bottom: 8px;"><%= t('.step2.url_caption') %></p>
 
     <div data-controller="copy" data-copy-text-value="<%= @webhook_url %>">
       <%# 本番 URL は 47 文字あり 375px モバイル幅で 3-4 行に折り返すため font-size は 13px に詰める (Issue #48 指摘 1) %>
@@ -49,7 +49,7 @@
               class="sketch-btn sketch-btn-primary"
               data-copy-target="button"
               data-action="click->copy#copy">
-        コピー
+        <%= t('.copy_button') %>
       </button>
     </div>
   </div>
@@ -64,18 +64,18 @@
       意図: 「直近に動作している実績があるか」を見たい (= 古い履歴より最近の動作実績を信頼)。
       `current_user.webhook_deliveries.exists?` に変えれば全件判定になるが、追加クエリ発生 + 「最近壊れてる人にも案内出ない」問題があるため不採用。 %>
   <% if @webhook_deliveries.empty? %>
-    <p class="sketch-label" style="margin-bottom: 6px;">Step 3</p>
+    <p class="sketch-label" style="margin-bottom: 6px;"><%= t('.step3.label') %></p>
     <div class="sketch-box" style="margin-bottom: 32px;">
-      <p class="sketch-h" style="margin-bottom: 8px;">🎉 あとはショートカットを入れるだけ</p>
+      <p class="sketch-h" style="margin-bottom: 8px;"><%= t('.step3.heading') %></p>
       <p class="sketch-body-text" style="margin-bottom: 16px;">
-        下のボタンから iPhone に Shortcut を追加 → 初回実行時に「<strong>ヘルスケアへのアクセス</strong>」を許可 → Step 1 でコピーした値を貼り付ければ完了です。
+        <%= t('.step3.description_html').html_safe %>
       </p>
-      <%= link_to "ショートカットをインストール",
+      <%= link_to t('.step3.install_button'),
             "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",
             class: "sketch-btn sketch-btn-primary",
             target: "_blank",
             rel: "noopener noreferrer" %>
-      <p class="sketch-small" style="margin: 8px 0 0;">タップで iCloud が開きます</p>
+      <p class="sketch-small" style="margin: 8px 0 0;"><%= t('.step3.install_note') %></p>
     </div>
   <% end %>
 
@@ -85,8 +85,8 @@
     <%# 受信ログがある時の再追加導線 (= Issue #48 指摘 0)。
         Step 3 を非表示にした代わりに、別端末でも追加したい人向けの控えめなリンク。 %>
     <p class="sketch-small" style="text-align: center; margin: 8px 0 24px; color: var(--muted);">
-      ショートカットを別の端末に追加したい場合は
-      <%= link_to "こちら",
+      <%= t('.re_install_link.prefix') %>
+      <%= link_to t('.re_install_link.anchor'),
             "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",
             target: "_blank",
             rel: "noopener noreferrer",
@@ -101,14 +101,12 @@
       かつ既存の native-health セクション (下記) が JS で代替表示される。UX ループ解消が目的。 %>
   <% if @show_android_app_promo %>
     <div class="sketch-box" style="margin-bottom: 24px;">
-      <h2 class="sketch-h" style="margin-bottom: 8px;">Android Health Connect 連携</h2>
+      <h2 class="sketch-h" style="margin-bottom: 8px;"><%= t('.web_android_promo.heading') %></h2>
       <p class="sketch-body-text" style="margin-bottom: 12px;">
-        お手元の Android スマホから Health Connect 経由で歩数 / 距離 / 階段を自動同期できます。
-        同期されたデータは Web 版にログインしてダッシュボードで閲覧できます。
+        <%= t('.web_android_promo.description') %>
       </p>
       <p class="sketch-body-text" style="margin-bottom: 0;">
-        現在 Android アプリのインストール手順を準備中です。
-        それまでは <strong>サンプルデータ</strong>で雰囲気をお試しください。
+        <%= t('.web_android_promo.prep_note_html').html_safe %>
       </p>
     </div>
   <% end %>
@@ -121,16 +119,15 @@
 
   <%# 危険ゾーン: トークン再生成 %>
   <div class="sketch-box sketch-box-danger-soft" style="margin-bottom: 24px;">
-    <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;">トークンの再生成</p>
+    <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;"><%= t('.regenerate_token.heading') %></p>
     <p class="sketch-body-text" style="margin-bottom: 16px;">
-      ⚠️ <strong>トークンを再生成すると、現在 Apple Shortcuts に設定済みのトークンは無効になります。</strong>
-      再生成後は Shortcut 側の設定も更新する必要があります。
+      <%= t('.regenerate_token.warning_html').html_safe %>
     </p>
-    <%= button_to "トークンを再生成する",
+    <%= button_to t('.regenerate_token.button'),
           regenerate_webhook_token_path,
           method: :post,
           class: "sketch-btn",
-          data: { turbo_confirm: "本当に再生成しますか？ 現在の Shortcut が動かなくなります。" } %>
+          data: { turbo_confirm: t('.regenerate_token.confirm') } %>
   </div>
 
   <%# 危険ゾーン: アカウント削除 %>
@@ -138,15 +135,14 @@
        data-confirm-deletion-expected-name-value="<%= current_user.name %>">
 
     <div class="sketch-box sketch-box-danger" style="margin-bottom: 24px;">
-      <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;">⚠️ アカウントの削除</p>
+      <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;"><%= t('.account_deletion.heading') %></p>
       <p class="sketch-body-text" style="margin-bottom: 16px;">
-        アカウントを削除すると、歩数記録・連携設定を含む<strong>すべてのデータが即時に削除</strong>されます。
-        この操作は取り消せません。
+        <%= t('.account_deletion.description_html').html_safe %>
       </p>
       <button type="button"
               class="sketch-btn sketch-btn-danger"
               data-action="click->confirm-deletion#openModal">
-        アカウントを削除する
+        <%= t('.account_deletion.button') %>
       </button>
     </div>
 
@@ -161,16 +157,16 @@
       <div class="sketch-box"
            style="width: min(90vw, 24rem); background: var(--paper); position: relative;">
         <p id="deletion-modal-title" class="sketch-h sketch-h-danger" style="margin-bottom: 12px;">
-          ⚠️ 本当に退会しますか？
+          <%= t('.deletion_modal.title') %>
         </p>
         <p class="sketch-body-text" style="margin-bottom: 16px;">
-          確認のため、あなたの名前 <strong><%= current_user.name %></strong> を下に入力してください。
+          <%= t('.deletion_modal.confirmation_prompt_html', name: current_user.name).html_safe %>
         </p>
 
         <%= form_with url: account_deletion_path, method: :delete do |f| %>
           <div style="margin-bottom: 16px;">
             <label for="deletion-name-input" class="sketch-label" style="display: block; margin-bottom: 6px;">
-              名前を入力
+              <%= t('.deletion_modal.name_label') %>
             </label>
             <input id="deletion-name-input"
                    type="text"
@@ -185,13 +181,13 @@
             <button type="button"
                     class="sketch-btn"
                     data-action="click->confirm-deletion#closeModal">
-              キャンセル
+              <%= t('.deletion_modal.cancel_button') %>
             </button>
             <button type="submit"
                     class="sketch-btn sketch-btn-danger"
                     disabled
                     data-confirm-deletion-target="submitButton">
-              退会する
+              <%= t('.deletion_modal.submit_button') %>
             </button>
           </div>
         <% end %>
@@ -206,12 +202,12 @@
       (= 通勤通学カジュアル) ターゲットのため後者を選択。詳細経緯は Issue #90 / PR description 参照。 %>
   <div class="sketch-box" style="margin-bottom: 24px;">
     <p class="sketch-small" style="margin-bottom: 6px; color: var(--muted);">
-      退会前に規約を確認したい場合はこちら
+      <%= t('.policy_links.prompt') %>
     </p>
     <p class="sketch-body-text">
-      <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--ink); text-decoration: underline;" %>
+      <%= link_to t('.policy_links.privacy'), privacy_path, style: "color: var(--ink); text-decoration: underline;" %>
       /
-      <%= link_to "利用規約", terms_path, style: "color: var(--ink); text-decoration: underline;" %>
+      <%= link_to t('.policy_links.terms'), terms_path, style: "color: var(--ink); text-decoration: underline;" %>
     </p>
   </div>
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -68,7 +68,7 @@
     <div class="sketch-box" style="margin-bottom: 32px;">
       <p class="sketch-h" style="margin-bottom: 8px;"><%= t('.step3.heading') %></p>
       <p class="sketch-body-text" style="margin-bottom: 16px;">
-        <%= t('.step3.description_html').html_safe %>
+        <%= t('.step3.description_html') %>
       </p>
       <%= link_to t('.step3.install_button'),
             "https://www.icloud.com/shortcuts/7e0199f480824ae1959a0833a443f564",
@@ -106,7 +106,7 @@
         <%= t('.web_android_promo.description') %>
       </p>
       <p class="sketch-body-text" style="margin-bottom: 0;">
-        <%= t('.web_android_promo.prep_note_html').html_safe %>
+        <%= t('.web_android_promo.prep_note_html') %>
       </p>
     </div>
   <% end %>
@@ -121,7 +121,7 @@
   <div class="sketch-box sketch-box-danger-soft" style="margin-bottom: 24px;">
     <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;"><%= t('.regenerate_token.heading') %></p>
     <p class="sketch-body-text" style="margin-bottom: 16px;">
-      <%= t('.regenerate_token.warning_html').html_safe %>
+      <%= t('.regenerate_token.warning_html') %>
     </p>
     <%= button_to t('.regenerate_token.button'),
           regenerate_webhook_token_path,
@@ -137,7 +137,7 @@
     <div class="sketch-box sketch-box-danger" style="margin-bottom: 24px;">
       <p class="sketch-h sketch-h-danger" style="margin-bottom: 8px;"><%= t('.account_deletion.heading') %></p>
       <p class="sketch-body-text" style="margin-bottom: 16px;">
-        <%= t('.account_deletion.description_html').html_safe %>
+        <%= t('.account_deletion.description_html') %>
       </p>
       <button type="button"
               class="sketch-btn sketch-btn-danger"
@@ -160,7 +160,7 @@
           <%= t('.deletion_modal.title') %>
         </p>
         <p class="sketch-body-text" style="margin-bottom: 16px;">
-          <%= t('.deletion_modal.confirmation_prompt_html', name: current_user.name).html_safe %>
+          <%= t('.deletion_modal.confirmation_prompt_html', name: current_user.name) %>
         </p>
 
         <%= form_with url: account_deletion_path, method: :delete do |f| %>

--- a/config/locales/ja/settings.yml
+++ b/config/locales/ja/settings.yml
@@ -1,0 +1,60 @@
+ja:
+  settings:
+    show:
+      title: "設定 — weight daily."
+      h1: "データ連携の設定"
+      lead: "iPhone は Apple Shortcuts、Android は Health Connect から、毎日の歩数を自動で取り込みます。"
+      copy_button: "コピー"
+      step1:
+        label: "Step 1"
+        token_caption: "あなた専用のトークン（秘密にしてください）"
+      step2:
+        label: "Step 2"
+        url_caption: "iPhone のショートカットアプリで使う URL"
+      step3:
+        label: "Step 3"
+        heading: "🎉 あとはショートカットを入れるだけ"
+        description_html: "下のボタンから iPhone に Shortcut を追加 → 初回実行時に「<strong>ヘルスケアへのアクセス</strong>」を許可 → Step 1 でコピーした値を貼り付ければ完了です。"
+        install_button: "ショートカットをインストール"
+        install_note: "タップで iCloud が開きます"
+      re_install_link:
+        prefix: "ショートカットを別の端末に追加したい場合は"
+        anchor: "こちら"
+      web_android_promo:
+        heading: "Android Health Connect 連携"
+        description: "お手元の Android スマホから Health Connect 経由で歩数 / 距離 / 階段を自動同期できます。同期されたデータは Web 版にログインしてダッシュボードで閲覧できます。"
+        prep_note_html: "現在 Android アプリのインストール手順を準備中です。それまでは <strong>サンプルデータ</strong>で雰囲気をお試しください。"
+      regenerate_token:
+        heading: "トークンの再生成"
+        warning_html: "⚠️ <strong>トークンを再生成すると、現在 Apple Shortcuts に設定済みのトークンは無効になります。</strong> 再生成後は Shortcut 側の設定も更新する必要があります。"
+        button: "トークンを再生成する"
+        confirm: "本当に再生成しますか？ 現在の Shortcut が動かなくなります。"
+      account_deletion:
+        heading: "⚠️ アカウントの削除"
+        description_html: "アカウントを削除すると、歩数記録・連携設定を含む<strong>すべてのデータが即時に削除</strong>されます。この操作は取り消せません。"
+        button: "アカウントを削除する"
+      deletion_modal:
+        title: "⚠️ 本当に退会しますか？"
+        confirmation_prompt_html: "確認のため、あなたの名前 <strong>%{name}</strong> を下に入力してください。"
+        name_label: "名前を入力"
+        cancel_button: "キャンセル"
+        submit_button: "退会する"
+      policy_links:
+        prompt: "退会前に規約を確認したい場合はこちら"
+        privacy: "プライバシーポリシー"
+        terms: "利用規約"
+    webhook_delivery_history:
+      label_html: "Shortcut からの送信ログ (直近 %{limit} 件)"
+      empty_state: "まだ Shortcut からの送信はありません。Step 3 のボタンからインストールしてください。"
+      last_sent_html: "最終送信: <strong>%{time_ago}前</strong>"
+      time_ago_suffix: "前"
+      count_unit: "件"
+    health_connect_section:
+      heading: "Android Health Connect 連携"
+      description: "Android アプリ版で Health Connect 経由で歩数 / 距離 / 階段を自動同期します。"
+      pre_sync_note_html: "※ 歩数アプリ (<strong>Google Fit</strong> や <strong>Samsung Health</strong> など) から Health Connect へデータが渡る設定になっているとスムーズに同期できます。0 歩のままの場合は、Health Connect アプリの「<strong>データとアクセス</strong>」 で書き込み設定をご確認ください。"
+      not_synced_yet: "まだ同期されていません"
+      checking: "確認中..."
+      request_permission_button: "歩数を取得する →"
+      sync_button: "📡 同期する"
+      recovery_button: "設定ページでトークンを再生成 →"

--- a/config/locales/ja/settings.yml
+++ b/config/locales/ja/settings.yml
@@ -1,3 +1,5 @@
+# sections: 中間ノードは不採用 (= form 中心で章立てなし、legal.yml と性質差で構造分岐)。
+# 詳細は PR #334 規約進化 4 点判断ログ参照。
 ja:
   settings:
     show:
@@ -44,10 +46,10 @@ ja:
         privacy: "プライバシーポリシー"
         terms: "利用規約"
     webhook_delivery_history:
-      label_html: "Shortcut からの送信ログ (直近 %{limit} 件)"
+      label: "Shortcut からの送信ログ (直近 %{limit} 件)"
       empty_state: "まだ Shortcut からの送信はありません。Step 3 のボタンからインストールしてください。"
       last_sent_html: "最終送信: <strong>%{time_ago}前</strong>"
-      time_ago_suffix: "前"
+      time_unit_ago: "前"
       count_unit: "件"
     health_connect_section:
       heading: "Android Health Connect 連携"


### PR DESCRIPTION
Closes #328

## Summary
- v1.1 改修フェーズの i18n 抽出 **2 例目** PR (= PR #326 legal パイロット → 本 PR settings → 別 PR about → 別 PR home の規約弾力性 / 安定性 / 完成度 3 段階検証)
- settings 画面 318 行 (= show 218 + partial × 2 = 39 + 58) を `config/locales/ja/settings.yml` に抽出 + `t('.xxx')` lazy lookup に置換
- PR #326 strategic 論点 3 由来の規約進化 4 点を本 PR で検証 + 判断ログ確定

## 規約進化 4 点の判断ログ

| # | 進化候補 | 判断 | 根拠 |
|---|---|---|---|
| 1 | form helper の i18n 化 | `settings.show.<context>.<key>` フラット型採用 | form 単発が多く、Rails 慣習 `activerecord.attributes.*` は不採用 |
| 2 | 部分テンプレ間 key 共有 | 部分テンプレ独自階層 (= `settings.webhook_delivery_history.*` / `settings.health_connect_section.*`、show と分離) | partial 内 lazy lookup は partial path 基準で名前空間解決 (= Rails 標準動作)、独立性が高い |
| 3 | flash / button 共通要素 → shared.yml | **本 PR では先送り、発火条件: 同一文言が 3 画面以上で重複した時点** | 「コピー」 button は settings 内 2 箇所のみ。3 例観測ルール準拠で about / home 着手時に再判断 |
| 4 | メタ要素 vs 本文の分離規約 | **`sections:` 中間ノード不採用** (= form 中心で章立てなし、legal と性質差) | settings は form 中心 → フラット構造で十分。legal (= 規約文書で章立て前提) と画面性質で構造選択する弾力性証明 |

## 3 者並列レビュー反映 (= 7 件全て本 PR 内吸収、軽量 Issue 1 PR ルール準拠)

### 🟡 推奨 (3 件)
- `label_html` → `label` rename (= HTML タグ含まないため `_html` suffix 誤用、code)
- shared.yml 発火条件を本 description に追記 (= 上記表 #3、strategic)
- JS 側 RECOVERY_LABELS の i18n 化を **マージ後即 Issue 起票** (= strategic、後続タスク)

### 🟢 採用提案 (3 件)
- 冗長な `.html_safe` 削除 (= legal.yml に倒う、`_html` suffix キーは自動で `html_safe` 済み、code)
- `time_ago_suffix` → `time_unit_ago` rename (= 意図命名、code)
- settings.yml 冒頭に「sections: 不採用理由」 コメント 1 行 (= strategic、後輩教材性補助)

### スコープ外 (= 別 PR / 別 Issue)
- design 提案: `copy_button` 共有化を活かして `copy_controller.js` の文言と一元管理 (= JS i18n は別アプローチ要、本 PR スコープ外)

## スコープ判断

### 含む (= 本 PR)
- view 3 ファイルのハードコード文字列を `t('.xxx')` 化
- 動的補間 (`%{limit}` for WEBHOOK_HISTORY_LIMIT、`%{time_ago}` for time_ago_in_words、`%{name}` for current_user.name)
- `_html` suffix で `<strong>` 等の HTML 要素を含む key の安全な扱い

### 含まない (= 別 PR / 別 Issue)
- JS 側 RECOVERY_LABELS の i18n 化 (= `app/javascript/controllers/native_health_controller.js` 等)
  - 理由: HTML 側は SSR 用ダミー (= JS で textContent 上書き)、JS 側 i18n 化は別アプローチ要 (= window.I18n bridge or Stimulus action)
  - **本 PR マージ後即 Issue 起票** (= strategic 論点 3)
- form helper の Rails 慣習化 (= `activerecord.attributes.*`)
  - 理由: 本 PR スコープでは画面文言の抽出が主目的、form attribute の正規化は別判断

## 影響範囲
- view 文字列のみ抽出、表示変化ゼロ (= legal と同パターン、表示文字列・HTML 構造とも完全同一)
- 既存 spec への影響なし: 50/50 pass (= raise_on_missing_translations 有効下で key 欠落即検出)
- ロールバック容易 (= PR revert で完全戻し)

## Test plan
- [x] settings 画面の既存 request spec 50/50 pass (= レビュー反映後も維持)
- [x] raise_on_missing_translations 有効下で全 key 解決確認
- [x] rubocop clean (= view ファイルは rubocop 対象外、yml は対象外なので 0 件)
- [x] 3 者並列レビュー実施 + 🟡 3 件 + 🟢 3 件吸収
- [ ] **手動確認**: settings 画面をブラウザで開き、表示崩れなし目視確認 (= マージ前 or マージ後どちらでも)
  - [ ] Step 1 / Step 2 トークン・URL 表示 + コピーボタン
  - [ ] Step 3 (= 受信ログ 0 件時のみ表示)
  - [ ] 送信ログ partial (= 直近 5 件 + 最終送信時刻 + `<strong>` 強調)
  - [ ] Health Connect partial (= Capacitor 検知時)
  - [ ] トークン再生成 + 確認ダイアログ
  - [ ] アカウント削除モーダル (= name 補間確認)
  - [ ] ポリシーリンク

## 関連
- PR #326 (= legal パイロット、規約確立元)
- Issue #329 (= 次 = about 画面、3 例目 / 安定性検証)
- Issue #330 (= 最終 = home 画面、4 例目 / 完成度テスト + 動的補間)
- memory `project_phase_1_1_refactoring.md` (= 1.1 改修フェーズ判断軸、本 PR で「i18n 規約 docs/ 化保留」 前提条件の 2 例目通過)
- memory `feedback_self_proposal_relativization.md` (= 同セッション完走型 5 例目候補になりうる場面)
- memory `feedback_light_issue_one_pr_completion.md` (= 軽量 Issue 1 PR ルール適用、🟡🟢 7 件全件本 PR 吸収)