### PR TITLE
feat(i18n): about 画面を ja.yml に抽出 (= 3 例目、規約安定性検証、#329)

### DIFF
--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "weight_dialy について" %>
+<% content_for :title, t('.title') %>
 
 <%# min-h は 100vh から navbar 62px (= Issue #49 slim 化後) + <main> の mt-4 (16px) ≈ 78px を引いた高さ。
     5rem (80px) で近似 (= 余裕 2px は min-h なので下方向マージン化、視覚影響なし)。
@@ -6,18 +6,18 @@
 <div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
   <div class="sketch-page-narrow w-full">
     <div class="sketch-box" style="text-align: center;">
-      <h1 class="sketch-hh" style="margin-bottom: 12px;">weight <span class="sketch-swoosh">daily.</span> について</h1>
+      <h1 class="sketch-hh" style="margin-bottom: 12px;"><%= t('.h1_prefix') %><span class="sketch-swoosh"><%= t('.h1_brand') %></span><%= t('.h1_suffix') %></h1>
       <p class="sketch-body-text">
-        通勤通学のついで歩きや、エスカレーターの代わりに階段。<br>
-        日常の小さな前向きな選択を自動で拾って褒める Web アプリです。
+        <%= t('.lead_first') %><br>
+        <%= t('.lead_second') %>
       </p>
       <div style="margin-top: 16px;">
-        <%= link_to "ホームへ戻る", root_path, class: "sketch-btn sketch-btn-primary" %>
+        <%= link_to t('.home_button'), root_path, class: "sketch-btn sketch-btn-primary" %>
       </div>
       <p class="sketch-small" style="margin-top: 20px; color: var(--ink-2);">
-        <%= link_to "プライバシーポリシー", privacy_path, style: "color: var(--ink-2); text-decoration: underline;" %>
+        <%= link_to t('.policy_links.privacy'), privacy_path, style: "color: var(--ink-2); text-decoration: underline;" %>
         /
-        <%= link_to "利用規約", terms_path, style: "color: var(--ink-2); text-decoration: underline;" %>
+        <%= link_to t('.policy_links.terms'), terms_path, style: "color: var(--ink-2); text-decoration: underline;" %>
       </p>
     </div>
   </div>

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -6,7 +6,7 @@
 <div class="min-h-[calc(100vh-5rem)] flex items-center justify-center">
   <div class="sketch-page-narrow w-full">
     <div class="sketch-box" style="text-align: center;">
-      <h1 class="sketch-hh" style="margin-bottom: 12px;"><%= t('.h1_prefix') %><span class="sketch-swoosh"><%= t('.h1_brand') %></span><%= t('.h1_suffix') %></h1>
+      <h1 class="sketch-hh" style="margin-bottom: 12px;"><%= t('.h1_prefix') %> <span class="sketch-swoosh"><%= t('.h1_brand') %></span> <%= t('.h1_suffix') %></h1>
       <p class="sketch-body-text">
         <%= t('.lead_first') %><br>
         <%= t('.lead_second') %>

--- a/config/locales/ja/about.yml
+++ b/config/locales/ja/about.yml
@@ -5,10 +5,12 @@
 ja:
   about:
     show:
-      title: "weight_dialy について"
-      h1_prefix: "weight "
+      title: "weight daily. について"
+      # h1 は sketch-swoosh 装飾 span のためにテキストを 3 分割 (= 装飾 class は view 側責務、yml はテキストのみ)。
+      # 前後の半角スペースは view 側で制御 (= 翻訳時のスペース有無見落とし防止)。
+      h1_prefix: "weight"
       h1_brand: "daily."
-      h1_suffix: " について"
+      h1_suffix: "について"
       lead_first: "通勤通学のついで歩きや、エスカレーターの代わりに階段。"
       lead_second: "日常の小さな前向きな選択を自動で拾って褒める Web アプリです。"
       home_button: "ホームへ戻る"

--- a/config/locales/ja/about.yml
+++ b/config/locales/ja/about.yml
@@ -1,0 +1,17 @@
+# 規約進化 5 候補 (= 1 例目観測): 装飾 HTML タグと UI 文言の分離。
+# - 意味的強調 (= <strong>) は yml 内 (= _html suffix)
+# - 装飾 class (= <span class="sketch-swoosh">) / レイアウト要素 (= <br>) は view 側に残し、テキストを分割
+# 詳細は PR #337 規約進化判断ログ参照。
+ja:
+  about:
+    show:
+      title: "weight_dialy について"
+      h1_prefix: "weight "
+      h1_brand: "daily."
+      h1_suffix: " について"
+      lead_first: "通勤通学のついで歩きや、エスカレーターの代わりに階段。"
+      lead_second: "日常の小さな前向きな選択を自動で拾って褒める Web アプリです。"
+      home_button: "ホームへ戻る"
+      policy_links:
+        privacy: "プライバシーポリシー"
+        terms: "利用規約"

--- a/spec/requests/about_spec.rb
+++ b/spec/requests/about_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'About', type: :request do
     end
 
     it 'includes the application name' do
-      expect(response.body).to include('weight_dialy')
+      expect(response.body).to include('weight daily.')
     end
 
     it 'includes a link back to the home page' do


### PR DESCRIPTION
Closes #329

## Summary
- v1.1 改修フェーズの i18n 抽出 **3 例目** PR (= legal → settings → **about** → home の 3 段階目)
- about 画面 (= 24 行軽量) を `config/locales/ja/about.yml` に抽出 + `t('.xxx')` lazy lookup に置換
- PR #326 (= legal パイロット) + PR #334 (= settings 弾力性) で確立した規約の **安定性検証 ✅ (= 必要条件確認、十分条件は home #330 で再評価)**
- **規約進化 5 候補 (= 1 例目観測)**: 装飾 HTML タグと UI 文言の分離ルール

## 規約進化 5 候補: 装飾 HTML タグと UI 文言の分離

about 画面に混在する 2 種類の HTML 要素から判断基準を確立 (= **本 PR で 1 例目観測、3 回観測ルールで 2-3 例目で確定検討**):

| 種別 | 例 | 抽出方針 | 根拠 |
|---|---|---|---|
| 意味的強調 | `<strong>` (= settings で確立済) | yml 内 (= `_html` suffix) | 翻訳時に強調位置を保持、language-agnostic |
| 装飾 class | `<span class="sketch-swoosh">daily.</span>` (= about h1) | view 側に残し、テキストを 3 分割 (= `h1_prefix` / `h1_brand` / `h1_suffix`) | sketch-swoosh は装飾、view 側責務 |
| レイアウト要素 | `<br>` (= about lead) | view 側に残し、テキストを 2 key 分割 (= `lead_first` / `lead_second`) | `<br>` は改行のレイアウト |

**判断軸**: yml は「翻訳・コピー編集対象のテキスト」 に責務を絞り、HTML 構造・装飾 class は view 側責務として分離。

## shared.yml 候補の 2 画面目観測 (= settings + about)

PR #334 で「同一文言が 3 画面以上で重複した時点で shared.yml 切り出し」 と決定。
- 「プライバシーポリシー」 / 「利用規約」: settings + **about** で重複 = **2 画面目観測**
- home 完走時 (= #330) に 3 画面目で重複 → shared.yml 切り出し判断
- → Issue #330 本文にコメント追記済 (= 観測ログ恒久化)

## 規約安定性検証結果 = ✅ (= 必要条件確認)

PR #334 規約 4 点 (= form helper / partial 階層 / shared.yml / sections: 不採用) は about 着手時に **再評価なし、ストレスなく完走**:
- form helper: about に form なし → 不問
- partial 階層: about に partial なし → 不問
- shared.yml: 上記 2 画面目観測、規約準拠で先送り判断
- `sections:` 不採用: about も章立てなし → フラット構造ブレなし

**⚠️ 限定句 (= strategic 論点 4 反映)**: 軽量画面 (= 24 行) で揺らがなかった = **必要条件**。十分条件は home (#330、502 行 + 動的補間 + pluralize + banner 3 種) で再評価する。

## 3 者並列レビュー反映 (= 6 件吸収、軽量 Issue 1 PR ルール準拠)

### 🟡 推奨 (3 件)
- title 修正: `"weight_dialy について"` → `"weight daily. について"` (= リポジトリ内部名不出ルール、code)
  - 連動: spec assertion を `'weight_dialy'` → `'weight daily.'` に修正 (= 必然修正)
- 規約進化 5 候補参照経路を Issue #330 本文に追記 (= 別コマンドで実施済、strategic)
- shared.yml 切り出し観測ログを Issue #330 本文に追記 (= 別コマンドで実施済、strategic)

### 💡 Nit 採用 (3 件)
- about.yml h1 3 分割にコメント追加 (= sketch-swoosh 装飾用、後輩教材性、design)
- 規約安定性に「十分条件は home で再評価」 限定句追加 (= 本 description で対応、strategic)
- h1_suffix 先頭スペース: yml 側削除 + view 側で半角スペース制御 (= 翻訳時のスペース見落とし防止、code)

### スコープ外 (= 別 PR / 別 Issue)
- design 提案: `lead_first` コピー磨き「動詞化」 検討 (= UI ポリッシュ別 PR)

## 影響範囲
- view 文字列のみ抽出、表示変化ゼロ (= title 修正で application name を正規化、これは UI として positive)
- 既存 spec 影響: 3/3 pass (= assertion を title 修正に合わせて連動更新)
- ロールバック容易

## Test plan
- [x] about 画面の既存 request spec 3/3 pass (= 連動修正後)
- [x] raise_on_missing_translations 有効下で全 key 解決確認
- [x] YAML syntax 確認
- [x] 3 者並列レビュー実施 + 🟡 3 件 + 💡 Nit 3 件吸収
- [ ] **手動確認**: about 画面をブラウザで開き、表示崩れなし目視確認

## 関連
- PR #326 (= legal パイロット、規約確立元)
- PR #334 (= settings 弾力性、規約 4 点判断ログ確定)
- Issue #330 (= 最終 = home 画面、4 例目 / 動的補間 / shared.yml 切り出し判断点、本 PR の追記コメント参照)
- memory `project_phase_1_1_refactoring.md` (= 1.1 改修フェーズ、本 PR で i18n 抽出 3/4 完走)
- memory `feedback_self_proposal_relativization.md` (= 規約進化 5 候補 1 例目、2-3 例目で確定検討)