### PR TITLE
fix(home): greeting 時間帯区分を case 式に修正 (#347)

### DIFF
--- a/app/views/home/_dashboard.html.erb
+++ b/app/views/home/_dashboard.html.erb
@@ -76,10 +76,14 @@
 
 <%# ---- トップバー ---- %>
 <%
-  # 時間帯挨拶 (= 配列 index ではなく名前付き key に正規化、yml 側順序入替リスク回避)。
-  # 0..5 = morning / 6..11 = afternoon / 12..23 = evening (= 正午以降はこんばんは、元実装踏襲)。
-  # 12-17 を昼として "afternoon" 扱いにする調整は別 Issue に切り出す (= 表示変化を伴うため i18n 抽出 PR スコープ外)。
-  greeting_key = %w[morning afternoon evening][[Time.current.hour / 6, 2].min]
+  # 時間帯挨拶 (= 名前付き key に正規化、yml 側順序入替リスク回避)。
+  # 5..10 = morning / 11..16 = afternoon / else = evening。
+  # else は夜 (17-23) と深夜 (0-4) の 2 区間を意図的に evening へ寄せる。
+  greeting_key = case Time.current.hour
+                 when 5..10  then "morning"
+                 when 11..16 then "afternoon"
+                 else             "evening"
+                 end
 %>
 <div class="sketch-topbar">
   <div>

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -274,6 +274,33 @@ RSpec.describe "Home", type: :request do
         expect(response.body).to include("ログアウト")
       end
     end
+
+    # ─────────────────────────────────────────────────
+    # 時間帯挨拶 (Issue #347): hour に応じた挨拶文言の切替
+    # 5..10 = おはようございます / 11..16 = こんにちは / それ以外 (= 夜 17-23 / 深夜 0-4) = こんばんは
+    # 元バグが「12 時から evening」の境界バグだったため、各区分の境界値を網羅する。
+    # ─────────────────────────────────────────────────
+    context "時間帯挨拶 (Issue #347、ゲスト状態でも表示される)" do
+      {
+        "朝 5 時 (morning 下限)"      => [ 5,  "おはようございます" ],
+        "朝 10 時 (morning 上限)"     => [ 10, "おはようございます" ],
+        "昼 11 時 (afternoon 下限)"   => [ 11, "こんにちは" ],
+        "昼 16 時 (afternoon 上限)"   => [ 16, "こんにちは" ],
+        "夕方 17 時 (evening 下限)"   => [ 17, "こんばんは" ],
+        "深夜 3 時 (evening が深夜帯も吸収)" => [ 3,  "こんばんは" ],
+        "深夜 23 時 (evening 夜帯)"   => [ 23, "こんばんは" ]
+      }.each do |label, (hour, greeting)|
+        context label do
+          # travel_to で時刻を固定し、CI 実行時刻に依存しない再現性を担保する。
+          around { |ex| travel_to(Time.zone.local(2026, 5, 15, hour, 0)) { ex.run } }
+          before { get root_path }
+
+          it "「#{greeting}」を表示する" do
+            expect(response.body).to include(greeting)
+          end
+        end
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- home dashboard トップバーの時間帯挨拶が 12-17 時に「こんばんは」になっていたバグを修正 (`Time.current.hour / 6` 配列 index 方式の切り捨て演算が原因)
- Issue #347 採用案 A に従い `case` 式へ置換: `5..10`=morning / `11..16`=afternoon / `else`=evening
- `else` が夜 (17-23) と深夜 (0-4) の 2 区間を吸収する設計意図を view コメントに明示 (strategic-reviewer 指摘)
- 元バグが境界バグのため、境界値を網羅する spec 7 ケースを追加 (code-reviewer 指摘)

## 3 者レビュー反映
- [code] 境界値 (5/10/11/16/17 時) + 深夜帯を網羅する spec に拡張
- [code] greeting context がゲスト状態であることを context 名に明記
- [strategic] view コメントを `else` の時刻範囲明示に修正

## Test plan
- [x] 各時間帯で挨拶文言が想定通り (朝 5/10 時・昼 11/16 時・夕方 17 時・深夜 3/23 時)
- [x] `travel_to` で時刻固定する spec 7 ケース追加
- [x] `bundle exec rspec spec/requests/home_spec.rb` → 51 examples 0 failures
- [x] rubocop clean

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)